### PR TITLE
feat(runtime-resolver): integrate Maven Resolver for transitive external plugin resolution

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -14,6 +14,14 @@ dependencies {
     implementation project(":gen")
     implementation project(":gen-schemas")
     implementation project(":gen-schemas-protobuf")
+    implementation libs.maven.resolver.api
+    implementation libs.maven.resolver.spi
+    implementation libs.maven.resolver.util
+    implementation libs.maven.resolver.impl
+    implementation libs.maven.resolver.supplier
+    implementation libs.maven.resolver.connector.basic
+    implementation libs.maven.resolver.transport.file
+    implementation libs.maven.resolver.transport.http
 }
 
 application {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -1,0 +1,169 @@
+package me.liam.microsmith.cli.plugins
+
+import org.eclipse.aether.DefaultRepositorySystemSession
+import org.eclipse.aether.RepositorySystem
+import org.eclipse.aether.RepositorySystemSession
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.collection.CollectRequest
+import org.eclipse.aether.graph.Dependency
+import org.eclipse.aether.repository.LocalRepository
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.resolution.ArtifactResult
+import org.eclipse.aether.resolution.DependencyRequest
+import org.eclipse.aether.resolution.DependencyResolutionException
+import org.eclipse.aether.supplier.RepositorySystemSupplier
+import org.eclipse.aether.transfer.ArtifactNotFoundException
+import org.eclipse.aether.util.artifact.JavaScopes
+import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal interface RemotePluginResolver {
+    fun resolve(
+        coordinate: Coordinate,
+        repositories: List<String>,
+        cacheDirectory: Path,
+        offline: Boolean,
+    ): ResolvedRemotePlugin
+}
+
+internal data class ResolvedRemotePlugin(val rootArtifactPath: Path, val classpath: List<Path>)
+
+internal enum class PluginResolverErrorCategory(val code: String) {
+    OFFLINE_CACHE_MISS("offline-cache-miss"),
+    DEPENDENCY_RESOLUTION("dependency-resolution"),
+    ROOT_ARTIFACT_MISSING("root-artifact-missing"),
+}
+
+internal class PluginResolutionDiagnosticException(
+    val category: PluginResolverErrorCategory,
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+internal class MavenRemotePluginResolver(
+    private val repositorySystem: RepositorySystem = RepositorySystemSupplier().get(),
+) : RemotePluginResolver {
+    override fun resolve(
+        coordinate: Coordinate,
+        repositories: List<String>,
+        cacheDirectory: Path,
+        offline: Boolean,
+    ): ResolvedRemotePlugin {
+        val localRepositoryRoot = pluginArtifactCacheRoot(cacheDirectory)
+        Files.createDirectories(localRepositoryRoot)
+
+        val expectedRootArtifactPath = cachePathFor(localRepositoryRoot, coordinate)
+        if (offline && !Files.exists(expectedRootArtifactPath)) {
+            throw PluginResolutionDiagnosticException(
+                category = PluginResolverErrorCategory.OFFLINE_CACHE_MISS,
+                message =
+                "Offline mode is enabled and plugin '${coordinate.value}' is not in cache at " +
+                    "'$expectedRootArtifactPath'. Run once without --offline to populate the cache.",
+            )
+        }
+
+        val session =
+            buildSession(
+                repositorySystem = repositorySystem,
+                localRepositoryRoot = localRepositoryRoot,
+                offline = offline,
+            )
+
+        val remoteRepositories = repositories.map { repository -> toRemoteRepository(repository) }
+        val dependencyRequest =
+            DependencyRequest(
+                CollectRequest(
+                    Dependency(DefaultArtifact(coordinate.value), JavaScopes.RUNTIME),
+                    remoteRepositories,
+                ),
+                null,
+            )
+
+        val dependencyResult =
+            try {
+                repositorySystem.resolveDependencies(session, dependencyRequest)
+            } catch (error: DependencyResolutionException) {
+                throw toDiagnostic(coordinate, localRepositoryRoot, repositories, offline, error)
+            }
+
+        val classpath = resolveClasspath(dependencyResult.artifactResults, dependencyResult.root)
+        val rootArtifactPath =
+            expectedRootArtifactPath.takeIf(Files::exists)
+                ?: classpath.firstOrNull()
+                ?: throw PluginResolutionDiagnosticException(
+                    category = PluginResolverErrorCategory.ROOT_ARTIFACT_MISSING,
+                    message =
+                    "Plugin '${coordinate.value}' resolved but no root jar was produced in cache at " +
+                        "'$expectedRootArtifactPath'.",
+                )
+
+        return ResolvedRemotePlugin(rootArtifactPath = rootArtifactPath, classpath = classpath)
+    }
+}
+
+private fun buildSession(
+    repositorySystem: RepositorySystem,
+    localRepositoryRoot: Path,
+    offline: Boolean,
+): RepositorySystemSession {
+    val sessionBuilder = DefaultRepositorySystemSession()
+    val localRepository = LocalRepository(localRepositoryRoot.toFile())
+    sessionBuilder.setOffline(offline)
+    sessionBuilder.setLocalRepositoryManager(
+        repositorySystem.newLocalRepositoryManager(sessionBuilder, localRepository),
+    )
+    return sessionBuilder
+}
+
+private fun toRemoteRepository(repository: String): RemoteRepository = RemoteRepository
+    .Builder(repository, "default", repository)
+    .build()
+
+private fun resolveClasspath(
+    artifactResults: List<ArtifactResult>,
+    root: org.eclipse.aether.graph.DependencyNode?,
+): List<Path> {
+    val visitor = PreorderNodeListGenerator()
+    root?.accept(visitor)
+    val visited = visitor.files.map { file -> file.toPath().toAbsolutePath().normalize() }
+    val fallback =
+        artifactResults
+            .mapNotNull { result -> result.artifact?.file?.toPath() }
+            .map { path -> path.toAbsolutePath().normalize() }
+    return (visited + fallback).distinct()
+}
+
+private fun toDiagnostic(
+    coordinate: Coordinate,
+    localRepositoryRoot: Path,
+    repositories: List<String>,
+    offline: Boolean,
+    error: DependencyResolutionException,
+): PluginResolutionDiagnosticException {
+    val cause: Throwable? = error.result.collectExceptions.firstOrNull() ?: error.cause
+    val repositoryList = repositories.joinToString(", ")
+    val reason =
+        when (cause) {
+            is ArtifactNotFoundException ->
+                "Artifact '${cause.artifact}' was not found in configured repositories."
+
+            else -> cause?.message ?: error.message ?: "Unknown resolver failure."
+        }
+
+    val remediation =
+        if (offline) {
+            "Offline mode is enabled. Ensure the full dependency graph is cached under " +
+                "'$localRepositoryRoot' by running once without --offline."
+        } else {
+            "Verify plugin coordinates and repository availability."
+        }
+
+    return PluginResolutionDiagnosticException(
+        category = PluginResolverErrorCategory.DEPENDENCY_RESOLUTION,
+        message =
+        "Could not resolve plugin '${coordinate.value}' with transitive dependencies. " +
+            "Repositories: $repositoryList. $reason $remediation",
+        cause = error,
+    )
+}

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -17,6 +17,7 @@ import org.eclipse.aether.resolution.DependencyResult
 import org.eclipse.aether.supplier.RepositorySystemSupplier
 import org.eclipse.aether.transfer.ArtifactNotFoundException
 import org.eclipse.aether.util.artifact.JavaScopes
+import org.eclipse.aether.util.filter.DependencyFilterUtils
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
 import java.nio.file.Files
 import java.nio.file.Path
@@ -117,13 +118,14 @@ private fun resolveDependencyGraph(
         )
 
     val remoteRepositories = repositories.mapIndexed(::toRemoteRepository)
+    val runtimeClasspathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.RUNTIME)
     val dependencyRequest =
         DependencyRequest(
             CollectRequest(
                 Dependency(DefaultArtifact(coordinate.value), JavaScopes.RUNTIME),
                 remoteRepositories,
             ),
-            null,
+            runtimeClasspathFilter,
         )
 
     return try {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -83,7 +83,6 @@ internal class MavenRemotePluginResolver(
                 coordinate = coordinate,
                 expectedRootArtifactPath = expectedRootArtifactPath,
                 artifactResults = dependencyResult.artifactResults,
-                classpath = classpath,
             )
 
         return ResolvedRemotePlugin(rootArtifactPath = rootArtifactPath, classpath = classpath)
@@ -167,7 +166,6 @@ private fun resolveRootArtifactPath(
     coordinate: Coordinate,
     expectedRootArtifactPath: Path,
     artifactResults: List<ArtifactResult>,
-    classpath: List<Path>,
 ): Path = expectedRootArtifactPath.takeIf(Files::exists)
     ?: artifactResults
         .asSequence()
@@ -177,7 +175,6 @@ private fun resolveRootArtifactPath(
         ?.toPath()
         ?.toAbsolutePath()
         ?.normalize()
-    ?: classpath.firstOrNull()
     ?: throw PluginResolutionDiagnosticException(
         category = PluginResolverErrorCategory.ROOT_ARTIFACT_MISSING,
         message =

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -70,7 +70,10 @@ internal class MavenRemotePluginResolver(
                 offline = offline,
             )
 
-        val remoteRepositories = repositories.map { repository -> toRemoteRepository(repository) }
+        val remoteRepositories =
+            repositories.mapIndexed { index, repository ->
+                toRemoteRepository(index, repository)
+            }
         val dependencyRequest =
             DependencyRequest(
                 CollectRequest(
@@ -116,8 +119,8 @@ private fun buildSession(
     return sessionBuilder
 }
 
-private fun toRemoteRepository(repository: String): RemoteRepository = RemoteRepository
-    .Builder(repository, "default", repository)
+private fun toRemoteRepository(index: Int, repository: String): RemoteRepository = RemoteRepository
+    .Builder("repo-$index", "default", repository)
     .build()
 
 private fun resolveClasspath(

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -3,20 +3,26 @@ package me.liam.microsmith.cli.plugins
 import org.eclipse.aether.DefaultRepositorySystemSession
 import org.eclipse.aether.RepositorySystem
 import org.eclipse.aether.RepositorySystemSession
+import org.eclipse.aether.artifact.Artifact
 import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.collection.CollectRequest
 import org.eclipse.aether.graph.Dependency
+import org.eclipse.aether.graph.DependencyNode
 import org.eclipse.aether.repository.LocalRepository
 import org.eclipse.aether.repository.RemoteRepository
 import org.eclipse.aether.resolution.ArtifactResult
 import org.eclipse.aether.resolution.DependencyRequest
 import org.eclipse.aether.resolution.DependencyResolutionException
+import org.eclipse.aether.resolution.DependencyResult
 import org.eclipse.aether.supplier.RepositorySystemSupplier
 import org.eclipse.aether.transfer.ArtifactNotFoundException
 import org.eclipse.aether.util.artifact.JavaScopes
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
 import java.nio.file.Files
 import java.nio.file.Path
+
+private const val REMOTE_REPOSITORY_ID_PREFIX = "repo"
+private const val REMOTE_REPOSITORY_TYPE_DEFAULT = "default"
 
 internal interface RemotePluginResolver {
     fun resolve(
@@ -50,58 +56,81 @@ internal class MavenRemotePluginResolver(
         cacheDirectory: Path,
         offline: Boolean,
     ): ResolvedRemotePlugin {
-        val localRepositoryRoot = pluginArtifactCacheRoot(cacheDirectory)
-        Files.createDirectories(localRepositoryRoot)
+        val localRepositoryRoot =
+            pluginArtifactCacheRoot(cacheDirectory).also { root ->
+                Files.createDirectories(root)
+            }
 
         val expectedRootArtifactPath = cachePathFor(localRepositoryRoot, coordinate)
-        if (offline && !Files.exists(expectedRootArtifactPath)) {
-            throw PluginResolutionDiagnosticException(
-                category = PluginResolverErrorCategory.OFFLINE_CACHE_MISS,
-                message =
-                "Offline mode is enabled and plugin '${coordinate.value}' is not in cache at " +
-                    "'$expectedRootArtifactPath'. Run once without --offline to populate the cache.",
-            )
-        }
+        ensureOfflineRootAvailability(
+            coordinate = coordinate,
+            expectedRootArtifactPath = expectedRootArtifactPath,
+            offline = offline,
+        )
 
-        val session =
-            buildSession(
+        val dependencyResult =
+            resolveDependencyGraph(
                 repositorySystem = repositorySystem,
+                coordinate = coordinate,
+                repositories = repositories,
                 localRepositoryRoot = localRepositoryRoot,
                 offline = offline,
             )
 
-        val remoteRepositories =
-            repositories.mapIndexed { index, repository ->
-                toRemoteRepository(index, repository)
-            }
-        val dependencyRequest =
-            DependencyRequest(
-                CollectRequest(
-                    Dependency(DefaultArtifact(coordinate.value), JavaScopes.RUNTIME),
-                    remoteRepositories,
-                ),
-                null,
-            )
-
-        val dependencyResult =
-            try {
-                repositorySystem.resolveDependencies(session, dependencyRequest)
-            } catch (error: DependencyResolutionException) {
-                throw toDiagnostic(coordinate, localRepositoryRoot, repositories, offline, error)
-            }
-
         val classpath = resolveClasspath(dependencyResult.artifactResults, dependencyResult.root)
         val rootArtifactPath =
-            expectedRootArtifactPath.takeIf(Files::exists)
-                ?: classpath.firstOrNull()
-                ?: throw PluginResolutionDiagnosticException(
-                    category = PluginResolverErrorCategory.ROOT_ARTIFACT_MISSING,
-                    message =
-                    "Plugin '${coordinate.value}' resolved but no root jar was produced in cache at " +
-                        "'$expectedRootArtifactPath'.",
-                )
+            resolveRootArtifactPath(
+                coordinate = coordinate,
+                expectedRootArtifactPath = expectedRootArtifactPath,
+                artifactResults = dependencyResult.artifactResults,
+                classpath = classpath,
+            )
 
         return ResolvedRemotePlugin(rootArtifactPath = rootArtifactPath, classpath = classpath)
+    }
+}
+
+private fun ensureOfflineRootAvailability(coordinate: Coordinate, expectedRootArtifactPath: Path, offline: Boolean) {
+    if (!offline || Files.exists(expectedRootArtifactPath)) {
+        return
+    }
+
+    throw PluginResolutionDiagnosticException(
+        category = PluginResolverErrorCategory.OFFLINE_CACHE_MISS,
+        message =
+        "Offline mode is enabled and plugin '${coordinate.value}' is not in cache at " +
+            "'$expectedRootArtifactPath'. Run once without --offline to populate the cache.",
+    )
+}
+
+private fun resolveDependencyGraph(
+    repositorySystem: RepositorySystem,
+    coordinate: Coordinate,
+    repositories: List<String>,
+    localRepositoryRoot: Path,
+    offline: Boolean,
+): DependencyResult {
+    val session =
+        buildSession(
+            repositorySystem = repositorySystem,
+            localRepositoryRoot = localRepositoryRoot,
+            offline = offline,
+        )
+
+    val remoteRepositories = repositories.mapIndexed(::toRemoteRepository)
+    val dependencyRequest =
+        DependencyRequest(
+            CollectRequest(
+                Dependency(DefaultArtifact(coordinate.value), JavaScopes.RUNTIME),
+                remoteRepositories,
+            ),
+            null,
+        )
+
+    return try {
+        repositorySystem.resolveDependencies(session, dependencyRequest)
+    } catch (error: DependencyResolutionException) {
+        throw toDiagnostic(coordinate, localRepositoryRoot, repositories, offline, error)
     }
 }
 
@@ -120,13 +149,10 @@ private fun buildSession(
 }
 
 private fun toRemoteRepository(index: Int, repository: String): RemoteRepository = RemoteRepository
-    .Builder("repo-$index", "default", repository)
+    .Builder("$REMOTE_REPOSITORY_ID_PREFIX-$index", REMOTE_REPOSITORY_TYPE_DEFAULT, repository)
     .build()
 
-private fun resolveClasspath(
-    artifactResults: List<ArtifactResult>,
-    root: org.eclipse.aether.graph.DependencyNode?,
-): List<Path> {
+private fun resolveClasspath(artifactResults: List<ArtifactResult>, root: DependencyNode?): List<Path> {
     val visitor = PreorderNodeListGenerator()
     root?.accept(visitor)
     val visited = visitor.files.map { file -> file.toPath().toAbsolutePath().normalize() }
@@ -137,6 +163,31 @@ private fun resolveClasspath(
     return (visited + fallback).distinct()
 }
 
+private fun resolveRootArtifactPath(
+    coordinate: Coordinate,
+    expectedRootArtifactPath: Path,
+    artifactResults: List<ArtifactResult>,
+    classpath: List<Path>,
+): Path = expectedRootArtifactPath.takeIf(Files::exists)
+    ?: artifactResults
+        .asSequence()
+        .mapNotNull { result -> result.artifact }
+        .firstOrNull { artifact -> artifact.matchesCoordinate(coordinate) }
+        ?.file
+        ?.toPath()
+        ?.toAbsolutePath()
+        ?.normalize()
+    ?: classpath.firstOrNull()
+    ?: throw PluginResolutionDiagnosticException(
+        category = PluginResolverErrorCategory.ROOT_ARTIFACT_MISSING,
+        message =
+        "Plugin '${coordinate.value}' resolved but no root jar was produced in cache at " +
+            "'$expectedRootArtifactPath'.",
+    )
+
+private fun Artifact.matchesCoordinate(coordinate: Coordinate): Boolean =
+    groupId == coordinate.group && artifactId == coordinate.artifact && version == coordinate.version
+
 private fun toDiagnostic(
     coordinate: Coordinate,
     localRepositoryRoot: Path,
@@ -144,7 +195,7 @@ private fun toDiagnostic(
     offline: Boolean,
     error: DependencyResolutionException,
 ): PluginResolutionDiagnosticException {
-    val cause: Throwable? = error.result.collectExceptions.firstOrNull() ?: error.cause
+    val cause: Throwable? = error.primaryResolutionCause()
     val repositoryList = repositories.joinToString(", ")
     val reason =
         when (cause) {
@@ -170,3 +221,10 @@ private fun toDiagnostic(
         cause = error,
     )
 }
+
+private fun DependencyResolutionException.primaryResolutionCause(): Throwable? = result.collectExceptions.firstOrNull()
+    ?: result.artifactResults
+        .asSequence()
+        .flatMap { artifactResult -> artifactResult.exceptions.asSequence() }
+        .firstOrNull()
+    ?: cause

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
@@ -1,18 +1,7 @@
 package me.liam.microsmith.cli.plugins
 
 import me.liam.microsmith.cli.command.RunCommand
-import java.io.IOException
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-import kotlin.io.path.name
-
-private const val HTTP_STATUS_OK = 200
-private val HTTP_CLIENT: HttpClient = HttpClient.newHttpClient()
 
 internal fun resolveRepositories(command: RunCommand, settings: PluginResolverSettings): List<String> =
     resolveRepositories(command, settings, settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy())
@@ -23,50 +12,17 @@ internal fun resolveRepositories(
     repositoryPolicy: RepositoryAllowlistPolicy,
 ): List<String> {
     val override = command.repositoryOverride?.trim()?.takeIf { it.isNotEmpty() }
-    val repositories = (listOfNotNull(override) + settings.defaultRepositories).distinct()
+    val repositories = (listOfNotNull(override) + settings.defaultRepositories).map(::normalizeRepositoryUri).distinct()
     repositories.forEach(repositoryPolicy::validate)
     return repositories
 }
 
-internal fun resolveRemoteArtifact(
-    coordinate: Coordinate,
-    repositories: List<String>,
-    cacheDirectory: Path,
-    offline: Boolean,
-): Path {
-    val cachePath = cachePathFor(cacheDirectory, coordinate)
-    if (Files.exists(cachePath)) {
-        return cachePath
-    }
+internal fun pluginArtifactCacheRoot(cacheDirectory: Path): Path = cacheDirectory
+    .resolve("artifacts")
+    .toAbsolutePath()
+    .normalize()
 
-    require(!offline) {
-        "Offline mode is enabled and plugin '${coordinate.value}' is not in cache at '$cachePath'. " +
-            "Run once without --offline to populate the cache."
-    }
-
-    val attemptedUris = mutableListOf<String>()
-    repositories.forEach { repository ->
-        val artifactUri = repositoryArtifactUri(repository, coordinate.relativeJarPath)
-        attemptedUris += artifactUri
-        val downloaded =
-            runCatching {
-                downloadArtifact(artifactUri, cachePath)
-            }.getOrElse { error ->
-                if (error is InterruptedException) {
-                    Thread.currentThread().interrupt()
-                }
-                false
-            }
-        if (downloaded) {
-            return cachePath
-        }
-    }
-
-    error("Could not resolve plugin '${coordinate.value}'. Tried: ${attemptedUris.joinToString(", ")}.")
-}
-
-private fun cachePathFor(cacheDirectory: Path, coordinate: Coordinate): Path {
-    val cacheRoot = cacheDirectory.resolve("artifacts").toAbsolutePath().normalize()
+internal fun cachePathFor(cacheRoot: Path, coordinate: Coordinate): Path {
     val artifactPath =
         cacheRoot
             .resolve(coordinate.group.replace('.', '/'))
@@ -78,61 +34,4 @@ private fun cachePathFor(cacheDirectory: Path, coordinate: Coordinate): Path {
         "Plugin coordinate '${coordinate.value}' resolves outside plugin cache directory."
     }
     return artifactPath
-}
-
-private fun repositoryArtifactUri(repository: String, relativePath: String): String =
-    "${repository.trimEnd('/')}/$relativePath"
-
-private fun downloadArtifact(artifactUri: String, destination: Path): Boolean {
-    val uri = URI.create(artifactUri)
-    return when (uri.scheme?.lowercase()) {
-        "file" -> copyFileRepositoryArtifact(uri, destination)
-        "http", "https" -> copyHttpRepositoryArtifact(uri, destination)
-        else -> false
-    }
-}
-
-private fun copyFileRepositoryArtifact(artifactUri: URI, destination: Path): Boolean {
-    val source = Path.of(artifactUri)
-    if (!Files.exists(source) || !Files.isRegularFile(source)) {
-        return false
-    }
-
-    copyArtifactToCache(source, destination)
-    return true
-}
-
-private fun copyHttpRepositoryArtifact(artifactUri: URI, destination: Path): Boolean {
-    val response: HttpResponse<ByteArray>? =
-        try {
-            val request = HttpRequest.newBuilder(artifactUri).GET().build()
-            HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofByteArray())
-        } catch (_: IOException) {
-            null
-        } catch (_: InterruptedException) {
-            Thread.currentThread().interrupt()
-            null
-        }
-
-    val downloaded =
-        if (response == null || response.statusCode() != HTTP_STATUS_OK) {
-            false
-        } else {
-            Files.createDirectories(destination.parent)
-            val tempPath = destination.resolveSibling("${destination.name}.part")
-            Files.write(tempPath, response.body())
-            Files.move(tempPath, destination, StandardCopyOption.REPLACE_EXISTING)
-            true
-        }
-
-    if (!downloaded) {
-        val tempPath = destination.resolveSibling("${destination.name}.part")
-        Files.deleteIfExists(tempPath)
-    }
-    return downloaded
-}
-
-private fun copyArtifactToCache(source: Path, destination: Path) {
-    Files.createDirectories(destination.parent)
-    Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING)
 }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
@@ -12,7 +12,10 @@ internal fun resolveRepositories(
     repositoryPolicy: RepositoryAllowlistPolicy,
 ): List<String> {
     val override = command.repositoryOverride?.trim()?.takeIf { it.isNotEmpty() }
-    val repositories = (listOfNotNull(override) + settings.defaultRepositories).map(::normalizeRepositoryUri).distinct()
+    val repositories =
+        (listOfNotNull(override) + settings.defaultRepositories)
+            .map(::normalizeRepositoryUri)
+            .distinct()
     repositories.forEach(repositoryPolicy::validate)
     return repositories
 }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -120,7 +120,9 @@ private fun resolveLocalPluginJars(pluginJars: Set<Path>): List<LocalPluginJar> 
     }.sortedBy(LocalPluginJar::lockKey)
 
 private fun Throwable.toResolutionDiagnostic(): String = when (this) {
-    is PluginResolutionDiagnosticException -> "[${category.code}] $message"
+    is PluginResolutionDiagnosticException ->
+        "[${category.code}] ${message ?: "plugin resolution failed"}"
+
     else -> "[unexpected] ${message ?: this::class.simpleName ?: "unknown plugin resolution error"}"
 }
 

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -24,14 +24,10 @@ internal fun resolvePlugins(
     settings: PluginResolverSettings = PluginResolverSettings(),
 ): PluginResolutionResult = runCatching {
     resolvePluginsOrThrow(command, settings)
-}.getOrElse { error ->
-    val message =
-        when (error) {
-            is PluginResolutionDiagnosticException -> "[${error.category.code}] ${error.message}"
-            else -> "[unexpected] ${error.message ?: error::class.simpleName ?: "unknown plugin resolution error"}"
-        }
-    PluginResolutionResult.Failure(listOf(message))
-}
+}.fold(
+    onSuccess = { success -> success },
+    onFailure = { error -> PluginResolutionResult.Failure(listOf(error.toResolutionDiagnostic())) },
+)
 
 private fun resolvePluginsOrThrow(
     command: RunCommand,
@@ -42,14 +38,7 @@ private fun resolvePluginsOrThrow(
     }
 
     val coordinates = command.plugins.toList().sorted().map(::parseCoordinate)
-    val localPluginJars =
-        command.pluginJars
-            .map { requestedPath ->
-                LocalPluginJar(
-                    artifactPath = requestedPath.toAbsolutePath().normalize(),
-                    lockKey = localPluginLockKey(requestedPath),
-                )
-            }.sortedBy(LocalPluginJar::lockKey)
+    val localPluginJars = resolveLocalPluginJars(command.pluginJars)
     localPluginJars.forEach { localJar ->
         require(Files.exists(localJar.artifactPath) && Files.isRegularFile(localJar.artifactPath)) {
             "Plugin jar '${localJar.artifactPath}' does not exist or is not a file."
@@ -112,8 +101,8 @@ private fun resolvePluginsOrThrow(
 }
 
 private fun buildRequestedLockKeys(coordinates: List<Coordinate>, localPluginLockKeys: List<String>): Set<LockKey> {
-    val remoteKeys = coordinates.map { LockKey(kind = REMOTE_KIND, key = it.value) }
-    val localKeys = localPluginLockKeys.map { LockKey(kind = LOCAL_KIND, key = it) }
+    val remoteKeys = coordinates.map { coordinate -> LockKey(kind = REMOTE_KIND, key = coordinate.value) }
+    val localKeys = localPluginLockKeys.map { lockKey -> LockKey(kind = LOCAL_KIND, key = lockKey) }
     return (remoteKeys + localKeys).toSet()
 }
 
@@ -121,6 +110,19 @@ private fun localPluginLockKey(pluginJarPath: Path): String = pluginJarPath
     .normalize()
     .toString()
     .replace('\\', '/')
+
+private fun resolveLocalPluginJars(pluginJars: Set<Path>): List<LocalPluginJar> = pluginJars
+    .map { requestedPath ->
+        LocalPluginJar(
+            artifactPath = requestedPath.toAbsolutePath().normalize(),
+            lockKey = localPluginLockKey(requestedPath),
+        )
+    }.sortedBy(LocalPluginJar::lockKey)
+
+private fun Throwable.toResolutionDiagnostic(): String = when (this) {
+    is PluginResolutionDiagnosticException -> "[${category.code}] $message"
+    else -> "[unexpected] ${message ?: this::class.simpleName ?: "unknown plugin resolution error"}"
+}
 
 private fun normalizeClasspath(rawClasspath: List<Path>): List<Path> = rawClasspath
     .map { it.toAbsolutePath().normalize() }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -16,6 +16,7 @@ internal data class PluginResolverSettings(
     val defaultRepositories: List<String> = listOf(MAVEN_CENTRAL_REPOSITORY),
     val repositoryPolicy: RepositoryAllowlistPolicy? = null,
     val checksumAllowlist: PluginChecksumAllowlist? = null,
+    val remotePluginResolver: RemotePluginResolver = MavenRemotePluginResolver(),
 )
 
 internal fun resolvePlugins(
@@ -24,7 +25,11 @@ internal fun resolvePlugins(
 ): PluginResolutionResult = runCatching {
     resolvePluginsOrThrow(command, settings)
 }.getOrElse { error ->
-    val message = error.message ?: error::class.simpleName ?: "unknown plugin resolution error"
+    val message =
+        when (error) {
+            is PluginResolutionDiagnosticException -> "[${error.category.code}] ${error.message}"
+            else -> "[unexpected] ${error.message ?: error::class.simpleName ?: "unknown plugin resolution error"}"
+        }
     PluginResolutionResult.Failure(listOf(message))
 }
 
@@ -67,12 +72,18 @@ private fun resolvePluginsOrThrow(
     val lockEntries = mutableListOf<LockEntry>()
 
     coordinates.forEach { coordinate ->
-        val artifactPath = resolveRemoteArtifact(coordinate, repositories, cacheDirectory, command.offline)
-        val checksum = sha256(artifactPath)
+        val resolvedRemotePlugin =
+            settings.remotePluginResolver.resolve(
+                coordinate = coordinate,
+                repositories = repositories,
+                cacheDirectory = cacheDirectory,
+                offline = command.offline,
+            )
+        val checksum = sha256(resolvedRemotePlugin.rootArtifactPath)
         lockfile?.verifyChecksum(REMOTE_KIND, coordinate.value, checksum)
         checksumAllowlist?.verifyChecksum(REMOTE_KIND, coordinate.value, checksum)
         lockEntries.add(LockEntry(kind = REMOTE_KIND, key = coordinate.value, checksum = checksum))
-        classpath.add(artifactPath)
+        classpath.addAll(resolvedRemotePlugin.classpath)
     }
 
     localPluginJars.forEach { localJar ->
@@ -95,7 +106,7 @@ private fun resolvePluginsOrThrow(
     }
 
     return PluginResolutionResult.Success(
-        classpath = classpath.distinct(),
+        classpath = normalizeClasspath(classpath),
         lockfilePath = lockfilePath,
     )
 }
@@ -110,5 +121,9 @@ private fun localPluginLockKey(pluginJarPath: Path): String = pluginJarPath
     .normalize()
     .toString()
     .replace('\\', '/')
+
+private fun normalizeClasspath(rawClasspath: List<Path>): List<Path> = rawClasspath
+    .map { it.toAbsolutePath().normalize() }
+    .distinct()
 
 private data class LocalPluginJar(val artifactPath: Path, val lockKey: String)

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
@@ -99,6 +99,62 @@ class PluginResolverTests :
             }
         }
 
+        "excludes test and provided transitive dependencies from runtime classpath" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-runtime-scope")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val rootCoordinate = "com.acme:plugin-root:1.0.0"
+                val runtimeCoordinate = "com.acme:runtime-dep:2.0.0"
+                val testCoordinate = "com.acme:test-dep:2.0.0"
+                val providedCoordinate = "com.acme:provided-dep:2.0.0"
+
+                publishMavenArtifact(repositoryRoot, runtimeCoordinate)
+                publishMavenArtifact(repositoryRoot, testCoordinate)
+                publishMavenArtifact(repositoryRoot, providedCoordinate)
+                publishMavenArtifact(
+                    repositoryRoot = repositoryRoot,
+                    coordinate = rootCoordinate,
+                    dependencies = listOf(runtimeCoordinate, testCoordinate, providedCoordinate),
+                    dependencyScopes =
+                    mapOf(
+                        testCoordinate to "test",
+                        providedCoordinate to "provided",
+                    ),
+                )
+                script.writeText("// test script")
+
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(rootCoordinate),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+
+                val result =
+                    resolvePlugins(
+                        command = command,
+                        settings =
+                        PluginResolverSettings(
+                            cacheDirectory = cache,
+                            repositoryPolicy = fileRepositoryAllowedPolicy(),
+                        ),
+                    )
+
+                val success = result.shouldBeTypeOf<PluginResolutionResult.Success>()
+                val classpathNames = success.classpath.map { path -> path.fileName.toString() }.toSet()
+                classpathNames shouldBe
+                    setOf(
+                        "plugin-root-1.0.0.jar",
+                        "runtime-dep-2.0.0.jar",
+                    )
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
         "deduplicates shared transitive dependencies deterministically" {
             val tempDir = createTempDirectory("microsmith-plugin-resolver-deterministic")
             try {
@@ -598,6 +654,7 @@ private fun publishMavenArtifact(
     repositoryRoot: Path,
     coordinate: String,
     dependencies: List<String> = emptyList(),
+    dependencyScopes: Map<String, String> = emptyMap(),
     jarContents: ByteArray = "plugin-jar-contents".toByteArray(),
 ) {
     val parsed = parseCoordinate(coordinate)
@@ -619,11 +676,18 @@ private fun publishMavenArtifact(
                 postfix = "\n</dependencies>",
             ) { dependency ->
                 val dep = parseCoordinate(dependency)
+                val scopeXml =
+                    dependencyScopes[dependency]
+                        ?.trim()
+                        ?.takeIf(String::isNotEmpty)
+                        ?.let { scope -> "\n  <scope>$scope</scope>" }
+                        .orEmpty()
                 """
                 <dependency>
                   <groupId>${dep.group}</groupId>
                   <artifactId>${dep.artifact}</artifactId>
                   <version>${dep.version}</version>
+                  $scopeXml
                 </dependency>
                 """.trimIndent()
             }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
@@ -1,6 +1,7 @@
 package me.liam.microsmith.cli.plugins
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -8,6 +9,7 @@ import io.kotest.matchers.types.shouldBeTypeOf
 import me.liam.microsmith.cli.command.RunCommand
 import java.nio.file.Path
 import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteRecursively
 import kotlin.io.path.exists
@@ -26,12 +28,7 @@ class PluginResolverTests :
                 val cache = tempDir.resolve("cache")
                 val repositoryRoot = tempDir.resolve("repo")
                 val coordinate = "com.acme:microsmith-emitter-ts:1.4.2"
-                val repositoryJar =
-                    repositoryRoot.resolve(
-                        "com/acme/microsmith-emitter-ts/1.4.2/microsmith-emitter-ts-1.4.2.jar",
-                    )
-                repositoryJar.parent?.toFile()?.mkdirs()
-                repositoryJar.writeBytes("plugin-jar-contents".toByteArray())
+                publishMavenArtifact(repositoryRoot, coordinate)
                 script.writeText("// test script")
 
                 val command =
@@ -63,6 +60,96 @@ class PluginResolverTests :
             }
         }
 
+        "resolves transitive dependencies for plugin coordinates" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-transitive")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val rootCoordinate = "com.acme:plugin-root:1.0.0"
+                val transitiveCoordinate = "com.acme:plugin-shared:2.1.0"
+                publishMavenArtifact(repositoryRoot, transitiveCoordinate)
+                publishMavenArtifact(repositoryRoot, rootCoordinate, dependencies = listOf(transitiveCoordinate))
+                script.writeText("// test script")
+
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(rootCoordinate),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+
+                val result =
+                    resolvePlugins(
+                        command = command,
+                        settings =
+                        PluginResolverSettings(
+                            cacheDirectory = cache,
+                            repositoryPolicy = fileRepositoryAllowedPolicy(),
+                        ),
+                    )
+
+                val success = result.shouldBeTypeOf<PluginResolutionResult.Success>()
+                success.classpath.shouldHaveSize(2)
+                success.classpath.map { path -> path.fileName.toString() }.toSet() shouldBe
+                    setOf("plugin-root-1.0.0.jar", "plugin-shared-2.1.0.jar")
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "deduplicates shared transitive dependencies deterministically" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-deterministic")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val coordinateA = "com.acme:plugin-a:1.0.0"
+                val coordinateB = "com.acme:plugin-b:1.0.0"
+                val shared = "com.acme:plugin-shared:1.1.0"
+
+                publishMavenArtifact(repositoryRoot, shared)
+                publishMavenArtifact(repositoryRoot, coordinateA, dependencies = listOf(shared))
+                publishMavenArtifact(repositoryRoot, coordinateB, dependencies = listOf(shared))
+                script.writeText("// test script")
+
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(coordinateA, coordinateB),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = cache,
+                        repositoryPolicy = fileRepositoryAllowedPolicy(),
+                    )
+
+                val first =
+                    resolvePlugins(command = command, settings = settings)
+                        .shouldBeTypeOf<PluginResolutionResult.Success>()
+                val second =
+                    resolvePlugins(command = command, settings = settings)
+                        .shouldBeTypeOf<PluginResolutionResult.Success>()
+
+                val firstNames = first.classpath.map { path -> path.fileName.toString() }
+                val secondNames = second.classpath.map { path -> path.fileName.toString() }
+                firstNames shouldContainExactly secondNames
+                firstNames.toSet() shouldBe
+                    setOf(
+                        "plugin-a-1.0.0.jar",
+                        "plugin-b-1.0.0.jar",
+                        "plugin-shared-1.1.0.jar",
+                    )
+                firstNames.size shouldBe 3
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
         "fails with remediation message when offline plugin artifact is missing from cache" {
             val tempDir = createTempDirectory("microsmith-plugin-resolver-offline")
             try {
@@ -83,7 +170,47 @@ class PluginResolverTests :
                     )
 
                 val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
+                failure.diagnostics.joinToString("\n").shouldContain("[offline-cache-miss]")
                 failure.diagnostics.joinToString("\n").shouldContain("Offline mode is enabled")
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "fails with categorized diagnostics when transitive dependency cannot be resolved" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-transitive-failure")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val coordinate = "com.acme:plugin-root:1.0.0"
+                val missing = "com.acme:missing-transitive:9.9.9"
+                publishMavenArtifact(repositoryRoot, coordinate, dependencies = listOf(missing))
+                script.writeText("// test script")
+
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(coordinate),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+
+                val result =
+                    resolvePlugins(
+                        command = command,
+                        settings =
+                        PluginResolverSettings(
+                            cacheDirectory = cache,
+                            repositoryPolicy = fileRepositoryAllowedPolicy(),
+                        ),
+                    )
+
+                val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
+                val message = failure.diagnostics.joinToString("\n")
+                message.shouldContain("[dependency-resolution]")
+                message.shouldContain("Could not resolve plugin 'com.acme:plugin-root:1.0.0'")
+                message.shouldContain("Verify plugin coordinates and repository availability")
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }
@@ -97,10 +224,7 @@ class PluginResolverTests :
                 val cache = tempDir.resolve("cache")
                 val repositoryRoot = tempDir.resolve("repo")
                 val coordinate = "com.acme:lock-test:1.0.0"
-                val repositoryJar =
-                    repositoryRoot.resolve("com/acme/lock-test/1.0.0/lock-test-1.0.0.jar")
-                repositoryJar.parent?.toFile()?.mkdirs()
-                repositoryJar.writeBytes("initial".toByteArray())
+                publishMavenArtifact(repositoryRoot, coordinate, jarContents = "initial".toByteArray())
                 script.writeText("// test script")
 
                 val command =
@@ -120,8 +244,7 @@ class PluginResolverTests :
                     ),
                 )
 
-                val cachedArtifact =
-                    cache.resolve("artifacts/com/acme/lock-test/1.0.0/lock-test-1.0.0.jar")
+                val cachedArtifact = cachePathFor(pluginArtifactCacheRoot(cache), parseCoordinate(coordinate))
                 cachedArtifact.writeBytes("tampered".toByteArray())
 
                 val mismatch =
@@ -149,10 +272,7 @@ class PluginResolverTests :
                 val cache = tempDir.resolve("cache")
                 val repositoryRoot = tempDir.resolve("repo")
                 val coordinate = "com.acme:fallback-test:1.0.0"
-                val repositoryJar =
-                    repositoryRoot.resolve("com/acme/fallback-test/1.0.0/fallback-test-1.0.0.jar")
-                repositoryJar.parent?.toFile()?.mkdirs()
-                repositoryJar.writeBytes("fallback-jar".toByteArray())
+                publishMavenArtifact(repositoryRoot, coordinate)
                 script.writeText("// test script")
 
                 val command =
@@ -359,10 +479,7 @@ class PluginResolverTests :
                 val cache = tempDir.resolve("cache")
                 val repositoryRoot = tempDir.resolve("repo")
                 val coordinate = "com.acme:file-blocked:1.0.0"
-                val repositoryJar =
-                    repositoryRoot.resolve("com/acme/file-blocked/1.0.0/file-blocked-1.0.0.jar")
-                repositoryJar.parent?.toFile()?.mkdirs()
-                repositoryJar.writeBytes("plugin-jar-contents".toByteArray())
+                publishMavenArtifact(repositoryRoot, coordinate)
                 script.writeText("// test script")
 
                 val command =
@@ -476,3 +593,56 @@ private fun fileRepositoryAllowedPolicy(vararg additionalAllowedRepositories: St
             .toSet(),
         allowFileRepositories = true,
     )
+
+private fun publishMavenArtifact(
+    repositoryRoot: Path,
+    coordinate: String,
+    dependencies: List<String> = emptyList(),
+    jarContents: ByteArray = "plugin-jar-contents".toByteArray(),
+) {
+    val parsed = parseCoordinate(coordinate)
+    val base =
+        repositoryRoot
+            .resolve(parsed.group.replace('.', '/'))
+            .resolve(parsed.artifact)
+            .resolve(parsed.version)
+    base.createDirectories()
+
+    val pomPath = base.resolve("${parsed.artifact}-${parsed.version}.pom")
+    val dependenciesBlock =
+        if (dependencies.isEmpty()) {
+            ""
+        } else {
+            dependencies.joinToString(
+                separator = "\n",
+                prefix = "<dependencies>\n",
+                postfix = "\n</dependencies>",
+            ) { dependency ->
+                val dep = parseCoordinate(dependency)
+                """
+                <dependency>
+                  <groupId>${dep.group}</groupId>
+                  <artifactId>${dep.artifact}</artifactId>
+                  <version>${dep.version}</version>
+                </dependency>
+                """.trimIndent()
+            }
+        }
+    val pomXml =
+        """
+        <project xmlns="http://maven.apache.org/POM/4.0.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>${parsed.group}</groupId>
+          <artifactId>${parsed.artifact}</artifactId>
+          <version>${parsed.version}</version>
+          <packaging>jar</packaging>
+          $dependenciesBlock
+        </project>
+        """.trimIndent()
+    pomPath.writeText(pomXml)
+
+    val jarPath = base.resolve("${parsed.artifact}-${parsed.version}.jar")
+    jarPath.writeBytes(jarContents)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.2.21"
 kotest = "6.0.1"
 coroutines = "1.10.2"
 spiTooling = "0.1.22"
+mavenResolver = "1.9.22"
 
 [libraries]
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
@@ -13,5 +14,13 @@ coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ve
 kotlin-scripting-common = { module = "org.jetbrains.kotlin:kotlin-scripting-common", version.ref = "kotlin" }
 kotlin-scripting-jvm = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm", version.ref = "kotlin" }
 kotlin-scripting-jvm-host = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm-host", version.ref = "kotlin" }
+maven-resolver-api = { module = "org.apache.maven.resolver:maven-resolver-api", version.ref = "mavenResolver" }
+maven-resolver-spi = { module = "org.apache.maven.resolver:maven-resolver-spi", version.ref = "mavenResolver" }
+maven-resolver-util = { module = "org.apache.maven.resolver:maven-resolver-util", version.ref = "mavenResolver" }
+maven-resolver-impl = { module = "org.apache.maven.resolver:maven-resolver-impl", version.ref = "mavenResolver" }
+maven-resolver-supplier = { module = "org.apache.maven.resolver:maven-resolver-supplier", version.ref = "mavenResolver" }
+maven-resolver-connector-basic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "mavenResolver" }
+maven-resolver-transport-file = { module = "org.apache.maven.resolver:maven-resolver-transport-file", version.ref = "mavenResolver" }
+maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "mavenResolver" }
 spi-tooling-annotations = { module = "io.github.eventhorizonlab:spi-tooling-annotations", version.ref = "spiTooling" }
 spi-tooling-processor = { module = "io.github.eventhorizonlab:spi-tooling-processor", version.ref = "spiTooling" }


### PR DESCRIPTION
## Summary
This PR implements issue #44 by replacing direct artifact download logic with a Maven Resolver-backed transitive plugin resolver for external `--plugin` coordinates.

## What Changed
- Added a resolver abstraction boundary in the CLI plugin pipeline:
  - `RemotePluginResolver`
  - `MavenRemotePluginResolver`
- Integrated Maven Resolver (Aether) into runtime coordinate resolution:
  - resolves full transitive dependency graphs for each external plugin coordinate
  - reuses the existing plugin cache root under `.../artifacts`
- Preserved existing runtime contract for local `--plugin-jar` workflows.
- Added deterministic classpath normalization/deduplication in resolver output.
- Added categorized/actionable diagnostics for resolver failures:
  - `offline-cache-miss`
  - `dependency-resolution`
  - `root-artifact-missing`
- Refactored repository utility layer:
  - kept repository allowlist/policy behavior
  - normalized repository URIs before dedupe/validation
- Added Maven Resolver dependencies to the CLI module and version catalog.

## Tests
- Updated resolver tests to publish realistic local Maven fixtures (`.pom` + `.jar`) instead of direct jar-only artifacts.
- Added coverage for:
  - transitive dependency resolution
  - deterministic classpath output with shared-transitive dedupe
  - categorized diagnostics on transitive resolution failures
- Revalidated existing lockfile, allowlist, offline, and policy behavior.

Commands run:
- `./gradlew :cli:kotest --stacktrace`
- `./gradlew :cli:check --stacktrace`

## Scope Boundaries
- Does not implement authenticated repository credentials/policies beyond current behavior (handled in #45).
- Does not implement graph-wide lockfile v2/offline completeness semantics (handled in #47).

Closes #44
