### PR TITLE
feat(runtime-auth): add authenticated private registry credentials and redacted diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ microsmith run schema.microsmith.kts --out ./generated --isolation process
   - Built-in allowlist: `https://repo1.maven.org/maven2`
   - Additional allowed endpoints via `MICROSMITH_REPOSITORY_ALLOWLIST` (comma-separated base URIs)
   - `file://` repositories are denied by default and can be explicitly enabled with `MICROSMITH_ALLOW_FILE_REPOSITORIES=true`.
+- Private repository credentials are optional and resolved with deterministic precedence:
+  - Per-endpoint credentials file via `MICROSMITH_REPOSITORY_CREDENTIALS_FILE` with entries:
+    - `<repository-uri>|<username>|<password>`
+  - GitHub Packages credentials for `https://maven.pkg.github.com` via
+    `MICROSMITH_GITHUB_PACKAGES_USER` + `MICROSMITH_GITHUB_PACKAGES_TOKEN`
+    (fallbacks: `GITHUB_ACTOR` + `GITHUB_TOKEN`)
+  - Global default credentials via `MICROSMITH_REPOSITORY_USERNAME` + `MICROSMITH_REPOSITORY_PASSWORD`
+  - Sensitive values are redacted in resolver diagnostics.
 - Plugin artifacts are SHA-256 checked against the script lockfile when present.
 - Optional plugin checksum allowlist can be enforced with `MICROSMITH_PLUGIN_ALLOWLIST_FILE`:
   - Entry format: `<kind>|<key>|<sha256>` where `kind` is `remote` or `local`.

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
@@ -14,6 +14,11 @@ Usage:
 Security policy env vars:
   MICROSMITH_REPOSITORY_ALLOWLIST   Comma-separated additional allowed repository base URIs.
   MICROSMITH_ALLOW_FILE_REPOSITORIES Set to true to allow file:// repositories for plugin coordinates.
+  MICROSMITH_REPOSITORY_CREDENTIALS_FILE Path to repository credentials file (<repository-uri>|<username>|<password>).
+  MICROSMITH_REPOSITORY_USERNAME    Default username for authenticated repository access.
+  MICROSMITH_REPOSITORY_PASSWORD    Default password/token for authenticated repository access.
+  MICROSMITH_GITHUB_PACKAGES_USER   Username for https://maven.pkg.github.com access.
+  MICROSMITH_GITHUB_PACKAGES_TOKEN  Token for https://maven.pkg.github.com access.
   MICROSMITH_PLUGIN_ALLOWLIST_FILE  Path to checksum allowlist file (<kind>|<key>|<sha256>).
   MICROSMITH_SCRIPT_CACHE_DIR       Override script compilation cache directory.
   MICROSMITH_PLUGIN_CACHE_DIR       Override plugin resolution cache directory.

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
@@ -134,7 +134,20 @@ internal class MicrosmithCli(
             return PreparedRun.Failure(CliFailureCode.PROVIDER_VALIDATION_FAILED)
         }
 
-        return when (val resolvedPlugins = pluginResolver(command)) {
+        val resolvedPlugins =
+            runCatching {
+                pluginResolver(command)
+            }.getOrElse { error ->
+                context.resolverStatus = RUN_STATUS_FAILURE
+                emitter.error(
+                    CliFailureCode.PLUGIN_RESOLUTION_FAILED,
+                    "[unexpected] Plugin resolution failed unexpectedly.",
+                    details = mapOf("exceptionType" to (error::class.simpleName ?: "unknown")),
+                )
+                return PreparedRun.Failure(CliFailureCode.PLUGIN_RESOLUTION_FAILED)
+            }
+
+        return when (resolvedPlugins) {
             is PluginResolutionResult.Failure -> {
                 context.resolverStatus = RUN_STATUS_FAILURE
                 resolvedPlugins.diagnostics.forEach { diagnostic ->

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -19,6 +19,7 @@ import org.eclipse.aether.transfer.ArtifactNotFoundException
 import org.eclipse.aether.util.artifact.JavaScopes
 import org.eclipse.aether.util.filter.DependencyFilterUtils
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
+import org.eclipse.aether.util.repository.AuthenticationBuilder
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -28,7 +29,7 @@ private const val REMOTE_REPOSITORY_TYPE_DEFAULT = "default"
 internal interface RemotePluginResolver {
     fun resolve(
         coordinate: Coordinate,
-        repositories: List<String>,
+        repositories: List<RepositoryEndpoint>,
         cacheDirectory: Path,
         offline: Boolean,
     ): ResolvedRemotePlugin
@@ -38,7 +39,9 @@ internal data class ResolvedRemotePlugin(val rootArtifactPath: Path, val classpa
 
 internal enum class PluginResolverErrorCategory(val code: String) {
     OFFLINE_CACHE_MISS("offline-cache-miss"),
+    AUTHENTICATION("authentication"),
     DEPENDENCY_RESOLUTION("dependency-resolution"),
+    REPOSITORY_POLICY("repository-policy"),
     ROOT_ARTIFACT_MISSING("root-artifact-missing"),
 }
 
@@ -53,7 +56,7 @@ internal class MavenRemotePluginResolver(
 ) : RemotePluginResolver {
     override fun resolve(
         coordinate: Coordinate,
-        repositories: List<String>,
+        repositories: List<RepositoryEndpoint>,
         cacheDirectory: Path,
         offline: Boolean,
     ): ResolvedRemotePlugin {
@@ -106,7 +109,7 @@ private fun ensureOfflineRootAvailability(coordinate: Coordinate, expectedRootAr
 private fun resolveDependencyGraph(
     repositorySystem: RepositorySystem,
     coordinate: Coordinate,
-    repositories: List<String>,
+    repositories: List<RepositoryEndpoint>,
     localRepositoryRoot: Path,
     offline: Boolean,
 ): DependencyResult {
@@ -131,7 +134,13 @@ private fun resolveDependencyGraph(
     return try {
         repositorySystem.resolveDependencies(session, dependencyRequest)
     } catch (error: DependencyResolutionException) {
-        throw toDiagnostic(coordinate, localRepositoryRoot, repositories, offline, error)
+        throw toDiagnostic(
+            coordinate = coordinate,
+            localRepositoryRoot = localRepositoryRoot,
+            repositories = repositories.map(RepositoryEndpoint::uri),
+            offline = offline,
+            error = error,
+        )
     }
 }
 
@@ -149,9 +158,22 @@ private fun buildSession(
     return sessionBuilder
 }
 
-private fun toRemoteRepository(index: Int, repository: String): RemoteRepository = RemoteRepository
-    .Builder("$REMOTE_REPOSITORY_ID_PREFIX-$index", REMOTE_REPOSITORY_TYPE_DEFAULT, repository)
-    .build()
+private fun toRemoteRepository(index: Int, repository: RepositoryEndpoint): RemoteRepository {
+    val builder = RemoteRepository.Builder(
+        "$REMOTE_REPOSITORY_ID_PREFIX-$index",
+        REMOTE_REPOSITORY_TYPE_DEFAULT,
+        repository.uri,
+    )
+    repository.credentials?.let { credentials ->
+        builder.setAuthentication(
+            AuthenticationBuilder()
+                .addUsername(credentials.username)
+                .addPassword(credentials.password)
+                .build(),
+        )
+    }
+    return builder.build()
+}
 
 private fun resolveClasspath(artifactResults: List<ArtifactResult>, root: DependencyNode?): List<Path> {
     val visitor = PreorderNodeListGenerator()
@@ -196,6 +218,7 @@ private fun toDiagnostic(
 ): PluginResolutionDiagnosticException {
     val cause: Throwable? = error.primaryResolutionCause()
     val repositoryList = repositories.joinToString(", ")
+    val authenticationFailure = isAuthenticationFailure(cause)
     val reason =
         when (cause) {
             is ArtifactNotFoundException ->
@@ -205,20 +228,50 @@ private fun toDiagnostic(
         }
 
     val remediation =
-        if (offline) {
+        if (authenticationFailure) {
+            "Verify repository credentials. Configure per-endpoint credentials via " +
+                "$REPOSITORY_CREDENTIALS_FILE_ENV, global credentials via " +
+                "$REPOSITORY_USERNAME_ENV/$REPOSITORY_PASSWORD_ENV, or GitHub Packages via " +
+                "$GITHUB_PACKAGES_USERNAME_ENV/$GITHUB_PACKAGES_TOKEN_ENV."
+        } else if (offline) {
             "Offline mode is enabled. Ensure the full dependency graph is cached under " +
                 "'$localRepositoryRoot' by running once without --offline."
         } else {
             "Verify plugin coordinates and repository availability."
         }
 
+    val category =
+        if (authenticationFailure) {
+            PluginResolverErrorCategory.AUTHENTICATION
+        } else {
+            PluginResolverErrorCategory.DEPENDENCY_RESOLUTION
+        }
+
     return PluginResolutionDiagnosticException(
-        category = PluginResolverErrorCategory.DEPENDENCY_RESOLUTION,
+        category = category,
         message =
         "Could not resolve plugin '${coordinate.value}' with transitive dependencies. " +
             "Repositories: $repositoryList. $reason $remediation",
         cause = error,
     )
+}
+
+private fun isAuthenticationFailure(cause: Throwable?): Boolean {
+    if (cause == null) {
+        return false
+    }
+
+    return generateSequence(cause) { throwable -> throwable.cause }
+        .mapNotNull(Throwable::message)
+        .map(String::lowercase)
+        .any { message ->
+            message.contains("status code: 401") ||
+                message.contains("status code: 403") ||
+                message.contains("unauthorized") ||
+                message.contains("forbidden") ||
+                message.contains("authentication failed") ||
+                message.contains("not authorized")
+        }
 }
 
 private fun DependencyResolutionException.primaryResolutionCause(): Throwable? = result.collectExceptions.firstOrNull()

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepository.kt
@@ -20,6 +20,19 @@ internal fun resolveRepositories(
     return repositories
 }
 
+internal fun resolveRepositoryEndpoints(
+    command: RunCommand,
+    settings: PluginResolverSettings,
+    repositoryPolicy: RepositoryAllowlistPolicy,
+    credentialsResolver: RepositoryCredentialsResolver,
+): List<RepositoryEndpoint> = resolveRepositories(command, settings, repositoryPolicy)
+    .map { repositoryUri ->
+        RepositoryEndpoint(
+            uri = repositoryUri,
+            credentials = credentialsResolver.resolve(repositoryUri),
+        )
+    }
+
 internal fun pluginArtifactCacheRoot(cacheDirectory: Path): Path = cacheDirectory
     .resolve("artifacts")
     .toAbsolutePath()

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentials.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentials.kt
@@ -1,0 +1,146 @@
+package me.liam.microsmith.cli.plugins
+
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal const val REPOSITORY_CREDENTIALS_FILE_ENV = "MICROSMITH_REPOSITORY_CREDENTIALS_FILE"
+internal const val REPOSITORY_USERNAME_ENV = "MICROSMITH_REPOSITORY_USERNAME"
+internal const val REPOSITORY_PASSWORD_ENV = "MICROSMITH_REPOSITORY_PASSWORD"
+internal const val GITHUB_PACKAGES_USERNAME_ENV = "MICROSMITH_GITHUB_PACKAGES_USER"
+internal const val GITHUB_PACKAGES_TOKEN_ENV = "MICROSMITH_GITHUB_PACKAGES_TOKEN"
+internal const val GITHUB_ACTOR_ENV = "GITHUB_ACTOR"
+internal const val GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
+
+private const val CREDENTIALS_FILE_ENTRY_PARTS = 3
+private const val DEFAULT_GITHUB_PACKAGES_USERNAME = "x-access-token"
+private const val GITHUB_PACKAGES_HOST = "maven.pkg.github.com"
+private const val REDACTED_SECRET = "<redacted>"
+
+internal data class RepositoryCredentials(val username: String, val password: String)
+
+internal interface RepositoryCredentialsResolver {
+    fun resolve(repositoryUri: String): RepositoryCredentials?
+
+    fun sensitiveValues(): Set<String> = emptySet()
+}
+
+internal class DefaultRepositoryCredentialsResolver(
+    private val fileCredentialsByRepository: Map<String, RepositoryCredentials>,
+    private val githubPackagesCredentials: RepositoryCredentials?,
+    private val defaultCredentials: RepositoryCredentials?,
+) : RepositoryCredentialsResolver {
+    override fun resolve(repositoryUri: String): RepositoryCredentials? {
+        val normalizedRepository = normalizeRepositoryUri(repositoryUri)
+        return fileCredentialsByRepository[normalizedRepository]
+            ?: githubPackagesCredentialsFor(normalizedRepository)
+            ?: defaultCredentials
+    }
+
+    override fun sensitiveValues(): Set<String> = buildSet {
+        fileCredentialsByRepository.values.mapTo(this) { credentials -> credentials.password }
+        githubPackagesCredentials?.password?.let(this::add)
+        defaultCredentials?.password?.let(this::add)
+    }.filter(String::isNotBlank).toSet()
+
+    private fun githubPackagesCredentialsFor(repositoryUri: String): RepositoryCredentials? {
+        val host = URI.create(repositoryUri).host?.lowercase()
+        if (host != GITHUB_PACKAGES_HOST) {
+            return null
+        }
+        return githubPackagesCredentials
+    }
+}
+
+internal fun defaultRepositoryCredentialsResolver(
+    repositoryCredentialsFileEnv: String? = System.getenv(REPOSITORY_CREDENTIALS_FILE_ENV),
+    repositoryUsernameEnv: String? = System.getenv(REPOSITORY_USERNAME_ENV),
+    repositoryPasswordEnv: String? = System.getenv(REPOSITORY_PASSWORD_ENV),
+    githubPackagesUsernameEnv: String? = System.getenv(GITHUB_PACKAGES_USERNAME_ENV),
+    githubPackagesTokenEnv: String? = System.getenv(GITHUB_PACKAGES_TOKEN_ENV),
+    githubActorEnv: String? = System.getenv(GITHUB_ACTOR_ENV),
+    githubTokenEnv: String? = System.getenv(GITHUB_TOKEN_ENV),
+): RepositoryCredentialsResolver {
+    val credentialsFilePath = repositoryCredentialsFileEnv?.trim()?.takeIf(String::isNotEmpty)?.let(Path::of)
+    val fileCredentials = credentialsFilePath?.let(::readRepositoryCredentialsFile).orEmpty()
+
+    val repositoryUsername = repositoryUsernameEnv?.trim().orEmpty()
+    val repositoryPassword = repositoryPasswordEnv?.trim().orEmpty()
+    require(repositoryUsername.isNotEmpty() == repositoryPassword.isNotEmpty()) {
+        "Set both $REPOSITORY_USERNAME_ENV and $REPOSITORY_PASSWORD_ENV, or leave both unset."
+    }
+    val defaultCredentials =
+        if (repositoryUsername.isNotEmpty()) {
+            RepositoryCredentials(username = repositoryUsername, password = repositoryPassword)
+        } else {
+            null
+        }
+
+    val githubPackagesToken =
+        githubPackagesTokenEnv
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?: githubTokenEnv
+                ?.trim()
+                ?.takeIf(String::isNotEmpty)
+    val githubPackagesCredentials =
+        if (githubPackagesToken != null) {
+            val githubPackagesUsername = githubPackagesUsernameEnv?.trim()?.takeIf(String::isNotEmpty)
+            val githubActorUsername = githubActorEnv?.trim()?.takeIf(String::isNotEmpty)
+            val username =
+                githubPackagesUsername
+                    ?: githubActorUsername
+                    ?: DEFAULT_GITHUB_PACKAGES_USERNAME
+            RepositoryCredentials(username = username, password = githubPackagesToken)
+        } else {
+            null
+        }
+
+    return DefaultRepositoryCredentialsResolver(
+        fileCredentialsByRepository = fileCredentials,
+        githubPackagesCredentials = githubPackagesCredentials,
+        defaultCredentials = defaultCredentials,
+    )
+}
+
+private fun readRepositoryCredentialsFile(credentialsFilePath: Path): Map<String, RepositoryCredentials> {
+    require(Files.exists(credentialsFilePath) && Files.isRegularFile(credentialsFilePath)) {
+        "Repository credentials file '$credentialsFilePath' does not exist or is not a regular file."
+    }
+
+    val credentialsByRepository = linkedMapOf<String, RepositoryCredentials>()
+    Files.readAllLines(credentialsFilePath).forEachIndexed { lineIndex, rawLine ->
+        val lineNumber = lineIndex + 1
+        val line = rawLine.trim()
+        if (line.isEmpty() || line.startsWith("#")) {
+            return@forEachIndexed
+        }
+
+        val parts = line.split('|', limit = CREDENTIALS_FILE_ENTRY_PARTS)
+        require(parts.size == CREDENTIALS_FILE_ENTRY_PARTS) {
+            "Invalid repository credentials entry at '$credentialsFilePath:$lineNumber'. " +
+                "Expected <repository-uri>|<username>|<password>."
+        }
+
+        val repositoryUri = normalizeRepositoryUri(parts[0])
+        val username = parts[1].trim()
+        val password = parts[2].trim()
+        require(username.isNotEmpty() && password.isNotEmpty()) {
+            "Invalid repository credentials entry at '$credentialsFilePath:$lineNumber'. " +
+                "Username and password must both be non-empty."
+        }
+        require(!credentialsByRepository.containsKey(repositoryUri)) {
+            "Duplicate repository credentials entry for '$repositoryUri' in '$credentialsFilePath'."
+        }
+        credentialsByRepository[repositoryUri] = RepositoryCredentials(username = username, password = password)
+    }
+
+    return credentialsByRepository.toMap()
+}
+
+internal fun String.redactSensitiveValues(sensitiveValues: Set<String>): String = sensitiveValues
+    .asSequence()
+    .map(String::trim)
+    .filter(String::isNotEmpty)
+    .distinct()
+    .fold(this) { sanitized, secret -> sanitized.replace(secret, REDACTED_SECRET) }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentials.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentials.kt
@@ -143,4 +143,5 @@ internal fun String.redactSensitiveValues(sensitiveValues: Set<String>): String 
     .map(String::trim)
     .filter(String::isNotEmpty)
     .distinct()
+    .sortedWith(compareByDescending<String> { secret -> secret.length }.thenBy { secret -> secret })
     .fold(this) { sanitized, secret -> sanitized.replace(secret, REDACTED_SECRET) }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentials.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentials.kt
@@ -3,6 +3,7 @@ package me.liam.microsmith.cli.plugins
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.LazyThreadSafetyMode
 
 internal const val REPOSITORY_CREDENTIALS_FILE_ENV = "MICROSMITH_REPOSITORY_CREDENTIALS_FILE"
 internal const val REPOSITORY_USERNAME_ENV = "MICROSMITH_REPOSITORY_USERNAME"
@@ -24,6 +25,20 @@ internal interface RepositoryCredentialsResolver {
 
     fun sensitiveValues(): Set<String> = emptySet()
 }
+
+private class LazyRepositoryCredentialsResolver(
+    resolverFactory: () -> RepositoryCredentialsResolver,
+) : RepositoryCredentialsResolver {
+    private val delegate: RepositoryCredentialsResolver by lazy(LazyThreadSafetyMode.NONE, resolverFactory)
+
+    override fun resolve(repositoryUri: String): RepositoryCredentials? = delegate.resolve(repositoryUri)
+
+    override fun sensitiveValues(): Set<String> = delegate.sensitiveValues()
+}
+
+internal fun lazyDefaultRepositoryCredentialsResolver(
+    resolverFactory: () -> RepositoryCredentialsResolver = ::defaultRepositoryCredentialsResolver,
+): RepositoryCredentialsResolver = LazyRepositoryCredentialsResolver(resolverFactory)
 
 internal class DefaultRepositoryCredentialsResolver(
     private val fileCredentialsByRepository: Map<String, RepositoryCredentials>,

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -15,7 +15,7 @@ internal data class PluginResolverSettings(
     val lockfilePathOverride: Path? = null,
     val defaultRepositories: List<String> = listOf(MAVEN_CENTRAL_REPOSITORY),
     val repositoryPolicy: RepositoryAllowlistPolicy? = null,
-    val repositoryCredentialsResolver: RepositoryCredentialsResolver = defaultRepositoryCredentialsResolver(),
+    val repositoryCredentialsResolver: RepositoryCredentialsResolver = lazyDefaultRepositoryCredentialsResolver(),
     val checksumAllowlist: PluginChecksumAllowlist? = null,
     val remotePluginResolver: RemotePluginResolver = MavenRemotePluginResolver(),
 )
@@ -42,7 +42,9 @@ internal fun resolvePlugins(command: RunCommand, settings: PluginResolverSetting
 
     var sensitiveValues: Set<String> = emptySet()
     return runCatching {
-        sensitiveValues = settings.repositoryCredentialsResolver.sensitiveValues()
+        if (command.plugins.isNotEmpty()) {
+            sensitiveValues = settings.repositoryCredentialsResolver.sensitiveValues()
+        }
         resolvePluginsOrThrow(command, settings)
     }.fold(
         onSuccess = { success -> success },
@@ -70,22 +72,25 @@ private fun resolvePluginsOrThrow(
 
     val lockfilePath = settings.lockfilePathOverride ?: defaultLockfilePath(command.script)
     val lockfile = readLockfile(lockfilePath)
-    val repositoryPolicy = settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy()
-    val repositoryCredentialsResolver = settings.repositoryCredentialsResolver
     val checksumAllowlist = settings.checksumAllowlist ?: loadPluginChecksumAllowlistFromEnvironment()
     val requestedLockKeys = buildRequestedLockKeys(coordinates, localPluginJars.map(LocalPluginJar::lockKey))
     checksumAllowlist?.assertCovers(requestedLockKeys)
     lockfile?.assertSamePluginSet(requestedLockKeys, lockfilePath)
 
     val repositories =
-        try {
-            resolveRepositoryEndpoints(command, settings, repositoryPolicy, repositoryCredentialsResolver)
-        } catch (error: IllegalArgumentException) {
-            throw PluginResolutionDiagnosticException(
-                category = PluginResolverErrorCategory.REPOSITORY_POLICY,
-                message = error.message ?: "Repository configuration was rejected by policy.",
-                cause = error,
-            )
+        if (coordinates.isEmpty()) {
+            emptyList()
+        } else {
+            try {
+                val repositoryPolicy = settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy()
+                resolveRepositoryEndpoints(command, settings, repositoryPolicy, settings.repositoryCredentialsResolver)
+            } catch (error: IllegalArgumentException) {
+                throw PluginResolutionDiagnosticException(
+                    category = PluginResolverErrorCategory.REPOSITORY_POLICY,
+                    message = error.message ?: "Repository configuration was rejected by policy.",
+                    cause = error,
+                )
+            }
         }
     val cacheDirectory = settings.cacheDirectory.toAbsolutePath().normalize()
     Files.createDirectories(cacheDirectory)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -20,12 +20,18 @@ internal data class PluginResolverSettings(
     val remotePluginResolver: RemotePluginResolver = MavenRemotePluginResolver(),
 )
 
-internal fun resolvePlugins(command: RunCommand, settings: PluginResolverSettings? = null): PluginResolutionResult {
-    var sensitiveValues: Set<String> = emptySet()
+internal fun resolvePlugins(command: RunCommand): PluginResolutionResult {
+    if (command.plugins.isEmpty() && command.pluginJars.isEmpty()) {
+        return PluginResolutionResult.Success(classpath = emptyList(), lockfilePath = null)
+    }
+
+    return resolvePlugins(command = command, settings = PluginResolverSettings())
+}
+
+internal fun resolvePlugins(command: RunCommand, settings: PluginResolverSettings): PluginResolutionResult {
+    val sensitiveValues = settings.repositoryCredentialsResolver.sensitiveValues()
     return runCatching {
-        val effectiveSettings = settings ?: PluginResolverSettings()
-        sensitiveValues = effectiveSettings.repositoryCredentialsResolver.sensitiveValues()
-        resolvePluginsOrThrow(command, effectiveSettings)
+        resolvePluginsOrThrow(command, settings)
     }.fold(
         onSuccess = { success -> success },
         onFailure = { error ->

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -15,19 +15,24 @@ internal data class PluginResolverSettings(
     val lockfilePathOverride: Path? = null,
     val defaultRepositories: List<String> = listOf(MAVEN_CENTRAL_REPOSITORY),
     val repositoryPolicy: RepositoryAllowlistPolicy? = null,
+    val repositoryCredentialsResolver: RepositoryCredentialsResolver = defaultRepositoryCredentialsResolver(),
     val checksumAllowlist: PluginChecksumAllowlist? = null,
     val remotePluginResolver: RemotePluginResolver = MavenRemotePluginResolver(),
 )
 
-internal fun resolvePlugins(
-    command: RunCommand,
-    settings: PluginResolverSettings = PluginResolverSettings(),
-): PluginResolutionResult = runCatching {
-    resolvePluginsOrThrow(command, settings)
-}.fold(
-    onSuccess = { success -> success },
-    onFailure = { error -> PluginResolutionResult.Failure(listOf(error.toResolutionDiagnostic())) },
-)
+internal fun resolvePlugins(command: RunCommand, settings: PluginResolverSettings? = null): PluginResolutionResult {
+    var sensitiveValues: Set<String> = emptySet()
+    return runCatching {
+        val effectiveSettings = settings ?: PluginResolverSettings()
+        sensitiveValues = effectiveSettings.repositoryCredentialsResolver.sensitiveValues()
+        resolvePluginsOrThrow(command, effectiveSettings)
+    }.fold(
+        onSuccess = { success -> success },
+        onFailure = { error ->
+            PluginResolutionResult.Failure(listOf(error.toResolutionDiagnostic(sensitiveValues)))
+        },
+    )
+}
 
 private fun resolvePluginsOrThrow(
     command: RunCommand,
@@ -48,12 +53,22 @@ private fun resolvePluginsOrThrow(
     val lockfilePath = settings.lockfilePathOverride ?: defaultLockfilePath(command.script)
     val lockfile = readLockfile(lockfilePath)
     val repositoryPolicy = settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy()
+    val repositoryCredentialsResolver = settings.repositoryCredentialsResolver
     val checksumAllowlist = settings.checksumAllowlist ?: loadPluginChecksumAllowlistFromEnvironment()
     val requestedLockKeys = buildRequestedLockKeys(coordinates, localPluginJars.map(LocalPluginJar::lockKey))
     checksumAllowlist?.assertCovers(requestedLockKeys)
     lockfile?.assertSamePluginSet(requestedLockKeys, lockfilePath)
 
-    val repositories = resolveRepositories(command, settings, repositoryPolicy)
+    val repositories =
+        try {
+            resolveRepositoryEndpoints(command, settings, repositoryPolicy, repositoryCredentialsResolver)
+        } catch (error: IllegalArgumentException) {
+            throw PluginResolutionDiagnosticException(
+                category = PluginResolverErrorCategory.REPOSITORY_POLICY,
+                message = error.message ?: "Repository configuration was rejected by policy.",
+                cause = error,
+            )
+        }
     val cacheDirectory = settings.cacheDirectory.toAbsolutePath().normalize()
     Files.createDirectories(cacheDirectory)
 
@@ -119,11 +134,14 @@ private fun resolveLocalPluginJars(pluginJars: Set<Path>): List<LocalPluginJar> 
         )
     }.sortedBy(LocalPluginJar::lockKey)
 
-private fun Throwable.toResolutionDiagnostic(): String = when (this) {
+private fun Throwable.toResolutionDiagnostic(sensitiveValues: Set<String>): String = when (this) {
     is PluginResolutionDiagnosticException ->
-        "[${category.code}] ${message ?: "plugin resolution failed"}"
+        "[${category.code}] ${(message ?: "plugin resolution failed").redactSensitiveValues(sensitiveValues)}"
 
-    else -> "[unexpected] ${message ?: this::class.simpleName ?: "unknown plugin resolution error"}"
+    else -> {
+        val unexpectedMessage = message ?: this::class.simpleName ?: "unknown plugin resolution error"
+        "[unexpected] ${unexpectedMessage.redactSensitiveValues(sensitiveValues)}"
+    }
 }
 
 private fun normalizeClasspath(rawClasspath: List<Path>): List<Path> = rawClasspath

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -25,12 +25,24 @@ internal fun resolvePlugins(command: RunCommand): PluginResolutionResult {
         return PluginResolutionResult.Success(classpath = emptyList(), lockfilePath = null)
     }
 
-    return resolvePlugins(command = command, settings = PluginResolverSettings())
+    return runCatching {
+        PluginResolverSettings()
+    }.fold(
+        onSuccess = { settings -> resolvePlugins(command = command, settings = settings) },
+        onFailure = { error ->
+            PluginResolutionResult.Failure(listOf(error.toResolutionDiagnostic(emptySet())))
+        },
+    )
 }
 
 internal fun resolvePlugins(command: RunCommand, settings: PluginResolverSettings): PluginResolutionResult {
-    val sensitiveValues = settings.repositoryCredentialsResolver.sensitiveValues()
+    if (command.plugins.isEmpty() && command.pluginJars.isEmpty()) {
+        return PluginResolutionResult.Success(classpath = emptyList(), lockfilePath = null)
+    }
+
+    var sensitiveValues: Set<String> = emptySet()
     return runCatching {
+        sensitiveValues = settings.repositoryCredentialsResolver.sensitiveValues()
         resolvePluginsOrThrow(command, settings)
     }.fold(
         onSuccess = { success -> success },

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/RepositoryEndpoint.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/RepositoryEndpoint.kt
@@ -1,0 +1,3 @@
+package me.liam.microsmith.cli.plugins
+
+internal data class RepositoryEndpoint(val uri: String, val credentials: RepositoryCredentials?)

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliTests.kt
@@ -160,6 +160,27 @@ class MicrosmithCliTests :
             out shouldBe emptyList()
         }
 
+        "returns deterministic plugin resolution exit code when plugin resolver throws unexpectedly" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    providerValidator = { emptyList() },
+                    pluginResolver = {
+                        throw IllegalStateException("simulated resolver crash")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("run", "schema.microsmith.kts", "--out", "build/generated"))
+
+            exitCode shouldBe 11
+            err.joinToString("\n").shouldContain("Plugin resolution failed unexpectedly")
+            err.joinToString("\n").shouldContain("MS-CLI-1101")
+            out shouldBe emptyList()
+        }
+
         "emits machine readable diagnostics when json mode is requested" {
             val out = mutableListOf<String>()
             val err = mutableListOf<String>()

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentialsTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentialsTests.kt
@@ -1,0 +1,124 @@
+package me.liam.microsmith.cli.plugins
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class PluginRepositoryCredentialsTests :
+    StringSpec({
+        "repository credentials file entries take precedence over global credentials" {
+            val tempDir = createTempDirectory("microsmith-plugin-credentials-precedence")
+            try {
+                val credentialsFile = tempDir.resolve("repository-credentials.txt")
+                credentialsFile.writeText(
+                    """
+                    https://repo1.maven.org/maven2|file-user|file-secret
+                    """.trimIndent(),
+                )
+
+                val resolver =
+                    defaultRepositoryCredentialsResolver(
+                        repositoryCredentialsFileEnv = credentialsFile.toString(),
+                        repositoryUsernameEnv = "global-user",
+                        repositoryPasswordEnv = "global-secret",
+                    )
+
+                resolver.resolve("https://repo1.maven.org/maven2") shouldBe
+                    RepositoryCredentials(username = "file-user", password = "file-secret")
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "github packages credentials use github actor fallback and only apply to github packages host" {
+            val resolver =
+                defaultRepositoryCredentialsResolver(
+                    githubPackagesUsernameEnv = null,
+                    githubPackagesTokenEnv = null,
+                    githubActorEnv = "octocat",
+                    githubTokenEnv = "gh-token",
+                )
+
+            resolver.resolve("https://maven.pkg.github.com/acme/microsmith") shouldBe
+                RepositoryCredentials(username = "octocat", password = "gh-token")
+            resolver.resolve("https://repo1.maven.org/maven2") shouldBe null
+        }
+
+        "global repository credentials are used for non-github repositories" {
+            val resolver =
+                defaultRepositoryCredentialsResolver(
+                    repositoryUsernameEnv = "ci-user",
+                    repositoryPasswordEnv = "ci-pass",
+                )
+
+            resolver.resolve("https://packages.acme.internal/maven") shouldBe
+                RepositoryCredentials(username = "ci-user", password = "ci-pass")
+        }
+
+        "fails when only one global credential environment variable is configured" {
+            shouldThrow<IllegalArgumentException> {
+                defaultRepositoryCredentialsResolver(
+                    repositoryUsernameEnv = "ci-user",
+                    repositoryPasswordEnv = null,
+                )
+            }.message.shouldContain("Set both MICROSMITH_REPOSITORY_USERNAME and MICROSMITH_REPOSITORY_PASSWORD")
+        }
+
+        "fails when repository credentials file has duplicate repository entries" {
+            val tempDir = createTempDirectory("microsmith-plugin-credentials-duplicate")
+            try {
+                val credentialsFile = tempDir.resolve("repository-credentials.txt")
+                credentialsFile.writeText(
+                    """
+                    https://repo1.maven.org/maven2|first|secret-one
+                    https://repo1.maven.org/maven2|second|secret-two
+                    """.trimIndent(),
+                )
+
+                shouldThrow<IllegalArgumentException> {
+                    defaultRepositoryCredentialsResolver(
+                        repositoryCredentialsFileEnv = credentialsFile.toString(),
+                    )
+                }.message.shouldContain("Duplicate repository credentials entry")
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "sensitive values includes secrets but excludes usernames" {
+            val tempDir = createTempDirectory("microsmith-plugin-credentials-sensitive-values")
+            try {
+                val credentialsFile = tempDir.resolve("repository-credentials.txt")
+                credentialsFile.writeText(
+                    """
+                    https://repo1.maven.org/maven2|file-user|file-secret
+                    """.trimIndent(),
+                )
+
+                val resolver =
+                    defaultRepositoryCredentialsResolver(
+                        repositoryCredentialsFileEnv = credentialsFile.toString(),
+                        repositoryUsernameEnv = "global-user",
+                        repositoryPasswordEnv = "global-secret",
+                        githubPackagesUsernameEnv = "gh-user",
+                        githubPackagesTokenEnv = "gh-secret",
+                    )
+
+                val sensitiveValues = resolver.sensitiveValues()
+                sensitiveValues shouldContain "file-secret"
+                sensitiveValues shouldContain "global-secret"
+                sensitiveValues shouldContain "gh-secret"
+                sensitiveValues.contains("gh-user") shouldBe false
+                sensitiveValues.contains("global-user") shouldBe false
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentialsTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginRepositoryCredentialsTests.kt
@@ -16,10 +16,12 @@ class PluginRepositoryCredentialsTests :
         "repository credentials file entries take precedence over global credentials" {
             val tempDir = createTempDirectory("microsmith-plugin-credentials-precedence")
             try {
+                val fileCredential = "example-file-credential"
+                val globalCredential = "example-global-credential"
                 val credentialsFile = tempDir.resolve("repository-credentials.txt")
                 credentialsFile.writeText(
                     """
-                    https://repo1.maven.org/maven2|file-user|file-secret
+                    https://repo1.maven.org/maven2|file-user|$fileCredential
                     """.trimIndent(),
                 )
 
@@ -27,39 +29,41 @@ class PluginRepositoryCredentialsTests :
                     defaultRepositoryCredentialsResolver(
                         repositoryCredentialsFileEnv = credentialsFile.toString(),
                         repositoryUsernameEnv = "global-user",
-                        repositoryPasswordEnv = "global-secret",
+                        repositoryPasswordEnv = globalCredential,
                     )
 
                 resolver.resolve("https://repo1.maven.org/maven2") shouldBe
-                    RepositoryCredentials(username = "file-user", password = "file-secret")
+                    RepositoryCredentials(username = "file-user", password = fileCredential)
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }
         }
 
         "github packages credentials use github actor fallback and only apply to github packages host" {
+            val githubCredential = "example-github-credential"
             val resolver =
                 defaultRepositoryCredentialsResolver(
                     githubPackagesUsernameEnv = null,
                     githubPackagesTokenEnv = null,
                     githubActorEnv = "octocat",
-                    githubTokenEnv = "gh-token",
+                    githubTokenEnv = githubCredential,
                 )
 
             resolver.resolve("https://maven.pkg.github.com/acme/microsmith") shouldBe
-                RepositoryCredentials(username = "octocat", password = "gh-token")
+                RepositoryCredentials(username = "octocat", password = githubCredential)
             resolver.resolve("https://repo1.maven.org/maven2") shouldBe null
         }
 
         "global repository credentials are used for non-github repositories" {
+            val globalCredential = "example-global-credential"
             val resolver =
                 defaultRepositoryCredentialsResolver(
                     repositoryUsernameEnv = "ci-user",
-                    repositoryPasswordEnv = "ci-pass",
+                    repositoryPasswordEnv = globalCredential,
                 )
 
             resolver.resolve("https://packages.acme.internal/maven") shouldBe
-                RepositoryCredentials(username = "ci-user", password = "ci-pass")
+                RepositoryCredentials(username = "ci-user", password = globalCredential)
         }
 
         "fails when only one global credential environment variable is configured" {
@@ -74,11 +78,13 @@ class PluginRepositoryCredentialsTests :
         "fails when repository credentials file has duplicate repository entries" {
             val tempDir = createTempDirectory("microsmith-plugin-credentials-duplicate")
             try {
+                val firstCredential = "example-first-credential"
+                val secondCredential = "example-second-credential"
                 val credentialsFile = tempDir.resolve("repository-credentials.txt")
                 credentialsFile.writeText(
                     """
-                    https://repo1.maven.org/maven2|first|secret-one
-                    https://repo1.maven.org/maven2|second|secret-two
+                    https://repo1.maven.org/maven2|first|$firstCredential
+                    https://repo1.maven.org/maven2|second|$secondCredential
                     """.trimIndent(),
                 )
 
@@ -95,10 +101,13 @@ class PluginRepositoryCredentialsTests :
         "sensitive values includes secrets but excludes usernames" {
             val tempDir = createTempDirectory("microsmith-plugin-credentials-sensitive-values")
             try {
+                val fileCredential = "example-file-credential"
+                val globalCredential = "example-global-credential"
+                val githubCredential = "example-github-credential"
                 val credentialsFile = tempDir.resolve("repository-credentials.txt")
                 credentialsFile.writeText(
                     """
-                    https://repo1.maven.org/maven2|file-user|file-secret
+                    https://repo1.maven.org/maven2|file-user|$fileCredential
                     """.trimIndent(),
                 )
 
@@ -106,19 +115,28 @@ class PluginRepositoryCredentialsTests :
                     defaultRepositoryCredentialsResolver(
                         repositoryCredentialsFileEnv = credentialsFile.toString(),
                         repositoryUsernameEnv = "global-user",
-                        repositoryPasswordEnv = "global-secret",
+                        repositoryPasswordEnv = globalCredential,
                         githubPackagesUsernameEnv = "gh-user",
-                        githubPackagesTokenEnv = "gh-secret",
+                        githubPackagesTokenEnv = githubCredential,
                     )
 
                 val sensitiveValues = resolver.sensitiveValues()
-                sensitiveValues shouldContain "file-secret"
-                sensitiveValues shouldContain "global-secret"
-                sensitiveValues shouldContain "gh-secret"
+                sensitiveValues shouldContain fileCredential
+                sensitiveValues shouldContain globalCredential
+                sensitiveValues shouldContain githubCredential
                 sensitiveValues.contains("gh-user") shouldBe false
                 sensitiveValues.contains("global-user") shouldBe false
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }
+        }
+
+        "redacts overlapping secrets using longest-first replacement" {
+            val sanitized =
+                "token=alphabet".redactSensitiveValues(
+                    setOf("alpha", "alphabet"),
+                )
+
+            sanitized shouldBe "token=<redacted>"
         }
     })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverGuardrailTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverGuardrailTests.kt
@@ -5,9 +5,12 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import me.liam.microsmith.cli.command.RunCommand
+import java.nio.file.Path
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteRecursively
+import kotlin.io.path.writeBytes
+import kotlin.io.path.writeText
 
 @OptIn(ExperimentalPathApi::class)
 class PluginResolverGuardrailTests :
@@ -39,6 +42,46 @@ class PluginResolverGuardrailTests :
                 val success = result.shouldBeTypeOf<PluginResolutionResult.Success>()
                 success.classpath.shouldBeEmpty()
                 success.lockfilePath shouldBe null
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "resolves local plugin jars without evaluating repository credential resolvers" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-local-only")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                script.writeText("// test script")
+                val localJar = tempDir.resolve("plugins/local-plugin.jar")
+                localJar.parent?.toFile()?.mkdirs()
+                localJar.writeBytes("local-plugin".toByteArray())
+
+                val workingDirectory = Path.of("").toAbsolutePath().normalize()
+                val relativeJarPath = workingDirectory.relativize(localJar.toAbsolutePath().normalize())
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        pluginJars = setOf(relativeJarPath),
+                    )
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = tempDir.resolve("cache"),
+                        repositoryCredentialsResolver =
+                        object : RepositoryCredentialsResolver {
+                            override fun resolve(repositoryUri: String): RepositoryCredentials {
+                                error("resolve() should not be called for local plugin-jar-only runs.")
+                            }
+
+                            override fun sensitiveValues(): Set<String> {
+                                error("sensitiveValues() should not be called for local plugin-jar-only runs.")
+                            }
+                        },
+                    )
+
+                val result = resolvePlugins(command = command, settings = settings)
+                val success = result.shouldBeTypeOf<PluginResolutionResult.Success>()
+                success.classpath shouldBe listOf(localJar.toAbsolutePath().normalize())
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverGuardrailTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverGuardrailTests.kt
@@ -1,0 +1,46 @@
+package me.liam.microsmith.cli.plugins
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import me.liam.microsmith.cli.command.RunCommand
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+
+@OptIn(ExperimentalPathApi::class)
+class PluginResolverGuardrailTests :
+    StringSpec({
+        "returns success without evaluating credential resolvers when no plugins are requested" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-no-plugins")
+            try {
+                val command =
+                    RunCommand(
+                        script = tempDir.resolve("schema.microsmith.kts"),
+                        outputDir = tempDir.resolve("generated"),
+                    )
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = tempDir.resolve("cache"),
+                        repositoryCredentialsResolver =
+                        object : RepositoryCredentialsResolver {
+                            override fun resolve(repositoryUri: String): RepositoryCredentials {
+                                error("resolve() should not be called when no plugins are requested.")
+                            }
+
+                            override fun sensitiveValues(): Set<String> {
+                                error("sensitiveValues() should not be called when no plugins are requested.")
+                            }
+                        },
+                    )
+
+                val result = resolvePlugins(command = command, settings = settings)
+                val success = result.shouldBeTypeOf<PluginResolutionResult.Success>()
+                success.classpath.shouldBeEmpty()
+                success.lockfilePath shouldBe null
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeTypeOf
 import me.liam.microsmith.cli.command.RunCommand
 import java.nio.file.Path
@@ -272,6 +273,61 @@ class PluginResolverTests :
             }
         }
 
+        "categorizes repository authentication failures and redacts sensitive values" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-auth-redaction")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val output = tempDir.resolve("generated")
+                val secretToken = "ghp_super_secret_token_12345"
+                script.writeText("// test script")
+
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = output,
+                        plugins = setOf("com.acme:secured-plugin:1.0.0"),
+                    )
+
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = tempDir.resolve("cache"),
+                        repositoryCredentialsResolver =
+                        object : RepositoryCredentialsResolver {
+                            override fun resolve(repositoryUri: String): RepositoryCredentials = RepositoryCredentials(
+                                username = "ci-user",
+                                password = secretToken,
+                            )
+
+                            override fun sensitiveValues(): Set<String> = setOf(secretToken)
+                        },
+                        remotePluginResolver =
+                        object : RemotePluginResolver {
+                            override fun resolve(
+                                coordinate: Coordinate,
+                                repositories: List<RepositoryEndpoint>,
+                                cacheDirectory: Path,
+                                offline: Boolean,
+                            ): ResolvedRemotePlugin {
+                                repositories.first().credentials?.password shouldBe secretToken
+                                throw PluginResolutionDiagnosticException(
+                                    category = PluginResolverErrorCategory.AUTHENTICATION,
+                                    message = "Unauthorized while using token '$secretToken'.",
+                                )
+                            }
+                        },
+                    )
+
+                val result = resolvePlugins(command = command, settings = settings)
+                val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
+                val message = failure.diagnostics.joinToString("\n")
+                message.shouldContain("[authentication]")
+                message.shouldContain("<redacted>")
+                message.shouldNotContain(secretToken)
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
         "fails when cached artifact checksum does not match existing lockfile" {
             val tempDir = createTempDirectory("microsmith-plugin-resolver-lock-mismatch")
             try {
@@ -521,6 +577,7 @@ class PluginResolverTests :
                         settings = PluginResolverSettings(cacheDirectory = tempDir),
                     )
                 val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
+                failure.diagnostics.joinToString("\n").shouldContain("[repository-policy]")
                 failure.diagnostics.joinToString("\n").shouldContain("allowed repository allowlist")
             } finally {
                 runCatching { tempDir.deleteRecursively() }
@@ -552,6 +609,7 @@ class PluginResolverTests :
                         settings = PluginResolverSettings(cacheDirectory = cache),
                     )
                 val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
+                failure.diagnostics.joinToString("\n").shouldContain("[repository-policy]")
                 failure.diagnostics.joinToString("\n").shouldContain("file:// repositories are not allowed")
             } finally {
                 runCatching { tempDir.deleteRecursively() }

--- a/docs/cli/quickstart-non-gradle.md
+++ b/docs/cli/quickstart-non-gradle.md
@@ -64,6 +64,30 @@ Offline mode:
 microsmith run schema.microsmith.kts --out ./generated --offline
 ```
 
+Authenticated private repository (global credentials):
+
+```bash
+export MICROSMITH_REPOSITORY_ALLOWLIST="https://maven.pkg.github.com/acme/microsmith"
+export MICROSMITH_REPOSITORY_USERNAME="octocat"
+export MICROSMITH_REPOSITORY_PASSWORD="$GITHUB_TOKEN"
+microsmith run schema.microsmith.kts --out ./generated \
+  --repository https://maven.pkg.github.com/acme/microsmith \
+  --plugin com.acme:private-emitter:1.2.3
+```
+
+Per-repository credentials file:
+
+```text
+# ~/.microsmith/repository-credentials.txt
+https://maven.pkg.github.com/acme/microsmith|octocat|ghp_xxx
+https://packages.acme.internal/maven|svc-microsmith|token-123
+```
+
+```bash
+export MICROSMITH_REPOSITORY_CREDENTIALS_FILE="$HOME/.microsmith/repository-credentials.txt"
+microsmith run schema.microsmith.kts --out ./generated --plugin com.acme:private-emitter:1.2.3
+```
+
 Security defaults are enabled by default:
 
 - script dependency directives are blocked

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -27,11 +27,19 @@ Symptom:
 - plugin coordinate cannot be resolved
 - repository URI rejected
 - checksum mismatch
+- authentication errors (`[authentication]`)
+- repository policy blocks (`[repository-policy]`)
 
 Actions:
 - validate coordinate syntax: `group:artifact:version`
 - confirm repository is in allowed endpoints
+- for private repositories, configure credentials using one of:
+  - `MICROSMITH_REPOSITORY_CREDENTIALS_FILE`
+  - `MICROSMITH_REPOSITORY_USERNAME` + `MICROSMITH_REPOSITORY_PASSWORD`
+  - `MICROSMITH_GITHUB_PACKAGES_USER` + `MICROSMITH_GITHUB_PACKAGES_TOKEN`
+    (fallback: `GITHUB_ACTOR` + `GITHUB_TOKEN`)
 - update or regenerate lock/checksum metadata when plugin versions change
+- verify diagnostics do not contain secret material; Microsmith redacts configured tokens/passwords by default
 
 ## Offline mode failures
 


### PR DESCRIPTION
## Summary
This PR implements issue #45 by adding authenticated repository resolution for plugin dependencies, preserving deny-by-default repository policy behavior, and redacting secrets from resolver diagnostics.

## What Changed
### Runtime auth and policy enforcement
- Added repository endpoint modeling via `RepositoryEndpoint` so resolver inputs can carry URI + credentials.
- Added `PluginRepositoryCredentials` with deterministic credential precedence:
  - Per-endpoint credentials file: `MICROSMITH_REPOSITORY_CREDENTIALS_FILE`
  - GitHub Packages credentials: `MICROSMITH_GITHUB_PACKAGES_USER` + `MICROSMITH_GITHUB_PACKAGES_TOKEN` (fallback `GITHUB_ACTOR` + `GITHUB_TOKEN`)
  - Global default credentials: `MICROSMITH_REPOSITORY_USERNAME` + `MICROSMITH_REPOSITORY_PASSWORD`
- Wired credentials into Maven Resolver remote repositories using `AuthenticationBuilder`.
- Added explicit repository policy categorization (`[repository-policy]`) when repositories are rejected before resolution.

### Diagnostics and security hardening
- Added authentication error category (`[authentication]`) when dependency resolution fails with unauthorized/forbidden authentication indicators.
- Added centralized secret redaction (`<redacted>`) for plugin resolution diagnostics using known sensitive values from resolver settings.

### Tests and docs
- Added `PluginRepositoryCredentialsTests` for precedence, validation, and sensitive-value behavior.
- Extended `PluginResolverTests` to verify:
  - authentication category + redaction behavior
  - repository policy category behavior
  - endpoint credential propagation to resolver path
- Updated CLI/docs to document auth env vars and troubleshooting for private repositories:
  - `cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt`
  - `README.md`
  - `docs/cli/quickstart-non-gradle.md`
  - `docs/cli/troubleshooting.md`

## Validation
- `./gradlew :cli:kotest --stacktrace`
- `./gradlew :cli:check --stacktrace`

## Issue
Closes #45
