### PR TITLE
fix: allow negative enum values in protobuf emission

### DIFF
--- a/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmissionValidation.kt
+++ b/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmissionValidation.kt
@@ -120,7 +120,6 @@ private fun Enum.requireUniqueEnumValueIndexes() {
 
 private fun EnumValue.validateForEmission() {
     ProtobufNameValidation.requireIdentifier(name, "Enum value name")
-    require(index >= 0) { "Enum value '$name' index must be non-negative, but was $index." }
 }
 
 private fun Oneof.validateForEmission() {

--- a/gen-schemas-protobuf/src/test/kotlin/me/liam/microsmith/gen/schemas/protobuf/ProtobufEmitterTests.kt
+++ b/gen-schemas-protobuf/src/test/kotlin/me/liam/microsmith/gen/schemas/protobuf/ProtobufEmitterTests.kt
@@ -271,6 +271,21 @@ class ProtobufEmitterTests :
             }
         }
 
+        "allows negative enum values after first zero value" {
+            val schema =
+                ProtobufSchema(
+                    "pkg.Code",
+                    Enum(
+                        name = "Code",
+                        values = listOf(EnumValue("UNSPECIFIED", 0), EnumValue("ERROR_UNKNOWN", -1), EnumValue("OK", 1))
+                    )
+                )
+
+            val (_, contents) = emit(schema)
+            contents.shouldContain("ERROR_UNKNOWN = -1;")
+            contents.shouldContain("OK = 1;")
+        }
+
         "resolves unqualified reference imports into current package" {
             val schema =
                 ProtobufSchema(


### PR DESCRIPTION
## Summary
- remove emission validation that rejected negative enum indices
- keep the proto3 invariant that the first enum value must be index 0
- add a regression test proving negative enum values after the first entry are emitted correctly

Closes #14

## Testing
- ./gradlew.bat :gen-schemas-protobuf:kotest