### PR TITLE
feat(formatting): normalize Kotlin style consistency across core modules

### DIFF
--- a/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
@@ -55,6 +55,7 @@ internal class MicrosmithCli(
             stdout(HELP_TEXT.trimIndent())
             0
         }
+
         is ErrorCommand -> {
             val emitter =
                 CliDiagnosticEmitter(
@@ -68,16 +69,17 @@ internal class MicrosmithCli(
             stderr(HELP_TEXT.trimIndent())
             CliFailureCode.USAGE_ERROR.exitCode
         }
+
         is RunCommand -> runCommand(parsed)
+
         is DoctorCommand -> runDoctor(parsed)
     }
 
     private fun runCommand(command: RunCommand): Int {
         val emitter = createEmitter(command.diagnosticsFormat, command.verbose)
         val context = RunExecutionContext()
-        val prepared = prepareRun(command, emitter, context)
 
-        return when (prepared) {
+        return when (val prepared = prepareRun(command, emitter, context)) {
             is PreparedRun.Failure ->
                 completeRun(
                     command = command,
@@ -296,16 +298,9 @@ internal class MicrosmithCli(
 }
 
 private sealed interface PreparedRun {
-    data class Ready(
-        val result: ScriptRunResult,
-    ) : PreparedRun
+    data class Ready(val result: ScriptRunResult) : PreparedRun
 
-    data class Failure(
-        val code: CliFailureCode,
-    ) : PreparedRun
+    data class Failure(val code: CliFailureCode) : PreparedRun
 }
 
-private data class RunExecutionContext(
-    var resolverStatus: String = "skipped",
-    var lockfilePath: Path? = null,
-)
+private data class RunExecutionContext(var resolverStatus: String = "skipped", var lockfilePath: Path? = null)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/command/ErrorCommand.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/command/ErrorCommand.kt
@@ -1,5 +1,3 @@
 package me.liam.microsmith.cli.command
 
-internal data class ErrorCommand(
-    val message: String,
-) : CliCommand
+internal data class ErrorCommand(val message: String) : CliCommand

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/diagnostics/CliDiagnostics.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/diagnostics/CliDiagnostics.kt
@@ -2,9 +2,7 @@ package me.liam.microsmith.cli.diagnostics
 
 import java.time.Instant
 
-internal enum class DiagnosticFormat(
-    val cliValue: String,
-) {
+internal enum class DiagnosticFormat(val cliValue: String) {
     TEXT("text"),
     JSON("json"),
     ;
@@ -14,10 +12,7 @@ internal enum class DiagnosticFormat(
     }
 }
 
-internal enum class CliFailureCode(
-    val id: String,
-    val exitCode: Int,
-) {
+internal enum class CliFailureCode(val id: String, val exitCode: Int) {
     USAGE_ERROR(id = "MS-CLI-0001", exitCode = 2),
     PROVIDER_VALIDATION_FAILED(id = "MS-CLI-1001", exitCode = 10),
     PLUGIN_RESOLUTION_FAILED(id = "MS-CLI-1101", exitCode = 11),
@@ -110,9 +105,13 @@ internal class CliDiagnosticEmitter(
 
 internal fun toJsonValue(value: Any?): String = when (value) {
     null -> "null"
+
     is String -> "\"${value.escapeJson()}\""
+
     is Number -> value.toString()
+
     is Boolean -> value.toString()
+
     is Map<*, *> ->
         value.entries.joinToString(
             prefix = "{",
@@ -121,7 +120,9 @@ internal fun toJsonValue(value: Any?): String = when (value) {
         ) { (key, mapValue) ->
             "\"${key.toString().escapeJson()}\":${toJsonValue(mapValue)}"
         }
+
     is Iterable<*> -> value.joinToString(prefix = "[", postfix = "]", separator = ",") { entry -> toJsonValue(entry) }
+
     else -> "\"${value.toString().escapeJson()}\""
 }
 
@@ -130,12 +131,19 @@ private fun String.escapeJson(): String {
     for (char in this) {
         when (char) {
             '\\' -> builder.append("\\\\")
+
             '"' -> builder.append("\\\"")
+
             '\b' -> builder.append("\\b")
+
             '\u000C' -> builder.append("\\f")
+
             '\n' -> builder.append("\\n")
+
             '\r' -> builder.append("\\r")
+
             '\t' -> builder.append("\\t")
+
             else -> {
                 if (char.code <= MAX_JSON_CONTROL_CHAR_CODE) {
                     builder.append("\\u%04x".format(char.code))

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
@@ -19,9 +19,7 @@ internal data class DoctorCheckResult(
     val details: Map<String, String> = emptyMap(),
 )
 
-internal data class DoctorResult(
-    val checks: List<DoctorCheckResult>,
-) {
+internal data class DoctorResult(val checks: List<DoctorCheckResult>) {
     val hasFailures: Boolean
         get() = checks.any { it.status == DoctorCheckStatus.FAIL }
 }
@@ -63,75 +61,69 @@ private fun checkJavaRuntime(): DoctorCheckResult {
     }
 }
 
-private fun checkProviderDiscovery(providerValidator: () -> List<String>): DoctorCheckResult {
-    return try {
-        val errors = providerValidator()
-        if (errors.isEmpty()) {
-            DoctorCheckResult(
-                id = "provider-discovery",
-                status = DoctorCheckStatus.PASS,
-                message = "Required built-in service providers are available.",
-            )
-        } else {
-            DoctorCheckResult(
-                id = "provider-discovery",
-                status = DoctorCheckStatus.FAIL,
-                message = "Required built-in service providers are missing.",
-                details = mapOf("errors" to errors.joinToString(" | ")),
-            )
-        }
-    } catch (error: ServiceConfigurationError) {
+private fun checkProviderDiscovery(providerValidator: () -> List<String>): DoctorCheckResult = try {
+    val errors = providerValidator()
+    if (errors.isEmpty()) {
+        DoctorCheckResult(
+            id = "provider-discovery",
+            status = DoctorCheckStatus.PASS,
+            message = "Required built-in service providers are available.",
+        )
+    } else {
         DoctorCheckResult(
             id = "provider-discovery",
             status = DoctorCheckStatus.FAIL,
-            message = "Service provider loading failed.",
-            details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
+            message = "Required built-in service providers are missing.",
+            details = mapOf("errors" to errors.joinToString(" | ")),
         )
     }
+} catch (error: ServiceConfigurationError) {
+    DoctorCheckResult(
+        id = "provider-discovery",
+        status = DoctorCheckStatus.FAIL,
+        message = "Service provider loading failed.",
+        details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
+    )
 }
 
-private fun checkDirectoryWritable(id: String, directory: Path): DoctorCheckResult {
-    return runCatching {
-        Files.createDirectories(directory)
-        val probe = Files.createTempFile(directory, "microsmith-doctor-", ".tmp")
-        probe.deleteIfExists()
-        DoctorCheckResult(
-            id = id,
-            status = DoctorCheckStatus.PASS,
-            message = "Directory is writable.",
-            details = mapOf("path" to directory.toAbsolutePath().normalize().toString()),
-        )
-    }.getOrElse { error ->
-        DoctorCheckResult(
-            id = id,
-            status = DoctorCheckStatus.FAIL,
-            message = "Directory is not writable.",
-            details =
-            mapOf(
-                "path" to directory.toAbsolutePath().normalize().toString(),
-                "error" to (error.message ?: error::class.simpleName.orEmpty()),
-            ),
-        )
-    }
+private fun checkDirectoryWritable(id: String, directory: Path): DoctorCheckResult = runCatching {
+    Files.createDirectories(directory)
+    val probe = Files.createTempFile(directory, "microsmith-doctor-", ".tmp")
+    probe.deleteIfExists()
+    DoctorCheckResult(
+        id = id,
+        status = DoctorCheckStatus.PASS,
+        message = "Directory is writable.",
+        details = mapOf("path" to directory.toAbsolutePath().normalize().toString()),
+    )
+}.getOrElse { error ->
+    DoctorCheckResult(
+        id = id,
+        status = DoctorCheckStatus.FAIL,
+        message = "Directory is not writable.",
+        details =
+        mapOf(
+            "path" to directory.toAbsolutePath().normalize().toString(),
+            "error" to (error.message ?: error::class.simpleName.orEmpty()),
+        ),
+    )
 }
 
-private fun checkRepositoryPolicy(): DoctorCheckResult {
-    return runCatching {
-        val policy = defaultRepositoryAllowlistPolicy()
-        DoctorCheckResult(
-            id = "repository-policy",
-            status = DoctorCheckStatus.PASS,
-            message = "Repository allowlist policy initialized successfully.",
-            details = mapOf("allowFileRepositories" to policy.allowFileRepositories.toString()),
-        )
-    }.getOrElse { error ->
-        DoctorCheckResult(
-            id = "repository-policy",
-            status = DoctorCheckStatus.FAIL,
-            message = "Repository allowlist policy could not be initialized.",
-            details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
-        )
-    }
+private fun checkRepositoryPolicy(): DoctorCheckResult = runCatching {
+    val policy = defaultRepositoryAllowlistPolicy()
+    DoctorCheckResult(
+        id = "repository-policy",
+        status = DoctorCheckStatus.PASS,
+        message = "Repository allowlist policy initialized successfully.",
+        details = mapOf("allowFileRepositories" to policy.allowFileRepositories.toString()),
+    )
+}.getOrElse { error ->
+    DoctorCheckResult(
+        id = "repository-policy",
+        status = DoctorCheckStatus.FAIL,
+        message = "Repository allowlist policy could not be initialized.",
+        details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
+    )
 }
 
 private fun defaultScriptCacheDirectory(): Path {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
@@ -24,14 +24,11 @@ internal const val EVENT_LOG_OPTION = "--event-log"
 private const val SCRIPT_EXTENSION = ".microsmith.kts"
 private val HELP_COMMANDS = setOf("--help", "-h", "help")
 
-internal fun parseCliArgs(args: List<String>): CliCommand {
-    val command = args.firstOrNull()
-    return when {
-        command == null || command in HELP_COMMANDS -> HelpCommand
-        command == RUN_COMMAND -> parseRunCommand(args)
-        command == DOCTOR_COMMAND -> parseDoctorCommand(args)
-        else -> ErrorCommand("Unknown command '$command'.")
-    }
+internal fun parseCliArgs(args: List<String>): CliCommand = when (val command = args.firstOrNull()) {
+    null, in HELP_COMMANDS -> HelpCommand
+    RUN_COMMAND -> parseRunCommand(args)
+    DOCTOR_COMMAND -> parseDoctorCommand(args)
+    else -> ErrorCommand("Unknown command '$command'.")
 }
 
 private fun parseRunCommand(args: List<String>): CliCommand {
@@ -61,7 +58,9 @@ private fun parseRunOptionsCommand(script: Path, args: List<String>, startIndex:
     val parsedOptions = parseRunOptions(args, startIndex)
     return when {
         parsedOptions.error != null -> ErrorCommand(parsedOptions.error)
+
         parsedOptions.outputDir == null -> ErrorCommand("Missing required --out <output-dir> option.")
+
         else ->
             RunCommand(
                 script = script,
@@ -107,9 +106,12 @@ private fun parseDoctorOptions(args: List<String>, startIndex: Int): ParsedDocto
                 error =
                     when {
                         value == null || value.startsWith("--") -> "Missing value for --diagnostics option."
+
                         diagnosticsSpecified -> "--diagnostics may only be specified once."
+
                         parsedFormat == null ->
                             "Invalid --diagnostics value '$value'. Expected 'text' or 'json'."
+
                         else -> null
                     }
                 if (error == null) {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/ParsedVariable.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/ParsedVariable.kt
@@ -1,7 +1,3 @@
 package me.liam.microsmith.cli.parsing
 
-internal data class ParsedVariable(
-    val key: String = "",
-    val value: String = "",
-    val error: String? = null,
-)
+internal data class ParsedVariable(val key: String = "", val value: String = "", val error: String? = null)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
@@ -15,9 +15,8 @@ internal fun parseRunOptions(args: List<String>, startIndex: Int): ParsedRunOpti
     return state.toParsedRunOptions()
 }
 
-private fun parseRunOptionToken(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
-    val token = args[index]
-    return when (token) {
+private fun parseRunOptionToken(args: List<String>, index: Int, state: RunOptionsState): ParsedToken =
+    when (val token = args[index]) {
         OUTPUT_OPTION -> parseOutputOption(args, index, state)
         VARIABLE_OPTION -> parseVariableOption(args, index, state)
         FLAG_OPTION -> parseFlagOption(args, index, state)
@@ -31,7 +30,6 @@ private fun parseRunOptionToken(args: List<String>, index: Int, state: RunOption
         EVENT_LOG_OPTION -> parseEventLogOption(args, index, state)
         else -> ParsedToken(nextIndex = index, error = "Unknown option '$token'.")
     }
-}
 
 private fun parseOutputOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
@@ -204,13 +202,11 @@ private fun parseDiagnosticsOption(args: List<String>, index: Int, state: RunOpt
     }
 }
 
-private fun parseVerboseOption(index: Int, state: RunOptionsState): ParsedToken {
-    return if (state.verbose) {
-        ParsedToken(nextIndex = index, error = "--verbose may only be specified once.")
-    } else {
-        state.verbose = true
-        ParsedToken(nextIndex = index + 1)
-    }
+private fun parseVerboseOption(index: Int, state: RunOptionsState): ParsedToken = if (state.verbose) {
+    ParsedToken(nextIndex = index, error = "--verbose may only be specified once.")
+} else {
+    state.verbose = true
+    ParsedToken(nextIndex = index + 1)
 }
 
 private fun parseEventLogOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
@@ -220,7 +216,9 @@ private fun parseEventLogOption(args: List<String>, index: Int, state: RunOption
 
     return when {
         missingValue -> ParsedToken(nextIndex = index, error = "Missing value for --event-log option.")
+
         duplicate -> ParsedToken(nextIndex = index, error = "--event-log may only be specified once.")
+
         else -> {
             state.eventLog = Path.of(value)
             ParsedToken(nextIndex = index + 2)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParsingSupport.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParsingSupport.kt
@@ -78,10 +78,7 @@ internal fun parseDiagnosticFormat(value: String?): DiagnosticFormat? {
     return DiagnosticFormat.parse(normalized)
 }
 
-internal data class ParsedToken(
-    val nextIndex: Int,
-    val error: String? = null,
-)
+internal data class ParsedToken(val nextIndex: Int, val error: String? = null)
 
 internal class RunOptionsState {
     var outputDir: Path? = null

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginChecksumAllowlist.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginChecksumAllowlist.kt
@@ -6,9 +6,7 @@ import java.nio.file.Path
 private const val CHECKSUM_ALLOWLIST_PATH_ENV = "MICROSMITH_PLUGIN_ALLOWLIST_FILE"
 private const val ALLOWLIST_ENTRY_PARTS = 3
 
-internal data class PluginChecksumAllowlist(
-    val entries: Map<LockKey, String>,
-) {
+internal data class PluginChecksumAllowlist(val entries: Map<LockKey, String>) {
     fun assertCovers(requestedKeys: Set<LockKey>) {
         val missing = requestedKeys - entries.keys
         require(missing.isEmpty()) {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
@@ -14,9 +14,8 @@ import kotlin.io.path.name
 private const val HTTP_STATUS_OK = 200
 private val HTTP_CLIENT: HttpClient = HttpClient.newHttpClient()
 
-internal fun resolveRepositories(command: RunCommand, settings: PluginResolverSettings): List<String> {
-    return resolveRepositories(command, settings, settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy())
-}
+internal fun resolveRepositories(command: RunCommand, settings: PluginResolverSettings): List<String> =
+    resolveRepositories(command, settings, settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy())
 
 internal fun resolveRepositories(
     command: RunCommand,

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryPolicy.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryPolicy.kt
@@ -17,11 +17,13 @@ internal data class RepositoryAllowlistPolicy(
                 "Repository '$repositoryUri' is blocked by policy: file:// repositories are not allowed. " +
                     "Set $ALLOW_FILE_REPOSITORIES_ENV=true to explicitly enable file repositories."
             }
+
             "http", "https" ->
                 require(allowedRepositories.contains(normalized)) {
                     "Repository '$repositoryUri' is not in the allowed repository allowlist. " +
                         "Configure $REPOSITORY_ALLOWLIST_ENV to permit additional endpoints."
                 }
+
             else -> error("Unsupported repository URI '$repositoryUri'. Use https://, http://, or file://.")
         }
     }
@@ -67,6 +69,7 @@ internal fun normalizeRepositoryUri(uri: String): String {
             val path = parsed.path?.ifEmpty { "/" } ?: "/"
             URI("file", null, path, null).toString().trimEnd('/')
         }
+
         "http", "https" -> {
             require(parsed.userInfo == null) {
                 "Repository URI '$uri' must not include userinfo credentials."
@@ -78,6 +81,7 @@ internal fun normalizeRepositoryUri(uri: String): String {
             val path = parsed.path?.ifEmpty { "" }.orEmpty()
             URI(scheme, parsed.userInfo, host, parsed.port, path, null, null).toString().trimEnd('/')
         }
+
         else -> error("Unsupported repository URI '$uri'. Use https://, http://, or file://.")
     }
 }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionModel.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionModel.kt
@@ -11,11 +11,7 @@ internal const val LOCAL_KIND = "local"
 private const val COORDINATE_PART_COUNT = 3
 private const val HEX_SHA256_LENGTH = 64
 
-internal data class Coordinate(
-    val group: String,
-    val artifact: String,
-    val version: String,
-) {
+internal data class Coordinate(val group: String, val artifact: String, val version: String) {
     val value: String
         get() = "$group:$artifact:$version"
 
@@ -23,21 +19,11 @@ internal data class Coordinate(
         get() = "${group.replace('.', '/')}/$artifact/$version/$artifact-$version.jar"
 }
 
-internal data class LockEntry(
-    val kind: String,
-    val key: String,
-    val checksum: String,
-)
+internal data class LockEntry(val kind: String, val key: String, val checksum: String)
 
-internal data class LockKey(
-    val kind: String,
-    val key: String,
-)
+internal data class LockKey(val kind: String, val key: String)
 
-internal data class ParsedLockfile(
-    val version: Int,
-    val entries: List<LockEntry>,
-)
+internal data class ParsedLockfile(val version: Int, val entries: List<LockEntry>)
 
 internal fun parseCoordinate(raw: String): Coordinate {
     val parts = raw.split(':')
@@ -98,9 +84,7 @@ internal fun sha256(path: Path): String {
     return digest.digest().toHexString()
 }
 
-internal fun isSha256(value: String): Boolean {
-    return value.length == HEX_SHA256_LENGTH && value.matches(Regex("^[a-f0-9]+$"))
-}
+internal fun isSha256(value: String): Boolean = value.length == HEX_SHA256_LENGTH && value.matches(Regex("^[a-f0-9]+$"))
 
 private fun ByteArray.toHexString(): String = joinToString(separator = "") { "%02x".format(it) }
 

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -5,14 +5,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 internal sealed interface PluginResolutionResult {
-    data class Success(
-        val classpath: List<Path>,
-        val lockfilePath: Path?,
-    ) : PluginResolutionResult
+    data class Success(val classpath: List<Path>, val lockfilePath: Path?) : PluginResolutionResult
 
-    data class Failure(
-        val diagnostics: List<String>,
-    ) : PluginResolutionResult
+    data class Failure(val diagnostics: List<String>) : PluginResolutionResult
 }
 
 internal data class PluginResolverSettings(
@@ -116,7 +111,4 @@ private fun localPluginLockKey(pluginJarPath: Path): String = pluginJarPath
     .toString()
     .replace('\\', '/')
 
-private data class LocalPluginJar(
-    val artifactPath: Path,
-    val lockKey: String,
-)
+private data class LocalPluginJar(val artifactPath: Path, val lockKey: String)

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/ProtobufBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/ProtobufBuilder.kt
@@ -3,9 +3,7 @@ package me.liam.microsmith.dsl.schemas.protobuf
 import me.liam.microsmith.dsl.schemas.protobuf.types.EnumBuilder
 import me.liam.microsmith.dsl.schemas.protobuf.types.MessageBuilder
 
-class ProtobufBuilder(
-    private val segments: List<String> = emptyList(),
-) : ProtobufScope {
+class ProtobufBuilder(private val segments: List<String> = emptyList()) : ProtobufScope {
     private val schemasByName = mutableMapOf<String, ProtobufSchema>()
     private val registeredNames = mutableSetOf<String>()
 

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/ProtobufSchema.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/ProtobufSchema.kt
@@ -4,15 +4,10 @@ import me.liam.microsmith.dsl.schemas.core.Schema
 import me.liam.microsmith.dsl.schemas.core.SchemaType
 import me.liam.microsmith.dsl.schemas.protobuf.types.Type
 
-enum class ProtobufSchemaType(
-    override val typeName: String,
-) : SchemaType {
+enum class ProtobufSchemaType(override val typeName: String) : SchemaType {
     PROTOBUF("protobuf"),
 }
 
-data class ProtobufSchema(
-    override val name: String,
-    val schema: Type,
-) : Schema {
+data class ProtobufSchema(override val name: String, val schema: Type) : Schema {
     override val type: SchemaType get() = ProtobufSchemaType.PROTOBUF
 }

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/FieldType.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/FieldType.kt
@@ -38,7 +38,4 @@ sealed interface PrimitiveType : ValueType {
 
 sealed interface MapKeyType : PrimitiveType
 
-data class MapType(
-    val key: MapKeyType,
-    val value: ValueType,
-) : FieldType
+data class MapType(val key: MapKeyType, val value: ValueType) : FieldType

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/MapField.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/MapField.kt
@@ -1,7 +1,3 @@
 package me.liam.microsmith.dsl.schemas.protobuf.field
 
-data class MapField(
-    override val name: String,
-    override val index: Int,
-    val type: MapType,
-) : Field
+data class MapField(override val name: String, override val index: Int, val type: MapType) : Field

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/OneofField.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/OneofField.kt
@@ -1,7 +1,3 @@
 package me.liam.microsmith.dsl.schemas.protobuf.field
 
-data class OneofField(
-    override val name: String,
-    override val index: Int,
-    val fieldType: ValueType,
-) : Field
+data class OneofField(override val name: String, override val index: Int, val fieldType: ValueType) : Field

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/OneofFieldBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/OneofFieldBuilder.kt
@@ -2,9 +2,7 @@ package me.liam.microsmith.dsl.schemas.protobuf.field
 
 import me.liam.microsmith.dsl.schemas.protobuf.OneofFieldScope
 
-class OneofFieldBuilder(
-    var index: Int? = null,
-) : OneofFieldScope {
+class OneofFieldBuilder(var index: Int? = null) : OneofFieldScope {
     override fun index(index: Int) {
         this.index = index
     }

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/ReferenceField.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/ReferenceField.kt
@@ -2,10 +2,7 @@ package me.liam.microsmith.dsl.schemas.protobuf.field
 
 import me.liam.microsmith.dsl.schemas.protobuf.types.Type
 
-data class Reference(
-    val name: String,
-    val type: Type? = null,
-) : ValueType
+data class Reference(val name: String, val type: Type? = null) : ValueType
 
 data class ReferenceField(
     override val name: String,

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/ReferenceFieldBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/ReferenceFieldBuilder.kt
@@ -2,10 +2,8 @@ package me.liam.microsmith.dsl.schemas.protobuf.field
 
 import me.liam.microsmith.dsl.schemas.protobuf.ReferenceFieldScope
 
-class ReferenceFieldBuilder(
-    var index: Int? = null,
-    var cardinality: Cardinality = Cardinality.REQUIRED,
-) : ReferenceFieldScope {
+class ReferenceFieldBuilder(var index: Int? = null, var cardinality: Cardinality = Cardinality.REQUIRED) :
+    ReferenceFieldScope {
     override fun index(index: Int) {
         this.index = index
     }

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/ScalarFieldBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/field/ScalarFieldBuilder.kt
@@ -2,10 +2,8 @@ package me.liam.microsmith.dsl.schemas.protobuf.field
 
 import me.liam.microsmith.dsl.schemas.protobuf.ScalarFieldScope
 
-class ScalarFieldBuilder(
-    var index: Int? = null,
-    var cardinality: Cardinality = Cardinality.REQUIRED,
-) : ScalarFieldScope {
+class ScalarFieldBuilder(var index: Int? = null, var cardinality: Cardinality = Cardinality.REQUIRED) :
+    ScalarFieldScope {
     override fun optional() {
         require(cardinality == Cardinality.REQUIRED) {
             "Cardinality already set to $cardinality"

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/oneof/Oneof.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/oneof/Oneof.kt
@@ -2,7 +2,4 @@ package me.liam.microsmith.dsl.schemas.protobuf.oneof
 
 import me.liam.microsmith.dsl.schemas.protobuf.field.OneofField
 
-data class Oneof(
-    val name: String,
-    val fields: List<OneofField>,
-)
+data class Oneof(val name: String, val fields: List<OneofField>)

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/reserved/Max.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/reserved/Max.kt
@@ -4,6 +4,4 @@ object Max {
     internal const val VALUE = 536_870_911
 }
 
-data class MaxRange(
-    val from: Int,
-)
+data class MaxRange(val from: Int)

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/reserved/Reserved.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/reserved/Reserved.kt
@@ -10,18 +10,10 @@ sealed interface Reserved {
     }
 }
 
-data class ReservedIndex(
-    val index: Int,
-) : Reserved
+data class ReservedIndex(val index: Int) : Reserved
 
-data class ReservedToMax(
-    val from: Int,
-) : Reserved
+data class ReservedToMax(val from: Int) : Reserved
 
-data class ReservedRange(
-    val indexRange: IntRange,
-) : Reserved
+data class ReservedRange(val indexRange: IntRange) : Reserved
 
-data class ReservedName(
-    val name: String,
-) : Reserved
+data class ReservedName(val name: String) : Reserved

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/reserved/ReservedBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/reserved/ReservedBuilder.kt
@@ -4,10 +4,7 @@ import me.liam.microsmith.dsl.schemas.protobuf.ReservedScope
 import me.liam.microsmith.dsl.schemas.protobuf.support.IndexAllocator
 import me.liam.microsmith.dsl.schemas.protobuf.support.NameRegistry
 
-class ReservedBuilder(
-    private val allocator: IndexAllocator,
-    private val names: NameRegistry,
-) : ReservedScope {
+class ReservedBuilder(private val allocator: IndexAllocator, private val names: NameRegistry) : ReservedScope {
     override fun index(index: Int) {
         allocator.reserve(index)
     }

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/IndexAllocator.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/IndexAllocator.kt
@@ -3,10 +3,7 @@ package me.liam.microsmith.dsl.schemas.protobuf.support
 import me.liam.microsmith.dsl.schemas.protobuf.extensions.merge
 import me.liam.microsmith.dsl.schemas.protobuf.reserved.Max
 
-class IndexAllocator(
-    private val min: Int,
-    private val protoReserved: IntRange? = null,
-) {
+class IndexAllocator(private val min: Int, private val protoReserved: IntRange? = null) {
     private val reserved = mutableSetOf<IntRange>()
 
     fun reserved() = reserved.toSet()

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferenceResolver.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferenceResolver.kt
@@ -39,9 +39,7 @@ private fun String.validatePathSegments(label: String): List<String> {
     return segments
 }
 
-private class ReferenceResolutionContext(
-    schemas: Set<ProtobufSchema>,
-) {
+private class ReferenceResolutionContext(schemas: Set<ProtobufSchema>) {
     private val schemasByName = schemas.associateBy { it.name }
     val errors = mutableListOf<String>()
 
@@ -56,12 +54,15 @@ private class ReferenceResolutionContext(
 
     private fun Field.resolve(messageName: String): Field = when (this) {
         is ReferenceField -> copy(reference = reference.resolve("message $messageName field '$name'"))
+
         is MapField -> {
             val resolvedValue =
                 (type.value as? Reference)?.resolve("message $messageName map field '$name' value") ?: type.value
             copy(type = MapType(type.key, resolvedValue))
         }
+
         is ScalarField -> this
+
         is OneofField -> this
     }
 

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/Enum.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/Enum.kt
@@ -2,11 +2,8 @@ package me.liam.microsmith.dsl.schemas.protobuf.types
 
 import me.liam.microsmith.dsl.schemas.protobuf.reserved.Reserved
 
-data class Enum(
-    override val name: String,
-    val values: List<EnumValue>,
-    val reserved: List<Reserved> = emptyList(),
-) : Type {
+data class Enum(override val name: String, val values: List<EnumValue>, val reserved: List<Reserved> = emptyList()) :
+    Type {
     companion object {
         internal const val UNSPECIFIED = "UNSPECIFIED"
     }

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/EnumBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/EnumBuilder.kt
@@ -11,9 +11,7 @@ import me.liam.microsmith.dsl.schemas.protobuf.reserved.ReservedName
 import me.liam.microsmith.dsl.schemas.protobuf.support.IndexAllocator
 import me.liam.microsmith.dsl.schemas.protobuf.support.NameRegistry
 
-class EnumBuilder(
-    private val name: String,
-) : EnumScope {
+class EnumBuilder(private val name: String) : EnumScope {
     private val allocator = IndexAllocator(0)
     private val nameRegistry = NameRegistry()
 

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/EnumValue.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/EnumValue.kt
@@ -1,6 +1,3 @@
 package me.liam.microsmith.dsl.schemas.protobuf.types
 
-data class EnumValue(
-    val name: String,
-    val index: Int,
-)
+data class EnumValue(val name: String, val index: Int)

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/EnumValueBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/EnumValueBuilder.kt
@@ -2,9 +2,7 @@ package me.liam.microsmith.dsl.schemas.protobuf.types
 
 import me.liam.microsmith.dsl.schemas.protobuf.EnumValueScope
 
-class EnumValueBuilder(
-    var index: Int? = null,
-) : EnumValueScope {
+class EnumValueBuilder(var index: Int? = null) : EnumValueScope {
     override fun index(index: Int) {
         this.index = index
     }

--- a/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/MessageBuilder.kt
+++ b/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/types/MessageBuilder.kt
@@ -29,10 +29,7 @@ import me.liam.microsmith.dsl.schemas.protobuf.support.IndexAllocator
 import me.liam.microsmith.dsl.schemas.protobuf.support.NameRegistry
 import me.liam.microsmith.dsl.schemas.protobuf.support.getReferencePath
 
-class MessageBuilder(
-    private val name: String,
-    private val segments: List<String>,
-) : MessageScope {
+class MessageBuilder(private val name: String, private val segments: List<String>) : MessageScope {
     private val allocator = IndexAllocator(1, protoReservedIndexes)
     private val nameRegistry = NameRegistry()
 

--- a/dsl-schemas/src/main/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasExtension.kt
+++ b/dsl-schemas/src/main/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasExtension.kt
@@ -5,9 +5,7 @@ import me.liam.microsmith.dsl.core.MicrosmithExtension
 /**
  * Root extension that holds all declared schemas.
  */
-data class SchemasExtension(
-    val schemas: Set<Schema>,
-) : MicrosmithExtension {
+data class SchemasExtension(val schemas: Set<Schema>) : MicrosmithExtension {
     init {
         val duplicateKeys =
             schemas

--- a/dsl-schemas/src/test/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasBuilderTests.kt
+++ b/dsl-schemas/src/test/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasBuilderTests.kt
@@ -8,10 +8,7 @@ private object FakeSchemaType : SchemaType {
     override val typeName = "fake"
 }
 
-private data class FakeSchema(
-    override val type: SchemaType = FakeSchemaType,
-    override val name: String,
-) : Schema
+private data class FakeSchema(override val type: SchemaType = FakeSchemaType, override val name: String) : Schema
 
 class SchemasBuilderTests :
     StringSpec({

--- a/dsl-schemas/src/test/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasExtensionTests.kt
+++ b/dsl-schemas/src/test/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasExtensionTests.kt
@@ -4,17 +4,12 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-private enum class TestSchemaTypes(
-    override val typeName: String,
-) : SchemaType {
+private enum class TestSchemaTypes(override val typeName: String) : SchemaType {
     PROTOBUF("protobuf"),
     JSON("json"),
 }
 
-private data class ExtFakeSchema(
-    override val type: SchemaType,
-    override val name: String,
-) : Schema
+private data class ExtFakeSchema(override val type: SchemaType, override val name: String) : Schema
 
 class SchemasExtensionTests :
     StringSpec({

--- a/dsl-schemas/src/test/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasScopeTests.kt
+++ b/dsl-schemas/src/test/kotlin/me/liam/microsmith/dsl/schemas/core/SchemasScopeTests.kt
@@ -5,17 +5,12 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import me.liam.microsmith.dsl.core.MicrosmithBuilder
 
-private enum class ScopeTestSchemaTypes(
-    override val typeName: String,
-) : SchemaType {
+private enum class ScopeTestSchemaTypes(override val typeName: String) : SchemaType {
     PROTOBUF("protobuf"),
     JSON("json"),
 }
 
-private data class ScopeFakeSchema(
-    override val type: SchemaType,
-    override val name: String,
-) : Schema
+private data class ScopeFakeSchema(override val type: SchemaType, override val name: String) : Schema
 
 private fun SchemasScope.fake(type: SchemaType, name: String) {
     val builder = this as SchemasBuilder

--- a/dsl/src/test/kotlin/me/liam/microsmith/dsl/core/MicrosmithBuilderTests.kt
+++ b/dsl/src/test/kotlin/me/liam/microsmith/dsl/core/MicrosmithBuilderTests.kt
@@ -5,9 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import me.liam.microsmith.dsl.helpers.put
 
-data class DummyExtension(
-    val value: String,
-) : MicrosmithExtension
+data class DummyExtension(val value: String) : MicrosmithExtension
 
 class MicrosmithBuilderTests :
     StringSpec({

--- a/dsl/src/test/kotlin/me/liam/microsmith/dsl/core/MicrosmithModelTests.kt
+++ b/dsl/src/test/kotlin/me/liam/microsmith/dsl/core/MicrosmithModelTests.kt
@@ -6,13 +6,9 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
-data class FooExtension(
-    val foo: String,
-) : MicrosmithExtension
+data class FooExtension(val foo: String) : MicrosmithExtension
 
-data class BarExtension(
-    val bar: Int,
-) : MicrosmithExtension
+data class BarExtension(val bar: Int) : MicrosmithExtension
 
 class MicrosmithModelTests :
     StringSpec({

--- a/dsl/src/test/kotlin/me/liam/microsmith/dsl/core/MicrosmithScopeTests.kt
+++ b/dsl/src/test/kotlin/me/liam/microsmith/dsl/core/MicrosmithScopeTests.kt
@@ -4,9 +4,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import me.liam.microsmith.dsl.helpers.put
 
-data class TestExtension(
-    val value: String,
-) : MicrosmithExtension
+data class TestExtension(val value: String) : MicrosmithExtension
 
 class MicrosmithScopeTests :
     StringSpec({

--- a/dsl/src/test/kotlin/me/liam/microsmith/dsl/helpers/MicrosmithModelExtensionsTests.kt
+++ b/dsl/src/test/kotlin/me/liam/microsmith/dsl/helpers/MicrosmithModelExtensionsTests.kt
@@ -9,13 +9,9 @@ import io.kotest.matchers.shouldBe
 import me.liam.microsmith.dsl.core.MicrosmithExtension
 import me.liam.microsmith.dsl.core.MicrosmithModel
 
-data class FooExt(
-    val foo: String,
-) : MicrosmithExtension
+data class FooExt(val foo: String) : MicrosmithExtension
 
-data class BarExt(
-    val bar: Int,
-) : MicrosmithExtension
+data class BarExt(val bar: Int) : MicrosmithExtension
 
 class MicrosmithModelExtensionsTests :
     StringSpec({

--- a/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmissionInvariantException.kt
+++ b/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmissionInvariantException.kt
@@ -5,6 +5,4 @@ package me.liam.microsmith.gen.schemas.protobuf.emission
  *
  * This is reserved for defensive checks that should never be hit through the DSL.
  */
-internal class ProtobufEmissionInvariantException(
-    message: String,
-) : IllegalStateException(message)
+internal class ProtobufEmissionInvariantException(message: String) : IllegalStateException(message)

--- a/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmissionValidation.kt
+++ b/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmissionValidation.kt
@@ -158,6 +158,7 @@ private fun Reference.validateForEmission() {
 private fun Reserved.validateForEmission() {
     when (this) {
         is ReservedIndex -> ProtobufFieldNumbers.requireValidFieldNumber(index, "Reserved index")
+
         is ReservedRange -> {
             require(indexRange.first <= indexRange.last) {
                 "Reserved range must be ascending, but was $indexRange."
@@ -165,7 +166,9 @@ private fun Reserved.validateForEmission() {
             ProtobufFieldNumbers.requireValidFieldNumber(indexRange.first, "Reserved range start")
             ProtobufFieldNumbers.requireValidFieldNumber(indexRange.last, "Reserved range end")
         }
+
         is ReservedToMax -> ProtobufFieldNumbers.requireValidFieldNumber(from, "Reserved-to-max start")
+
         is ReservedName -> ProtobufNameValidation.requireIdentifier(name, "Reserved name")
     }
 }

--- a/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmitter.kt
+++ b/gen-schemas-protobuf/src/main/kotlin/me/liam/microsmith/gen/schemas/protobuf/emission/ProtobufEmitter.kt
@@ -21,9 +21,8 @@ import kotlin.reflect.KClass
  * This emitter is stateless and therefore safe for concurrent use.
  */
 @ServiceProvider(SchemaEmitter::class)
-class ProtobufEmitter(
-    override val type: KClass<ProtobufSchema> = ProtobufSchema::class,
-) : SchemaEmitter<ProtobufSchema> {
+class ProtobufEmitter(override val type: KClass<ProtobufSchema> = ProtobufSchema::class) :
+    SchemaEmitter<ProtobufSchema> {
     /**
      * Converts the receiving schema into a deterministic protobuf source file.
      *

--- a/gen/src/main/kotlin/me/liam/microsmith/gen/files/DirectorySpace.kt
+++ b/gen/src/main/kotlin/me/liam/microsmith/gen/files/DirectorySpace.kt
@@ -3,9 +3,7 @@ package me.liam.microsmith.gen.files
 import java.nio.file.Files
 import java.nio.file.Path
 
-class DirectorySpace private constructor(
-    override val root: Path,
-) : FileSpace {
+class DirectorySpace private constructor(override val root: Path) : FileSpace {
     companion object {
         fun from(path: Path): DirectorySpace {
             val normalizedRoot = path.toAbsolutePath().normalize()

--- a/gen/src/main/kotlin/me/liam/microsmith/gen/files/GeneratedFile.kt
+++ b/gen/src/main/kotlin/me/liam/microsmith/gen/files/GeneratedFile.kt
@@ -2,10 +2,7 @@ package me.liam.microsmith.gen.files
 
 import java.nio.file.Path
 
-class GeneratedFile(
-    val relativePath: Path,
-    contents: ByteArray,
-) {
+class GeneratedFile(val relativePath: Path, contents: ByteArray) {
     private val bytes = contents.copyOf()
 
     val contents: ByteArray

--- a/gen/src/main/kotlin/me/liam/microsmith/gen/files/TemporaryDirectory.kt
+++ b/gen/src/main/kotlin/me/liam/microsmith/gen/files/TemporaryDirectory.kt
@@ -8,9 +8,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Comparator
 
-class TemporaryDirectory private constructor(
-    override val root: Path,
-) : FileSpace,
+class TemporaryDirectory private constructor(override val root: Path) :
+    FileSpace,
     Closeable {
     override fun close() {
         runCatching {

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/cache/RuntimeClasspathFingerprint.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/cache/RuntimeClasspathFingerprint.kt
@@ -36,14 +36,17 @@ internal object RuntimeClasspathFingerprint {
 private fun MessageDigest.addClasspathEntryFingerprint(entry: Path) {
     when {
         !Files.exists(entry) -> addChunk("missing")
+
         Files.isRegularFile(entry) -> {
             addChunk("file")
             addFileDigest(entry)
         }
+
         Files.isDirectory(entry) -> {
             addChunk("directory")
             addDirectoryFingerprint(entry)
         }
+
         else -> addChunk("other")
     }
 }

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/MicrosmithScriptHost.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/MicrosmithScriptHost.kt
@@ -4,9 +4,7 @@ import me.liam.microsmith.runtime.scripting.model.ScriptRunRequest
 import me.liam.microsmith.runtime.scripting.model.ScriptRunResult
 import java.nio.file.Path
 
-class MicrosmithScriptHost(
-    private val cacheDirectory: Path = ScriptHostPaths.defaultCacheDirectory(),
-) {
+class MicrosmithScriptHost(cacheDirectory: Path = ScriptHostPaths.defaultCacheDirectory()) {
     private val runExecutor = ScriptRunExecutor(cacheDirectory)
 
     fun run(request: ScriptRunRequest): ScriptRunResult {

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ProcessIsolatedScriptExecutor.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ProcessIsolatedScriptExecutor.kt
@@ -9,9 +9,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Comparator
 
-internal class ProcessIsolatedScriptExecutor(
-    private val cacheDirectory: Path,
-) {
+internal class ProcessIsolatedScriptExecutor(private val cacheDirectory: Path) {
     fun execute(request: ScriptRunRequest, scriptPath: Path, outputPath: Path): ScriptRunResult {
         Files.createDirectories(cacheDirectory)
         val workingDirectory = Files.createTempDirectory(cacheDirectory, "process-isolation-")
@@ -142,9 +140,5 @@ internal class ProcessIsolatedScriptExecutor(
         }
     }
 
-    private data class ProcessOutcome(
-        val exitCode: Int,
-        val processOutput: String,
-        val parsedResult: ScriptRunResult?,
-    )
+    private data class ProcessOutcome(val exitCode: Int, val processOutput: String, val parsedResult: ScriptRunResult?)
 }

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ProcessIsolationProtocol.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ProcessIsolationProtocol.kt
@@ -130,6 +130,7 @@ internal object ProcessIsolationProtocol {
                     properties["$RESULT_WARNING_PREFIX$index"] = warning
                 }
             }
+
             is ScriptRunFailure -> {
                 properties[RESULT_STATUS] = RESULT_STATUS_FAILURE
                 properties[RESULT_DIAGNOSTIC_COUNT] = result.diagnostics.size.toString()
@@ -171,6 +172,7 @@ internal object ProcessIsolationProtocol {
                     )
                 ScriptRunSuccess(warnings = warnings, cacheHit = cacheHit, elapsedMillis = elapsedMillis)
             }
+
             RESULT_STATUS_FAILURE -> {
                 val diagnostics =
                     readIndexedList(
@@ -184,6 +186,7 @@ internal object ProcessIsolationProtocol {
                     type = failureType,
                 )
             }
+
             else -> error("Missing or invalid '$RESULT_STATUS' in process isolation result.")
         }
     }

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptDirectivePolicy.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptDirectivePolicy.kt
@@ -51,7 +51,7 @@ internal object ScriptDirectivePolicy {
                     groupStartLine = index + 1
                     groupBuffer += line
                     if (GROUP_FILE_DIRECTIVE_END.containsMatchIn(line)) {
-                        val start = requireNotNull(groupStartLine)
+                        val start = groupStartLine
                         violations += collectGroupedViolations(groupBuffer.joinToString("\n"), start)
                         groupStartLine = null
                         groupBuffer.clear()
@@ -61,7 +61,7 @@ internal object ScriptDirectivePolicy {
                 groupStartLine != null -> {
                     groupBuffer += line
                     if (GROUP_FILE_DIRECTIVE_END.containsMatchIn(line)) {
-                        val start = requireNotNull(groupStartLine)
+                        val start = groupStartLine
                         violations += collectGroupedViolations(groupBuffer.joinToString("\n"), start)
                         groupStartLine = null
                         groupBuffer.clear()
@@ -77,7 +77,7 @@ internal object ScriptDirectivePolicy {
         val matches = GROUP_FORBIDDEN_DIRECTIVE.findAll(groupText)
         return matches
             .map { match ->
-                val newlineCountBeforeMatch = groupText.substring(0, match.range.first).count { it == '\n' }
+                val newlineCountBeforeMatch = groupText.take(match.range.first).count { it == '\n' }
                 val lineNumber = startLine + newlineCountBeforeMatch
                 val directive = match.groupValues[1]
                 violationMessage(lineNumber, directive)

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunExecutor.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunExecutor.kt
@@ -10,9 +10,7 @@ import me.liam.microsmith.runtime.scripting.model.ScriptRunResult
 import java.nio.file.Files
 import java.nio.file.Path
 
-internal class ScriptRunExecutor(
-    private val cacheDirectory: Path,
-) {
+internal class ScriptRunExecutor(private val cacheDirectory: Path) {
     fun execute(request: ScriptRunRequest, scriptPath: Path, outputPath: Path): ScriptRunResult {
         val normalizedPluginClasspath = request.pluginClasspath.map { it.toAbsolutePath().normalize() }
         return when (request.isolationMode) {

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunResultMapper.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunResultMapper.kt
@@ -75,6 +75,7 @@ internal object ScriptRunResultMapper {
     private fun ensureModelGenerated(evaluationResult: EvaluationResult, scriptContext: MicrosmithScriptContext) {
         when (val returnValue = evaluationResult.returnValue) {
             is ResultValue.Error -> rethrow(returnValue.error)
+
             is ResultValue.Value -> {
                 val returnedModel = returnValue.value as? MicrosmithModel
                 when {
@@ -83,6 +84,7 @@ internal object ScriptRunResultMapper {
                     else -> modelRequiredFailure()
                 }
             }
+
             is ResultValue.Unit,
             ResultValue.NotEvaluated,
             -> {

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/model/ScriptIsolationMode.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/model/ScriptIsolationMode.kt
@@ -1,8 +1,6 @@
 package me.liam.microsmith.runtime.scripting.model
 
-enum class ScriptIsolationMode(
-    val cliValue: String,
-) {
+enum class ScriptIsolationMode(val cliValue: String) {
     CLASSLOADER("classloader"),
     PROCESS("process"),
     ;

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/model/ScriptRunFailure.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/model/ScriptRunFailure.kt
@@ -1,6 +1,4 @@
 package me.liam.microsmith.runtime.scripting.model
 
-data class ScriptRunFailure(
-    val diagnostics: List<String>,
-    val type: ScriptFailureType = ScriptFailureType.HOST,
-) : ScriptRunResult
+data class ScriptRunFailure(val diagnostics: List<String>, val type: ScriptFailureType = ScriptFailureType.HOST) :
+    ScriptRunResult

--- a/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/model/ScriptRunSuccess.kt
+++ b/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/model/ScriptRunSuccess.kt
@@ -1,7 +1,4 @@
 package me.liam.microsmith.runtime.scripting.model
 
-data class ScriptRunSuccess(
-    val warnings: List<String>,
-    val cacheHit: Boolean,
-    val elapsedMillis: Long,
-) : ScriptRunResult
+data class ScriptRunSuccess(val warnings: List<String>, val cacheHit: Boolean, val elapsedMillis: Long) :
+    ScriptRunResult


### PR DESCRIPTION
## Summary
This PR applies a formatting normalization pass across core Kotlin modules and tests to improve consistency and reduce future diff noise.

## What changed
- Normalized Kotlin formatting across `cli`, `dsl`, `dsl-schemas`, `dsl-schemas-protobuf`, `gen`, `gen-schemas-protobuf`, and `runtime-scripting`.
- Kept changes isolated to style/readability-focused edits.
- Preserved existing behavior and API intent.

## Why
- Establishes a stable formatting baseline before new feature implementation.
- Improves readability and review signal for follow-on PRs.

## Verification
- `./gradlew :cli:compileKotlin :dsl:compileTestKotlin :dsl-schemas:compileTestKotlin :dsl-schemas-protobuf:compileKotlin :gen-schemas-protobuf:compileKotlin :runtime-scripting:compileKotlin`
- `./gradlew :cli:kotest :dsl:kotest :dsl-schemas:kotest :dsl-schemas-protobuf:kotest :runtime-scripting:kotest`

Closes #55
