### PR TITLE
feat(runtime-locking): implement lockfile v2 graph locking and offline cache completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,10 @@ microsmith run schema.microsmith.kts --out ./generated --isolation process
     (fallbacks: `GITHUB_ACTOR` + `GITHUB_TOKEN`)
   - Global default credentials via `MICROSMITH_REPOSITORY_USERNAME` + `MICROSMITH_REPOSITORY_PASSWORD`
   - Sensitive values are redacted in resolver diagnostics.
-- Plugin artifacts are SHA-256 checked against the script lockfile when present.
+- Plugin artifacts are SHA-256 checked against the script lockfile, including transitive dependency graph artifacts in lockfile v2.
 - Optional plugin checksum allowlist can be enforced with `MICROSMITH_PLUGIN_ALLOWLIST_FILE`:
-  - Entry format: `<kind>|<key>|<sha256>` where `kind` is `remote` or `local`.
+  - Entry format: `<kind>|<key>|<sha256>` where `kind` is `remote`, `remote-artifact`, or `local`.
+- `--offline` for remote plugins requires lockfile v2 metadata and a complete cached dependency graph.
 - Generated output writes are constrained to the configured output root and reject traversal/symlink escapes.
 - Default isolation executes each run in an isolated per-run classloader; `--isolation process` executes in a separate JVM.
 

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
@@ -19,7 +19,7 @@ Security policy env vars:
   MICROSMITH_REPOSITORY_PASSWORD    Default password/token for authenticated repository access.
   MICROSMITH_GITHUB_PACKAGES_USER   Username for https://maven.pkg.github.com access.
   MICROSMITH_GITHUB_PACKAGES_TOKEN  Token for https://maven.pkg.github.com access.
-  MICROSMITH_PLUGIN_ALLOWLIST_FILE  Path to checksum allowlist file (<kind>|<key>|<sha256>).
+  MICROSMITH_PLUGIN_ALLOWLIST_FILE  Path to checksum allowlist file (<kind>|<key>|<sha256>; kind=remote|remote-artifact|local).
   MICROSMITH_SCRIPT_CACHE_DIR       Override script compilation cache directory.
   MICROSMITH_PLUGIN_CACHE_DIR       Override plugin resolution cache directory.
 """

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -47,6 +47,7 @@ internal enum class PluginResolverErrorCategory(val code: String) {
     OFFLINE_CACHE_MISS("offline-cache-miss"),
     AUTHENTICATION("authentication"),
     DEPENDENCY_RESOLUTION("dependency-resolution"),
+    LOCKFILE("lockfile"),
     REPOSITORY_POLICY("repository-policy"),
     ROOT_ARTIFACT_MISSING("root-artifact-missing"),
 }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -35,7 +35,13 @@ internal interface RemotePluginResolver {
     ): ResolvedRemotePlugin
 }
 
-internal data class ResolvedRemotePlugin(val rootArtifactPath: Path, val classpath: List<Path>)
+internal data class ResolvedRemoteArtifact(val lockKey: String, val artifactPath: Path)
+
+internal data class ResolvedRemotePlugin(
+    val rootArtifactPath: Path,
+    val classpath: List<Path>,
+    val artifacts: List<ResolvedRemoteArtifact>,
+)
 
 internal enum class PluginResolverErrorCategory(val code: String) {
     OFFLINE_CACHE_MISS("offline-cache-miss"),
@@ -88,8 +94,19 @@ internal class MavenRemotePluginResolver(
                 expectedRootArtifactPath = expectedRootArtifactPath,
                 artifactResults = dependencyResult.artifactResults,
             )
+        val artifacts =
+            resolveArtifacts(
+                coordinate = coordinate,
+                artifactResults = dependencyResult.artifactResults,
+                localRepositoryRoot = localRepositoryRoot,
+                rootArtifactPath = rootArtifactPath,
+            )
 
-        return ResolvedRemotePlugin(rootArtifactPath = rootArtifactPath, classpath = classpath)
+        return ResolvedRemotePlugin(
+            rootArtifactPath = rootArtifactPath,
+            classpath = classpath,
+            artifacts = artifacts,
+        )
     }
 }
 
@@ -205,6 +222,57 @@ private fun resolveRootArtifactPath(
         "Plugin '${coordinate.value}' resolved but no root jar was produced in cache at " +
             "'$expectedRootArtifactPath'.",
     )
+
+private fun resolveArtifacts(
+    coordinate: Coordinate,
+    artifactResults: List<ArtifactResult>,
+    localRepositoryRoot: Path,
+    rootArtifactPath: Path,
+): List<ResolvedRemoteArtifact> {
+    val resolved =
+        artifactResults
+            .asSequence()
+            .mapNotNull { result -> result.artifact?.file?.toPath() }
+            .map { path -> path.toAbsolutePath().normalize() }
+            .filter(Files::exists)
+            .map { artifactPath ->
+                ResolvedRemoteArtifact(
+                    lockKey =
+                    toRemoteArtifactLockKey(
+                        coordinate = coordinate,
+                        localRepositoryRoot = localRepositoryRoot,
+                        artifactPath = artifactPath,
+                    ),
+                    artifactPath = artifactPath,
+                )
+            }.distinctBy(ResolvedRemoteArtifact::lockKey)
+            .toMutableList()
+
+    val rootLockKey =
+        toRemoteArtifactLockKey(
+            coordinate = coordinate,
+            localRepositoryRoot = localRepositoryRoot,
+            artifactPath = rootArtifactPath,
+        )
+    if (resolved.none { artifact -> artifact.lockKey == rootLockKey }) {
+        resolved.add(
+            0,
+            ResolvedRemoteArtifact(
+                lockKey = rootLockKey,
+                artifactPath = rootArtifactPath,
+            ),
+        )
+    }
+
+    return resolved
+}
+
+private fun toRemoteArtifactLockKey(coordinate: Coordinate, localRepositoryRoot: Path, artifactPath: Path): String {
+    require(artifactPath.startsWith(localRepositoryRoot)) {
+        "Resolved artifact for plugin '${coordinate.value}' escapes plugin cache root: '$artifactPath'."
+    }
+    return localRepositoryRoot.relativize(artifactPath).toString().replace('\\', '/')
+}
 
 private fun Artifact.matchesCoordinate(coordinate: Coordinate): Boolean =
     groupId == coordinate.group && artifactId == coordinate.artifact && version == coordinate.version

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/MavenRemotePluginResolver.kt
@@ -229,49 +229,83 @@ private fun resolveArtifacts(
     localRepositoryRoot: Path,
     rootArtifactPath: Path,
 ): List<ResolvedRemoteArtifact> {
-    val resolved =
+    val resolvedRuntimeArtifacts =
         artifactResults
             .asSequence()
             .mapNotNull { result -> result.artifact?.file?.toPath() }
             .map { path -> path.toAbsolutePath().normalize() }
             .filter(Files::exists)
-            .map { artifactPath ->
-                ResolvedRemoteArtifact(
-                    lockKey =
-                    toRemoteArtifactLockKey(
-                        coordinate = coordinate,
-                        localRepositoryRoot = localRepositoryRoot,
-                        artifactPath = artifactPath,
-                    ),
-                    artifactPath = artifactPath,
+            .toList()
+    val resolvedDescriptorArtifacts =
+        artifactResults
+            .asSequence()
+            .mapNotNull { result -> result.artifact }
+            .map { artifact ->
+                resolveDescriptorPath(
+                    coordinate = coordinate,
+                    localRepositoryRoot = localRepositoryRoot,
+                    artifact = artifact,
                 )
-            }.distinctBy(ResolvedRemoteArtifact::lockKey)
-            .toMutableList()
+            }.toList()
 
-    val rootLockKey =
-        toRemoteArtifactLockKey(
-            coordinate = coordinate,
-            localRepositoryRoot = localRepositoryRoot,
-            artifactPath = rootArtifactPath,
-        )
-    if (resolved.none { artifact -> artifact.lockKey == rootLockKey }) {
-        resolved.add(
-            0,
+    return (resolvedRuntimeArtifacts + listOf(rootArtifactPath) + resolvedDescriptorArtifacts)
+        .distinct()
+        .map { artifactPath ->
             ResolvedRemoteArtifact(
-                lockKey = rootLockKey,
-                artifactPath = rootArtifactPath,
-            ),
-        )
-    }
+                lockKey =
+                toRemoteArtifactLockKey(
+                    coordinate = coordinate,
+                    localRepositoryRoot = localRepositoryRoot,
+                    artifactPath = artifactPath,
+                ),
+                artifactPath = artifactPath,
+            )
+        }.sortedBy(ResolvedRemoteArtifact::lockKey)
+}
 
-    return resolved
+private fun resolveDescriptorPath(coordinate: Coordinate, localRepositoryRoot: Path, artifact: Artifact): Path {
+    val fromArtifactFile =
+        artifact.file
+            ?.toPath()
+            ?.toAbsolutePath()
+            ?.normalize()
+            ?.let(::toPomSiblingPath)
+    val fromArtifactCoordinates =
+        localRepositoryRoot
+            .resolve(artifact.groupId.replace('.', '/'))
+            .resolve(artifact.artifactId)
+            .resolve(artifact.version)
+            .resolve("${artifact.artifactId}-${artifact.version}.pom")
+            .toAbsolutePath()
+            .normalize()
+    val candidates = listOfNotNull(fromArtifactFile, fromArtifactCoordinates).distinct()
+    val resolvedPath = candidates.firstOrNull(Files::exists) ?: candidates.first()
+    require(Files.exists(resolvedPath) && Files.isRegularFile(resolvedPath)) {
+        "Dependency descriptor for '${artifact.groupId}:${artifact.artifactId}:${artifact.version}' " +
+            "is missing from cache at '$resolvedPath'."
+    }
+    require(resolvedPath.startsWith(localRepositoryRoot)) {
+        "Resolved descriptor for plugin '${coordinate.value}' escapes plugin cache root: '$resolvedPath'."
+    }
+    return resolvedPath
+}
+
+private fun toPomSiblingPath(artifactPath: Path): Path? {
+    val fileName = artifactPath.fileName?.toString() ?: return null
+    val extensionSeparator = fileName.lastIndexOf('.')
+    if (extensionSeparator <= 0) {
+        return null
+    }
+    val pomName = fileName.substring(0, extensionSeparator) + ".pom"
+    return artifactPath.resolveSibling(pomName).toAbsolutePath().normalize()
 }
 
 private fun toRemoteArtifactLockKey(coordinate: Coordinate, localRepositoryRoot: Path, artifactPath: Path): String {
-    require(artifactPath.startsWith(localRepositoryRoot)) {
+    val normalizedArtifactPath = artifactPath.toAbsolutePath().normalize()
+    require(normalizedArtifactPath.startsWith(localRepositoryRoot)) {
         "Resolved artifact for plugin '${coordinate.value}' escapes plugin cache root: '$artifactPath'."
     }
-    return localRepositoryRoot.relativize(artifactPath).toString().replace('\\', '/')
+    return localRepositoryRoot.relativize(normalizedArtifactPath).toString().replace('\\', '/')
 }
 
 private fun Artifact.matchesCoordinate(coordinate: Coordinate): Boolean =

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginChecksumAllowlist.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginChecksumAllowlist.kt
@@ -66,7 +66,7 @@ private fun parseAllowlistEntry(line: String): LockEntry {
     val kind = parts[0]
     val key = parts[1]
     val checksum = parts[2]
-    require(kind == REMOTE_KIND || kind == LOCAL_KIND) {
+    require(kind == REMOTE_KIND || kind == REMOTE_ARTIFACT_KIND || kind == LOCAL_KIND) {
         "Invalid plugin allowlist entry kind '$kind'."
     }
     require(key.isNotBlank()) { "Plugin allowlist entry key must not be blank." }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginLockfile.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginLockfile.kt
@@ -4,7 +4,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 private const val LOCKFILE_ENTRY_PARTS = 3
-private val SUPPORTED_LOCKFILE_VERSIONS = setOf(LOCKFILE_VERSION_V1, LOCKFILE_VERSION)
 
 internal fun readLockfile(lockfilePath: Path): ParsedLockfile? {
     if (!Files.exists(lockfilePath)) {
@@ -21,15 +20,14 @@ internal fun readLockfile(lockfilePath: Path): ParsedLockfile? {
         "Plugin lockfile '$lockfilePath' is invalid. Missing version line."
     }
     val version = versionLine.substringAfter("version=").toIntOrNull()
-    require(version != null && version in SUPPORTED_LOCKFILE_VERSIONS) {
-        "Plugin lockfile '$lockfilePath' has unsupported version '$version'. " +
-            "Expected one of: ${SUPPORTED_LOCKFILE_VERSIONS.sorted().joinToString()}."
+    require(version == LOCKFILE_VERSION) {
+        "Plugin lockfile '$lockfilePath' has unsupported version '$version'. Expected '$LOCKFILE_VERSION'."
     }
 
     val entries =
         nonBlankLines
             .drop(1)
-            .map { line -> parseLockEntry(line = line, version = version) }
+            .map(::parseLockEntry)
             .distinctBy { it.kind to it.key }
 
     return ParsedLockfile(version = version, entries = entries)
@@ -60,10 +58,6 @@ internal fun ParsedLockfile.assertSamePluginSet(requestedKeys: Set<LockKey>, loc
 }
 
 internal fun ParsedLockfile.assertSameRemoteArtifactSet(resolvedKeys: Set<String>, lockfilePath: Path) {
-    if (version < LOCKFILE_VERSION) {
-        return
-    }
-
     val lockedKeys =
         entries
             .asSequence()
@@ -113,7 +107,7 @@ internal fun writeLockfile(lockfilePath: Path, lockfile: ParsedLockfile) {
     Files.write(lockfilePath, lines)
 }
 
-private fun parseLockEntry(line: String, version: Int): LockEntry {
+private fun parseLockEntry(line: String): LockEntry {
     val parts = line.split('|')
     require(parts.size == LOCKFILE_ENTRY_PARTS) {
         "Invalid plugin lockfile entry '$line'. Expected <kind>|<key>|<sha256>."
@@ -122,11 +116,7 @@ private fun parseLockEntry(line: String, version: Int): LockEntry {
     val kind = parts[0]
     val key = parts[1]
     val checksum = parts[2]
-    val allowedKinds =
-        when {
-            version >= LOCKFILE_VERSION -> setOf(REMOTE_KIND, REMOTE_ARTIFACT_KIND, LOCAL_KIND)
-            else -> setOf(REMOTE_KIND, LOCAL_KIND)
-        }
+    val allowedKinds = setOf(REMOTE_KIND, REMOTE_ARTIFACT_KIND, LOCAL_KIND)
     require(kind in allowedKinds) {
         "Invalid plugin lockfile entry kind '$kind'."
     }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginLockfile.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginLockfile.kt
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 private const val LOCKFILE_ENTRY_PARTS = 3
+private val SUPPORTED_LOCKFILE_VERSIONS = setOf(LOCKFILE_VERSION_V1, LOCKFILE_VERSION)
 
 internal fun readLockfile(lockfilePath: Path): ParsedLockfile? {
     if (!Files.exists(lockfilePath)) {
@@ -20,21 +21,27 @@ internal fun readLockfile(lockfilePath: Path): ParsedLockfile? {
         "Plugin lockfile '$lockfilePath' is invalid. Missing version line."
     }
     val version = versionLine.substringAfter("version=").toIntOrNull()
-    require(version == LOCKFILE_VERSION) {
-        "Plugin lockfile '$lockfilePath' has unsupported version '$version'. Expected '$LOCKFILE_VERSION'."
+    require(version != null && version in SUPPORTED_LOCKFILE_VERSIONS) {
+        "Plugin lockfile '$lockfilePath' has unsupported version '$version'. " +
+            "Expected one of: ${SUPPORTED_LOCKFILE_VERSIONS.sorted().joinToString()}."
     }
 
     val entries =
         nonBlankLines
             .drop(1)
-            .map(::parseLockEntry)
+            .map { line -> parseLockEntry(line = line, version = version) }
             .distinctBy { it.kind to it.key }
 
     return ParsedLockfile(version = version, entries = entries)
 }
 
 internal fun ParsedLockfile.assertSamePluginSet(requestedKeys: Set<LockKey>, lockfilePath: Path) {
-    val lockedKeys = entries.map { LockKey(kind = it.kind, key = it.key) }.toSet()
+    val lockedKeys =
+        entries
+            .asSequence()
+            .filter(::isRequestedPluginEntry)
+            .map { entry -> LockKey(kind = entry.kind, key = entry.key) }
+            .toSet()
     val missingFromLock = requestedKeys - lockedKeys
     val extraInLock = lockedKeys - requestedKeys
 
@@ -48,6 +55,34 @@ internal fun ParsedLockfile.assertSamePluginSet(requestedKeys: Set<LockKey>, loc
                 append(" Not requested by CLI: ${extraInLock.joinToString { "${it.kind}:${it.key}" }}.")
             }
             append(" Update plugin flags or regenerate the lockfile.")
+        }
+    }
+}
+
+internal fun ParsedLockfile.assertSameRemoteArtifactSet(resolvedKeys: Set<String>, lockfilePath: Path) {
+    if (version < LOCKFILE_VERSION) {
+        return
+    }
+
+    val lockedKeys =
+        entries
+            .asSequence()
+            .filter { entry -> entry.kind == REMOTE_ARTIFACT_KIND }
+            .map(LockEntry::key)
+            .toSet()
+    val missingFromLock = resolvedKeys - lockedKeys
+    val extraInLock = lockedKeys - resolvedKeys
+
+    require(missingFromLock.isEmpty() && extraInLock.isEmpty()) {
+        buildString {
+            append("Resolved remote dependency graph does not match lockfile '$lockfilePath'.")
+            if (missingFromLock.isNotEmpty()) {
+                append(" Missing from lockfile: ${missingFromLock.sorted().joinToString()}.")
+            }
+            if (extraInLock.isNotEmpty()) {
+                append(" Not present in resolved graph: ${extraInLock.sorted().joinToString()}.")
+            }
+            append(" Regenerate the lockfile after reviewing dependency changes.")
         }
     }
 }
@@ -78,7 +113,7 @@ internal fun writeLockfile(lockfilePath: Path, lockfile: ParsedLockfile) {
     Files.write(lockfilePath, lines)
 }
 
-private fun parseLockEntry(line: String): LockEntry {
+private fun parseLockEntry(line: String, version: Int): LockEntry {
     val parts = line.split('|')
     require(parts.size == LOCKFILE_ENTRY_PARTS) {
         "Invalid plugin lockfile entry '$line'. Expected <kind>|<key>|<sha256>."
@@ -87,7 +122,12 @@ private fun parseLockEntry(line: String): LockEntry {
     val kind = parts[0]
     val key = parts[1]
     val checksum = parts[2]
-    require(kind == REMOTE_KIND || kind == LOCAL_KIND) {
+    val allowedKinds =
+        when {
+            version >= LOCKFILE_VERSION -> setOf(REMOTE_KIND, REMOTE_ARTIFACT_KIND, LOCAL_KIND)
+            else -> setOf(REMOTE_KIND, LOCAL_KIND)
+        }
+    require(kind in allowedKinds) {
         "Invalid plugin lockfile entry kind '$kind'."
     }
     require(key.isNotBlank()) { "Plugin lockfile entry key must not be blank." }
@@ -97,3 +137,5 @@ private fun parseLockEntry(line: String): LockEntry {
 
     return LockEntry(kind = kind, key = key, checksum = checksum)
 }
+
+private fun isRequestedPluginEntry(entry: LockEntry): Boolean = entry.kind == REMOTE_KIND || entry.kind == LOCAL_KIND

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionModel.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionModel.kt
@@ -4,9 +4,11 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
 
-internal const val LOCKFILE_VERSION = 1
+internal const val LOCKFILE_VERSION = 2
+internal const val LOCKFILE_VERSION_V1 = 1
 internal const val MAVEN_CENTRAL_REPOSITORY = "https://repo1.maven.org/maven2"
 internal const val REMOTE_KIND = "remote"
+internal const val REMOTE_ARTIFACT_KIND = "remote-artifact"
 internal const val LOCAL_KIND = "local"
 private const val COORDINATE_PART_COUNT = 3
 private const val HEX_SHA256_LENGTH = 64

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionModel.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionModel.kt
@@ -5,7 +5,6 @@ import java.nio.file.Path
 import java.security.MessageDigest
 
 internal const val LOCKFILE_VERSION = 2
-internal const val LOCKFILE_VERSION_V1 = 1
 internal const val MAVEN_CENTRAL_REPOSITORY = "https://repo1.maven.org/maven2"
 internal const val REMOTE_KIND = "remote"
 internal const val REMOTE_ARTIFACT_KIND = "remote-artifact"

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -87,10 +87,12 @@ private fun resolvePluginsOrThrow(
             checksumAllowlist = context.checksumAllowlist,
         )
 
-    context.lockfile?.assertSameRemoteArtifactSet(
-        remoteResolution.remoteArtifactChecksums.keys.toSet(),
-        context.lockfilePath,
-    )
+    withLockfileDiagnostics {
+        context.lockfile?.assertSameRemoteArtifactSet(
+            remoteResolution.remoteArtifactChecksums.keys.toSet(),
+            context.lockfilePath,
+        )
+    }
 
     val lockEntries =
         buildList {
@@ -125,11 +127,11 @@ private fun buildResolutionContext(
     localPluginJars: List<LocalPluginJar>,
 ): ResolutionContext {
     val lockfilePath = settings.lockfilePathOverride ?: defaultLockfilePath(command.script)
-    val lockfile = readLockfile(lockfilePath)
+    val lockfile = withLockfileDiagnostics { readLockfile(lockfilePath) }
     val checksumAllowlist = settings.checksumAllowlist ?: loadPluginChecksumAllowlistFromEnvironment()
     val requestedLockKeys = buildRequestedLockKeys(coordinates, localPluginJars.map(LocalPluginJar::lockKey))
     checksumAllowlist?.assertCovers(requestedLockKeys)
-    lockfile?.assertSamePluginSet(requestedLockKeys, lockfilePath)
+    withLockfileDiagnostics { lockfile?.assertSamePluginSet(requestedLockKeys, lockfilePath) }
 
     val cacheDirectory = settings.cacheDirectory.toAbsolutePath().normalize()
     if (command.offline && coordinates.isNotEmpty()) {
@@ -189,7 +191,9 @@ private fun resolveRemotePlugins(
                 offline = command.offline,
             )
         val rootChecksum = sha256(resolvedRemotePlugin.rootArtifactPath)
-        context.lockfile?.verifyChecksum(REMOTE_KIND, coordinate.value, rootChecksum)
+        withLockfileDiagnostics {
+            context.lockfile?.verifyChecksum(REMOTE_KIND, coordinate.value, rootChecksum)
+        }
         context.checksumAllowlist?.verifyChecksum(REMOTE_KIND, coordinate.value, rootChecksum)
         rootRemoteLockEntries.add(LockEntry(kind = REMOTE_KIND, key = coordinate.value, checksum = rootChecksum))
         mergeRemoteArtifactChecksums(
@@ -216,7 +220,9 @@ private fun mergeRemoteArtifactChecksums(
 ) {
     artifacts.forEach { artifact ->
         val checksum = sha256(artifact.artifactPath)
-        lockfile?.verifyChecksum(REMOTE_ARTIFACT_KIND, artifact.lockKey, checksum)
+        withLockfileDiagnostics {
+            lockfile?.verifyChecksum(REMOTE_ARTIFACT_KIND, artifact.lockKey, checksum)
+        }
         checksumAllowlist?.verifyChecksum(REMOTE_ARTIFACT_KIND, artifact.lockKey, checksum)
         val previous = checksums.putIfAbsent(artifact.lockKey, checksum)
         require(previous == null || previous == checksum) {
@@ -235,7 +241,9 @@ private fun resolveLocalPlugins(
 
     localPluginJars.forEach { localJar ->
         val checksum = sha256(localJar.artifactPath)
-        lockfile?.verifyChecksum(LOCAL_KIND, localJar.lockKey, checksum)
+        withLockfileDiagnostics {
+            lockfile?.verifyChecksum(LOCAL_KIND, localJar.lockKey, checksum)
+        }
         checksumAllowlist?.verifyChecksum(LOCAL_KIND, localJar.lockKey, checksum)
         lockEntries.add(LockEntry(kind = LOCAL_KIND, key = localJar.lockKey, checksum = checksum))
         classpath.add(localJar.artifactPath)
@@ -318,6 +326,16 @@ private fun resolveAndValidateLocalPluginJars(pluginJars: Set<Path>): List<Local
         }
     }
     return localPluginJars
+}
+
+private inline fun <T> withLockfileDiagnostics(block: () -> T): T = try {
+    block()
+} catch (error: IllegalArgumentException) {
+    throw PluginResolutionDiagnosticException(
+        category = PluginResolverErrorCategory.LOCKFILE,
+        message = error.message ?: "Plugin lockfile validation failed.",
+        cause = error,
+    )
 }
 
 private fun Throwable.toResolutionDiagnostic(sensitiveValues: Set<String>): String = when (this) {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -63,13 +63,67 @@ private fun resolvePluginsOrThrow(
     }
 
     val coordinates = command.plugins.toList().sorted().map(::parseCoordinate)
-    val localPluginJars = resolveLocalPluginJars(command.pluginJars)
-    localPluginJars.forEach { localJar ->
-        require(Files.exists(localJar.artifactPath) && Files.isRegularFile(localJar.artifactPath)) {
-            "Plugin jar '${localJar.artifactPath}' does not exist or is not a file."
-        }
+    val localPluginJars = resolveAndValidateLocalPluginJars(command.pluginJars)
+    val context =
+        buildResolutionContext(
+            command = command,
+            settings = settings,
+            coordinates = coordinates,
+            localPluginJars = localPluginJars,
+        )
+    Files.createDirectories(context.cacheDirectory)
+
+    val remoteResolution =
+        resolveRemotePlugins(
+            coordinates = coordinates,
+            command = command,
+            context = context,
+            settings = settings,
+        )
+    val localResolution =
+        resolveLocalPlugins(
+            localPluginJars = localPluginJars,
+            lockfile = context.lockfile,
+            checksumAllowlist = context.checksumAllowlist,
+        )
+
+    context.lockfile?.assertSameRemoteArtifactSet(
+        remoteResolution.remoteArtifactChecksums.keys.toSet(),
+        context.lockfilePath,
+    )
+
+    val lockEntries =
+        buildList {
+            addAll(remoteResolution.rootRemoteLockEntries)
+            addAll(remoteResolution.remoteArtifactChecksums.toLockEntries())
+            addAll(localResolution.lockEntries)
+        }.sortedWith(compareBy(LockEntry::kind, LockEntry::key))
+
+    context.checksumAllowlist?.assertCovers(lockEntries.toLockKeys())
+
+    if (context.lockfile == null || context.lockfile.version < LOCKFILE_VERSION) {
+        writeLockfile(
+            lockfilePath = context.lockfilePath,
+            lockfile =
+            ParsedLockfile(
+                version = LOCKFILE_VERSION,
+                entries = lockEntries,
+            ),
+        )
     }
 
+    return PluginResolutionResult.Success(
+        classpath = normalizeClasspath(remoteResolution.classpath + localResolution.classpath),
+        lockfilePath = context.lockfilePath,
+    )
+}
+
+private fun buildResolutionContext(
+    command: RunCommand,
+    settings: PluginResolverSettings,
+    coordinates: List<Coordinate>,
+    localPluginJars: List<LocalPluginJar>,
+): ResolutionContext {
     val lockfilePath = settings.lockfilePathOverride ?: defaultLockfilePath(command.script)
     val lockfile = readLockfile(lockfilePath)
     val checksumAllowlist = settings.checksumAllowlist ?: loadPluginChecksumAllowlistFromEnvironment()
@@ -77,41 +131,107 @@ private fun resolvePluginsOrThrow(
     checksumAllowlist?.assertCovers(requestedLockKeys)
     lockfile?.assertSamePluginSet(requestedLockKeys, lockfilePath)
 
-    val repositories =
-        if (coordinates.isEmpty()) {
-            emptyList()
-        } else {
-            try {
-                val repositoryPolicy = settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy()
-                resolveRepositoryEndpoints(command, settings, repositoryPolicy, settings.repositoryCredentialsResolver)
-            } catch (error: IllegalArgumentException) {
-                throw PluginResolutionDiagnosticException(
-                    category = PluginResolverErrorCategory.REPOSITORY_POLICY,
-                    message = error.message ?: "Repository configuration was rejected by policy.",
-                    cause = error,
-                )
-            }
-        }
     val cacheDirectory = settings.cacheDirectory.toAbsolutePath().normalize()
-    Files.createDirectories(cacheDirectory)
+    if (command.offline && coordinates.isNotEmpty()) {
+        assertOfflineGraphReadiness(
+            lockfile = lockfile,
+            lockfilePath = lockfilePath,
+            cacheRoot = pluginArtifactCacheRoot(cacheDirectory),
+        )
+    }
 
+    return ResolutionContext(
+        lockfilePath = lockfilePath,
+        lockfile = lockfile,
+        checksumAllowlist = checksumAllowlist,
+        cacheDirectory = cacheDirectory,
+        repositories = resolveRepositoryEndpointsForCommand(command, settings, coordinates),
+    )
+}
+
+private fun resolveRepositoryEndpointsForCommand(
+    command: RunCommand,
+    settings: PluginResolverSettings,
+    coordinates: List<Coordinate>,
+): List<RepositoryEndpoint> {
+    if (coordinates.isEmpty()) {
+        return emptyList()
+    }
+
+    return try {
+        val repositoryPolicy = settings.repositoryPolicy ?: defaultRepositoryAllowlistPolicy()
+        resolveRepositoryEndpoints(command, settings, repositoryPolicy, settings.repositoryCredentialsResolver)
+    } catch (error: IllegalArgumentException) {
+        throw PluginResolutionDiagnosticException(
+            category = PluginResolverErrorCategory.REPOSITORY_POLICY,
+            message = error.message ?: "Repository configuration was rejected by policy.",
+            cause = error,
+        )
+    }
+}
+
+private fun resolveRemotePlugins(
+    coordinates: List<Coordinate>,
+    command: RunCommand,
+    context: ResolutionContext,
+    settings: PluginResolverSettings,
+): RemoteResolutionSummary {
     val classpath = mutableListOf<Path>()
-    val lockEntries = mutableListOf<LockEntry>()
+    val rootRemoteLockEntries = mutableListOf<LockEntry>()
+    val remoteArtifactChecksums = linkedMapOf<String, String>()
 
     coordinates.forEach { coordinate ->
         val resolvedRemotePlugin =
             settings.remotePluginResolver.resolve(
                 coordinate = coordinate,
-                repositories = repositories,
-                cacheDirectory = cacheDirectory,
+                repositories = context.repositories,
+                cacheDirectory = context.cacheDirectory,
                 offline = command.offline,
             )
-        val checksum = sha256(resolvedRemotePlugin.rootArtifactPath)
-        lockfile?.verifyChecksum(REMOTE_KIND, coordinate.value, checksum)
-        checksumAllowlist?.verifyChecksum(REMOTE_KIND, coordinate.value, checksum)
-        lockEntries.add(LockEntry(kind = REMOTE_KIND, key = coordinate.value, checksum = checksum))
+        val rootChecksum = sha256(resolvedRemotePlugin.rootArtifactPath)
+        context.lockfile?.verifyChecksum(REMOTE_KIND, coordinate.value, rootChecksum)
+        context.checksumAllowlist?.verifyChecksum(REMOTE_KIND, coordinate.value, rootChecksum)
+        rootRemoteLockEntries.add(LockEntry(kind = REMOTE_KIND, key = coordinate.value, checksum = rootChecksum))
+        mergeRemoteArtifactChecksums(
+            checksums = remoteArtifactChecksums,
+            artifacts = resolvedRemotePlugin.artifacts,
+            lockfile = context.lockfile,
+            checksumAllowlist = context.checksumAllowlist,
+        )
         classpath.addAll(resolvedRemotePlugin.classpath)
     }
+
+    return RemoteResolutionSummary(
+        classpath = classpath,
+        rootRemoteLockEntries = rootRemoteLockEntries,
+        remoteArtifactChecksums = remoteArtifactChecksums,
+    )
+}
+
+private fun mergeRemoteArtifactChecksums(
+    checksums: MutableMap<String, String>,
+    artifacts: List<ResolvedRemoteArtifact>,
+    lockfile: ParsedLockfile?,
+    checksumAllowlist: PluginChecksumAllowlist?,
+) {
+    artifacts.forEach { artifact ->
+        val checksum = sha256(artifact.artifactPath)
+        lockfile?.verifyChecksum(REMOTE_ARTIFACT_KIND, artifact.lockKey, checksum)
+        checksumAllowlist?.verifyChecksum(REMOTE_ARTIFACT_KIND, artifact.lockKey, checksum)
+        val previous = checksums.putIfAbsent(artifact.lockKey, checksum)
+        require(previous == null || previous == checksum) {
+            "Resolved remote artifact '${artifact.lockKey}' produced inconsistent checksums."
+        }
+    }
+}
+
+private fun resolveLocalPlugins(
+    localPluginJars: List<LocalPluginJar>,
+    lockfile: ParsedLockfile?,
+    checksumAllowlist: PluginChecksumAllowlist?,
+): LocalResolutionSummary {
+    val classpath = mutableListOf<Path>()
+    val lockEntries = mutableListOf<LockEntry>()
 
     localPluginJars.forEach { localJar ->
         val checksum = sha256(localJar.artifactPath)
@@ -121,21 +241,7 @@ private fun resolvePluginsOrThrow(
         classpath.add(localJar.artifactPath)
     }
 
-    if (lockfile == null) {
-        writeLockfile(
-            lockfilePath = lockfilePath,
-            lockfile =
-            ParsedLockfile(
-                version = LOCKFILE_VERSION,
-                entries = lockEntries.sortedWith(compareBy(LockEntry::kind, LockEntry::key)),
-            ),
-        )
-    }
-
-    return PluginResolutionResult.Success(
-        classpath = normalizeClasspath(classpath),
-        lockfilePath = lockfilePath,
-    )
+    return LocalResolutionSummary(classpath = classpath, lockEntries = lockEntries)
 }
 
 private fun buildRequestedLockKeys(coordinates: List<Coordinate>, localPluginLockKeys: List<String>): Set<LockKey> {
@@ -143,6 +249,57 @@ private fun buildRequestedLockKeys(coordinates: List<Coordinate>, localPluginLoc
     val localKeys = localPluginLockKeys.map { lockKey -> LockKey(kind = LOCAL_KIND, key = lockKey) }
     return (remoteKeys + localKeys).toSet()
 }
+
+private fun assertOfflineGraphReadiness(lockfile: ParsedLockfile?, lockfilePath: Path, cacheRoot: Path) {
+    val errorMessage =
+        when {
+            lockfile == null ->
+                "Offline mode requires a plugin lockfile. Generate '$lockfilePath' by running once without --offline."
+
+            lockfile.version < LOCKFILE_VERSION ->
+                "Offline mode requires lockfile version $LOCKFILE_VERSION for full dependency-graph validation. " +
+                    "Regenerate '$lockfilePath' by running once without --offline."
+
+            else -> {
+                val remoteArtifactEntries = lockfile.entries.filter { entry -> entry.kind == REMOTE_ARTIFACT_KIND }
+                when {
+                    remoteArtifactEntries.isEmpty() ->
+                        "Offline mode requires locked remote dependency graph entries in '$lockfilePath'. " +
+                            "Regenerate the lockfile by running once without --offline."
+
+                    else -> {
+                        val missingArtifacts = findMissingOfflineArtifacts(remoteArtifactEntries, cacheRoot)
+                        if (missingArtifacts.isNotEmpty()) {
+                            "Offline mode is enabled but plugin cache is missing locked dependency graph artifacts: " +
+                                missingArtifacts.sorted().joinToString(", ") +
+                                ". Run once without --offline to restore the cache."
+                        } else {
+                            null
+                        }
+                    }
+                }
+            }
+        }
+
+    if (errorMessage != null) {
+        failOfflineCacheReadiness(errorMessage)
+    }
+}
+
+private fun findMissingOfflineArtifacts(entries: List<LockEntry>, cacheRoot: Path): List<String> = entries
+    .map { entry -> entry.key to cacheRoot.resolve(entry.key).normalize() }
+    .mapNotNull { (key, path) ->
+        when {
+            !path.startsWith(cacheRoot) -> key
+            !Files.exists(path) || !Files.isRegularFile(path) -> key
+            else -> null
+        }
+    }
+
+private fun failOfflineCacheReadiness(message: String): Nothing = throw PluginResolutionDiagnosticException(
+    category = PluginResolverErrorCategory.OFFLINE_CACHE_MISS,
+    message = message,
+)
 
 private fun localPluginLockKey(pluginJarPath: Path): String = pluginJarPath
     .normalize()
@@ -157,6 +314,16 @@ private fun resolveLocalPluginJars(pluginJars: Set<Path>): List<LocalPluginJar> 
         )
     }.sortedBy(LocalPluginJar::lockKey)
 
+private fun resolveAndValidateLocalPluginJars(pluginJars: Set<Path>): List<LocalPluginJar> {
+    val localPluginJars = resolveLocalPluginJars(pluginJars)
+    localPluginJars.forEach { localJar ->
+        require(Files.exists(localJar.artifactPath) && Files.isRegularFile(localJar.artifactPath)) {
+            "Plugin jar '${localJar.artifactPath}' does not exist or is not a file."
+        }
+    }
+    return localPluginJars
+}
+
 private fun Throwable.toResolutionDiagnostic(sensitiveValues: Set<String>): String = when (this) {
     is PluginResolutionDiagnosticException ->
         "[${category.code}] ${(message ?: "plugin resolution failed").redactSensitiveValues(sensitiveValues)}"
@@ -170,5 +337,29 @@ private fun Throwable.toResolutionDiagnostic(sensitiveValues: Set<String>): Stri
 private fun normalizeClasspath(rawClasspath: List<Path>): List<Path> = rawClasspath
     .map { it.toAbsolutePath().normalize() }
     .distinct()
+
+private fun Map<String, String>.toLockEntries(): List<LockEntry> = entries.map { (key, checksum) ->
+    LockEntry(kind = REMOTE_ARTIFACT_KIND, key = key, checksum = checksum)
+}
+
+private fun List<LockEntry>.toLockKeys(): Set<LockKey> = map { entry ->
+    LockKey(kind = entry.kind, key = entry.key)
+}.toSet()
+
+private data class ResolutionContext(
+    val lockfilePath: Path,
+    val lockfile: ParsedLockfile?,
+    val checksumAllowlist: PluginChecksumAllowlist?,
+    val cacheDirectory: Path,
+    val repositories: List<RepositoryEndpoint>,
+)
+
+private data class RemoteResolutionSummary(
+    val classpath: List<Path>,
+    val rootRemoteLockEntries: List<LockEntry>,
+    val remoteArtifactChecksums: Map<String, String>,
+)
+
+private data class LocalResolutionSummary(val classpath: List<Path>, val lockEntries: List<LockEntry>)
 
 private data class LocalPluginJar(val artifactPath: Path, val lockKey: String)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -101,7 +101,7 @@ private fun resolvePluginsOrThrow(
 
     context.checksumAllowlist?.assertCovers(lockEntries.toLockKeys())
 
-    if (context.lockfile == null || context.lockfile.version < LOCKFILE_VERSION) {
+    if (context.lockfile == null) {
         writeLockfile(
             lockfilePath = context.lockfilePath,
             lockfile =
@@ -255,10 +255,6 @@ private fun assertOfflineGraphReadiness(lockfile: ParsedLockfile?, lockfilePath:
         when {
             lockfile == null ->
                 "Offline mode requires a plugin lockfile. Generate '$lockfilePath' by running once without --offline."
-
-            lockfile.version < LOCKFILE_VERSION ->
-                "Offline mode requires lockfile version $LOCKFILE_VERSION for full dependency-graph validation. " +
-                    "Regenerate '$lockfilePath' by running once without --offline."
 
             else -> {
                 val remoteArtifactEntries = lockfile.entries.filter { entry -> entry.kind == REMOTE_ARTIFACT_KIND }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
@@ -1,0 +1,242 @@
+package me.liam.microsmith.cli.plugins
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeTypeOf
+import me.liam.microsmith.cli.command.RunCommand
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.readLines
+import kotlin.io.path.writeBytes
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class PluginResolverLockingTests :
+    StringSpec({
+        "migrates existing v1 lockfile to graph-aware v2 format" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-lockfile-migration")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val rootCoordinate = "com.acme:plugin-root:1.0.0"
+                val transitiveCoordinate = "com.acme:plugin-shared:2.1.0"
+                publishMavenArtifact(repositoryRoot, transitiveCoordinate)
+                publishMavenArtifact(repositoryRoot, rootCoordinate, dependencies = listOf(transitiveCoordinate))
+                script.writeText("// test script")
+
+                val v1LockfilePath = defaultLockfilePath(script)
+                val rootJar = repositoryRoot.resolve(parseCoordinate(rootCoordinate).relativeJarPath)
+                v1LockfilePath.writeText(
+                    """
+                    version=1
+                    remote|$rootCoordinate|${sha256(rootJar)}
+                    """.trimIndent(),
+                )
+
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(rootCoordinate),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = cache,
+                        repositoryPolicy = fileRepositoryAllowedPolicy(),
+                    )
+
+                val success =
+                    resolvePlugins(command = command, settings = settings)
+                        .shouldBeTypeOf<PluginResolutionResult.Success>()
+                val lockfilePath = requireNotNull(success.lockfilePath)
+                val lockContents = lockfilePath.readLines().joinToString("\n")
+                lockContents.shouldContain("version=2")
+                lockContents.shouldContain("remote|$rootCoordinate|")
+                lockContents.shouldContain("remote-artifact|${parseCoordinate(rootCoordinate).relativeJarPath}|")
+                lockContents.shouldContain("remote-artifact|${parseCoordinate(transitiveCoordinate).relativeJarPath}|")
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "fails offline when lockfile is v1 and cannot validate full graph" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-offline-v1-lock")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val coordinate = "com.acme:offline-lock:1.0.0"
+                publishMavenArtifact(repositoryRoot, coordinate)
+                script.writeText("// test script")
+
+                val lockfilePath = defaultLockfilePath(script)
+                val rootJar = repositoryRoot.resolve(parseCoordinate(coordinate).relativeJarPath)
+                lockfilePath.writeText(
+                    """
+                    version=1
+                    remote|$coordinate|${sha256(rootJar)}
+                    """.trimIndent(),
+                )
+
+                val result =
+                    resolvePlugins(
+                        command =
+                        RunCommand(
+                            script = script,
+                            outputDir = tempDir.resolve("generated"),
+                            plugins = setOf(coordinate),
+                            repositoryOverride = repositoryRoot.toUri().toString(),
+                            offline = true,
+                        ),
+                        settings =
+                        PluginResolverSettings(
+                            cacheDirectory = cache,
+                            repositoryPolicy = fileRepositoryAllowedPolicy(),
+                        ),
+                    )
+
+                val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
+                val message = failure.diagnostics.joinToString("\n")
+                message.shouldContain("[offline-cache-miss]")
+                message.shouldContain("requires lockfile version 2")
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "fails offline when locked transitive artifact is missing from cache" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-offline-graph-missing")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val rootCoordinate = "com.acme:plugin-root:1.0.0"
+                val transitiveCoordinate = "com.acme:plugin-shared:2.1.0"
+                publishMavenArtifact(repositoryRoot, transitiveCoordinate)
+                publishMavenArtifact(repositoryRoot, rootCoordinate, dependencies = listOf(transitiveCoordinate))
+                script.writeText("// test script")
+
+                val baseCommand =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(rootCoordinate),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = cache,
+                        repositoryPolicy = fileRepositoryAllowedPolicy(),
+                    )
+
+                resolvePlugins(command = baseCommand, settings = settings)
+                    .shouldBeTypeOf<PluginResolutionResult.Success>()
+
+                val cachedTransitive =
+                    cachePathFor(pluginArtifactCacheRoot(cache), parseCoordinate(transitiveCoordinate))
+                cachedTransitive.toFile().delete()
+
+                val failure =
+                    resolvePlugins(command = baseCommand.copy(offline = true), settings = settings)
+                        .shouldBeTypeOf<PluginResolutionResult.Failure>()
+                val message = failure.diagnostics.joinToString("\n")
+                message.shouldContain("[offline-cache-miss]")
+                message.shouldContain(parseCoordinate(transitiveCoordinate).relativeJarPath)
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "fails when transitive cached artifact checksum does not match existing lockfile" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-transitive-lock-mismatch")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val rootCoordinate = "com.acme:plugin-root:1.0.0"
+                val transitiveCoordinate = "com.acme:plugin-shared:2.1.0"
+                publishMavenArtifact(repositoryRoot, transitiveCoordinate)
+                publishMavenArtifact(repositoryRoot, rootCoordinate, dependencies = listOf(transitiveCoordinate))
+                script.writeText("// test script")
+
+                val command =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(rootCoordinate),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = cache,
+                        repositoryPolicy = fileRepositoryAllowedPolicy(),
+                    )
+
+                resolvePlugins(command = command, settings = settings)
+                    .shouldBeTypeOf<PluginResolutionResult.Success>()
+
+                val cachedTransitive =
+                    cachePathFor(pluginArtifactCacheRoot(cache), parseCoordinate(transitiveCoordinate))
+                cachedTransitive.writeBytes("tampered-transitive".toByteArray())
+
+                val failure =
+                    resolvePlugins(command = command.copy(offline = true), settings = settings)
+                        .shouldBeTypeOf<PluginResolutionResult.Failure>()
+                val message = failure.diagnostics.joinToString("\n")
+                message.shouldContain("Checksum mismatch for remote-artifact plugin")
+                message.shouldContain(parseCoordinate(transitiveCoordinate).relativeJarPath)
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "fails when plugin checksum allowlist omits transitive remote artifacts" {
+            val tempDir = createTempDirectory("microsmith-plugin-allowlist-transitive-missing")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val rootCoordinate = "com.acme:plugin-root:1.0.0"
+                val transitiveCoordinate = "com.acme:plugin-shared:2.1.0"
+                publishMavenArtifact(repositoryRoot, transitiveCoordinate)
+                publishMavenArtifact(repositoryRoot, rootCoordinate, dependencies = listOf(transitiveCoordinate))
+                script.writeText("// test script")
+
+                val rootJar = repositoryRoot.resolve(parseCoordinate(rootCoordinate).relativeJarPath)
+                val allowlist =
+                    PluginChecksumAllowlist(
+                        entries =
+                        mapOf(
+                            LockKey(kind = REMOTE_KIND, key = rootCoordinate) to sha256(rootJar),
+                        ),
+                    )
+
+                val result =
+                    resolvePlugins(
+                        command =
+                        RunCommand(
+                            script = script,
+                            outputDir = tempDir.resolve("generated"),
+                            plugins = setOf(rootCoordinate),
+                            repositoryOverride = repositoryRoot.toUri().toString(),
+                        ),
+                        settings =
+                        PluginResolverSettings(
+                            cacheDirectory = cache,
+                            repositoryPolicy = fileRepositoryAllowedPolicy(),
+                            checksumAllowlist = allowlist,
+                        ),
+                    )
+
+                val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
+                val message = failure.diagnostics.joinToString("\n")
+                message.shouldContain("Plugin allowlist is missing required entries")
+                message.shouldContain("remote-artifact:${parseCoordinate(transitiveCoordinate).relativeJarPath}")
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
@@ -7,62 +7,13 @@ import me.liam.microsmith.cli.command.RunCommand
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteRecursively
-import kotlin.io.path.readLines
 import kotlin.io.path.writeBytes
 import kotlin.io.path.writeText
 
 @OptIn(ExperimentalPathApi::class)
 class PluginResolverLockingTests :
     StringSpec({
-        "migrates existing v1 lockfile to graph-aware v2 format" {
-            val tempDir = createTempDirectory("microsmith-plugin-resolver-lockfile-migration")
-            try {
-                val script = tempDir.resolve("schema.microsmith.kts")
-                val cache = tempDir.resolve("cache")
-                val repositoryRoot = tempDir.resolve("repo")
-                val rootCoordinate = "com.acme:plugin-root:1.0.0"
-                val transitiveCoordinate = "com.acme:plugin-shared:2.1.0"
-                publishMavenArtifact(repositoryRoot, transitiveCoordinate)
-                publishMavenArtifact(repositoryRoot, rootCoordinate, dependencies = listOf(transitiveCoordinate))
-                script.writeText("// test script")
-
-                val v1LockfilePath = defaultLockfilePath(script)
-                val rootJar = repositoryRoot.resolve(parseCoordinate(rootCoordinate).relativeJarPath)
-                v1LockfilePath.writeText(
-                    """
-                    version=1
-                    remote|$rootCoordinate|${sha256(rootJar)}
-                    """.trimIndent(),
-                )
-
-                val command =
-                    RunCommand(
-                        script = script,
-                        outputDir = tempDir.resolve("generated"),
-                        plugins = setOf(rootCoordinate),
-                        repositoryOverride = repositoryRoot.toUri().toString(),
-                    )
-                val settings =
-                    PluginResolverSettings(
-                        cacheDirectory = cache,
-                        repositoryPolicy = fileRepositoryAllowedPolicy(),
-                    )
-
-                val success =
-                    resolvePlugins(command = command, settings = settings)
-                        .shouldBeTypeOf<PluginResolutionResult.Success>()
-                val lockfilePath = requireNotNull(success.lockfilePath)
-                val lockContents = lockfilePath.readLines().joinToString("\n")
-                lockContents.shouldContain("version=2")
-                lockContents.shouldContain("remote|$rootCoordinate|")
-                lockContents.shouldContain("remote-artifact|${parseCoordinate(rootCoordinate).relativeJarPath}|")
-                lockContents.shouldContain("remote-artifact|${parseCoordinate(transitiveCoordinate).relativeJarPath}|")
-            } finally {
-                runCatching { tempDir.deleteRecursively() }
-            }
-        }
-
-        "fails offline when lockfile is v1 and cannot validate full graph" {
+        "fails when lockfile version is unsupported" {
             val tempDir = createTempDirectory("microsmith-plugin-resolver-offline-v1-lock")
             try {
                 val script = tempDir.resolve("schema.microsmith.kts")
@@ -89,7 +40,6 @@ class PluginResolverLockingTests :
                             outputDir = tempDir.resolve("generated"),
                             plugins = setOf(coordinate),
                             repositoryOverride = repositoryRoot.toUri().toString(),
-                            offline = true,
                         ),
                         settings =
                         PluginResolverSettings(
@@ -100,8 +50,8 @@ class PluginResolverLockingTests :
 
                 val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
                 val message = failure.diagnostics.joinToString("\n")
-                message.shouldContain("[offline-cache-miss]")
-                message.shouldContain("requires lockfile version 2")
+                message.shouldContain("[unexpected]")
+                message.shouldContain("unsupported version '1'")
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
@@ -100,6 +100,52 @@ class PluginResolverLockingTests :
             }
         }
 
+        "fails offline when locked transitive descriptor is missing from cache" {
+            val tempDir = createTempDirectory("microsmith-plugin-resolver-offline-descriptor-missing")
+            try {
+                val script = tempDir.resolve("schema.microsmith.kts")
+                val cache = tempDir.resolve("cache")
+                val repositoryRoot = tempDir.resolve("repo")
+                val rootCoordinate = "com.acme:plugin-root:1.0.0"
+                val transitiveCoordinate = "com.acme:plugin-shared:2.1.0"
+                publishMavenArtifact(repositoryRoot, transitiveCoordinate)
+                publishMavenArtifact(repositoryRoot, rootCoordinate, dependencies = listOf(transitiveCoordinate))
+                script.writeText("// test script")
+
+                val baseCommand =
+                    RunCommand(
+                        script = script,
+                        outputDir = tempDir.resolve("generated"),
+                        plugins = setOf(rootCoordinate),
+                        repositoryOverride = repositoryRoot.toUri().toString(),
+                    )
+                val settings =
+                    PluginResolverSettings(
+                        cacheDirectory = cache,
+                        repositoryPolicy = fileRepositoryAllowedPolicy(),
+                    )
+
+                resolvePlugins(command = baseCommand, settings = settings)
+                    .shouldBeTypeOf<PluginResolutionResult.Success>()
+
+                val parsedTransitive = parseCoordinate(transitiveCoordinate)
+                val cachedTransitiveJar = cachePathFor(pluginArtifactCacheRoot(cache), parsedTransitive)
+                val cachedTransitivePom =
+                    cachedTransitiveJar.resolveSibling("${parsedTransitive.artifact}-${parsedTransitive.version}.pom")
+                cachedTransitivePom.toFile().delete()
+
+                val failure =
+                    resolvePlugins(command = baseCommand.copy(offline = true), settings = settings)
+                        .shouldBeTypeOf<PluginResolutionResult.Failure>()
+                val message = failure.diagnostics.joinToString("\n")
+                val descriptorLockKey = parsedTransitive.relativeJarPath.removeSuffix(".jar") + ".pom"
+                message.shouldContain("[offline-cache-miss]")
+                message.shouldContain(descriptorLockKey)
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
         "fails when transitive cached artifact checksum does not match existing lockfile" {
             val tempDir = createTempDirectory("microsmith-plugin-resolver-transitive-lock-mismatch")
             try {

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverLockingTests.kt
@@ -50,7 +50,7 @@ class PluginResolverLockingTests :
 
                 val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
                 val message = failure.diagnostics.joinToString("\n")
-                message.shouldContain("[unexpected]")
+                message.shouldContain("[lockfile]")
                 message.shouldContain("unsupported version '1'")
             } finally {
                 runCatching { tempDir.deleteRecursively() }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/plugins/PluginResolverTests.kt
@@ -54,8 +54,10 @@ class PluginResolverTests :
                 success.classpath.first().exists() shouldBe true
                 val lockfilePath = requireNotNull(success.lockfilePath)
                 lockfilePath.exists() shouldBe true
-                lockfilePath.readLines().joinToString("\n").shouldContain("version=1")
-                lockfilePath.readLines().joinToString("\n").shouldContain("remote|$coordinate|")
+                val lockContents = lockfilePath.readLines().joinToString("\n")
+                lockContents.shouldContain("version=2")
+                lockContents.shouldContain("remote|$coordinate|")
+                lockContents.shouldContain("remote-artifact|${parseCoordinate(coordinate).relativeJarPath}|")
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }
@@ -95,6 +97,11 @@ class PluginResolverTests :
                 success.classpath.shouldHaveSize(2)
                 success.classpath.map { path -> path.fileName.toString() }.toSet() shouldBe
                     setOf("plugin-root-1.0.0.jar", "plugin-shared-2.1.0.jar")
+                val lockfilePath = requireNotNull(success.lockfilePath)
+                val lockContents = lockfilePath.readLines().joinToString("\n")
+                lockContents.shouldContain("remote|$rootCoordinate|")
+                lockContents.shouldContain("remote-artifact|${parseCoordinate(rootCoordinate).relativeJarPath}|")
+                lockContents.shouldContain("remote-artifact|${parseCoordinate(transitiveCoordinate).relativeJarPath}|")
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }
@@ -207,7 +214,7 @@ class PluginResolverTests :
             }
         }
 
-        "fails with remediation message when offline plugin artifact is missing from cache" {
+        "fails with remediation message when offline mode is used without lockfile metadata" {
             val tempDir = createTempDirectory("microsmith-plugin-resolver-offline")
             try {
                 val script = tempDir.resolve("schema.microsmith.kts")
@@ -228,7 +235,7 @@ class PluginResolverTests :
 
                 val failure = result.shouldBeTypeOf<PluginResolutionResult.Failure>()
                 failure.diagnostics.joinToString("\n").shouldContain("[offline-cache-miss]")
-                failure.diagnostics.joinToString("\n").shouldContain("Offline mode is enabled")
+                failure.diagnostics.joinToString("\n").shouldContain("Offline mode requires a plugin lockfile")
             } finally {
                 runCatching { tempDir.deleteRecursively() }
             }
@@ -699,7 +706,7 @@ class PluginResolverTests :
         }
     })
 
-private fun fileRepositoryAllowedPolicy(vararg additionalAllowedRepositories: String): RepositoryAllowlistPolicy =
+internal fun fileRepositoryAllowedPolicy(vararg additionalAllowedRepositories: String): RepositoryAllowlistPolicy =
     RepositoryAllowlistPolicy(
         allowedRepositories =
         (listOf(MAVEN_CENTRAL_REPOSITORY) + additionalAllowedRepositories)
@@ -708,7 +715,7 @@ private fun fileRepositoryAllowedPolicy(vararg additionalAllowedRepositories: St
         allowFileRepositories = true,
     )
 
-private fun publishMavenArtifact(
+internal fun publishMavenArtifact(
     repositoryRoot: Path,
     coordinate: String,
     dependencies: List<String> = emptyList(),

--- a/docs/cli/quickstart-non-gradle.md
+++ b/docs/cli/quickstart-non-gradle.md
@@ -65,7 +65,7 @@ microsmith run schema.microsmith.kts --out ./generated --offline
 ```
 
 Notes:
-- Run once without `--offline` first to generate/upgrade lockfile metadata and warm the plugin cache.
+- Run once without `--offline` first to generate lockfile metadata and warm the plugin cache.
 - Offline remote plugin resolution requires lockfile v2 and a complete cached dependency graph.
 
 Authenticated private repository (global credentials):

--- a/docs/cli/quickstart-non-gradle.md
+++ b/docs/cli/quickstart-non-gradle.md
@@ -64,6 +64,10 @@ Offline mode:
 microsmith run schema.microsmith.kts --out ./generated --offline
 ```
 
+Notes:
+- Run once without `--offline` first to generate/upgrade lockfile metadata and warm the plugin cache.
+- Offline remote plugin resolution requires lockfile v2 and a complete cached dependency graph.
+
 Authenticated private repository (global credentials):
 
 ```bash

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -49,7 +49,7 @@ Symptom:
 
 Actions:
 - ensure lockfile metadata exists and is on version 2
-- run once online to prime cache and upgrade lock metadata when needed
+- run once online to prime cache and generate lock metadata when missing
 - ensure the full locked dependency graph exists in plugin cache directory
 - rerun with `--offline` after cache warmup
 

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -27,6 +27,7 @@ Symptom:
 - plugin coordinate cannot be resolved
 - repository URI rejected
 - checksum mismatch
+- lockfile validation errors (`[lockfile]`)
 - authentication errors (`[authentication]`)
 - repository policy blocks (`[repository-policy]`)
 
@@ -39,6 +40,7 @@ Actions:
   - `MICROSMITH_GITHUB_PACKAGES_USER` + `MICROSMITH_GITHUB_PACKAGES_TOKEN`
     (fallback: `GITHUB_ACTOR` + `GITHUB_TOKEN`)
 - update or regenerate lock/checksum metadata when plugin versions change
+- if lockfile diagnostics are reported, regenerate lock metadata with a non-offline run
 - for strict allowlist mode, include transitive graph entries (`remote-artifact|<cache-relative-path>|<sha256>`) in the allowlist file
 - verify diagnostics do not contain secret material; Microsmith redacts configured tokens/passwords by default
 

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -39,6 +39,7 @@ Actions:
   - `MICROSMITH_GITHUB_PACKAGES_USER` + `MICROSMITH_GITHUB_PACKAGES_TOKEN`
     (fallback: `GITHUB_ACTOR` + `GITHUB_TOKEN`)
 - update or regenerate lock/checksum metadata when plugin versions change
+- for strict allowlist mode, include transitive graph entries (`remote-artifact|<cache-relative-path>|<sha256>`) in the allowlist file
 - verify diagnostics do not contain secret material; Microsmith redacts configured tokens/passwords by default
 
 ## Offline mode failures
@@ -47,8 +48,9 @@ Symptom:
 - `--offline` run cannot resolve plugins
 
 Actions:
-- run once online to prime cache and lock metadata
-- ensure plugin artifacts exist in cache directory
+- ensure lockfile metadata exists and is on version 2
+- run once online to prime cache and upgrade lock metadata when needed
+- ensure the full locked dependency graph exists in plugin cache directory
 - rerun with `--offline` after cache warmup
 
 ## Built-in provider discovery failures


### PR DESCRIPTION
## Summary
Implements issue #47 by upgrading plugin locking/offline behavior to dependency-graph semantics with a single maintained lockfile schema (`version=2`).

## What Changed
- Upgraded plugin lockfile schema to `version=2`.
- Enforced v2-only lockfile support (older versions now fail with deterministic diagnostics).
- Added graph-level lock entries via `remote-artifact|<cache-relative-path>|<sha256>`.
- Enforced offline preflight for remote plugins:
  - requires lockfile metadata
  - requires lockfile v2
  - requires full locked graph to be present in cache
- Extended checksum verification to resolved transitive artifacts.
- Extended checksum allowlist parsing to support `remote-artifact` entries.
- Refactored resolver internals for maintainability and static-analysis compliance.
- Added dedicated locking/offline regression tests, including unsupported lockfile-version coverage.
- Updated docs/help text for the v2-only lockfile/offline and allowlist contracts.

## Validation
- `./gradlew :cli:check :cli:jvmKotest`

## Backward Compatibility
- Plugin locking now supports lockfile `version=2` only.
- Older lockfile versions are rejected with deterministic diagnostics and must be regenerated.

Closes #47
