### PR TITLE
feat(runtime-distribution): bundle common plugins with distribution integrity validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ microsmith run schema.microsmith.kts --out ./generated --isolation process
 - Optional plugin checksum allowlist can be enforced with `MICROSMITH_PLUGIN_ALLOWLIST_FILE`:
   - Entry format: `<kind>|<key>|<sha256>` where `kind` is `remote`, `remote-artifact`, or `local`.
 - `--offline` for remote plugins requires lockfile v2 metadata and a complete cached dependency graph.
+- Official CLI distributions include a pinned bundled plugin profile (`bundled-plugins.lock`) for built-in workflows.
 - Generated output writes are constrained to the configured output root and reject traversal/symlink escapes.
 - Default isolation executes each run in an isolated per-run classloader; `--isolation process` executes in a separate JVM.
 
@@ -205,6 +206,9 @@ Inside .microsmith.kts scripts:
 - Cross-platform distribution archives:
   - `cli/build/distributions/microsmith-cli-<version>-dist.zip`
   - `cli/build/distributions/microsmith-cli-<version>-dist.tar.gz`
+- Distribution metadata:
+  - `cli/build/generated/microsmith/bundled-plugins.lock` (generated bundled plugin catalog, pinned to CLI version)
+  - packaged as `META-INF/microsmith/bundled-plugins.lock` in the fat jar and `bundled-plugins.lock` in dist archives
 - Build them with `./gradlew :cli:distArtifacts`
 
 ### Adoption docs

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -231,6 +231,9 @@ def bundledPluginCatalogText = bundledPluginCatalogLines.join("\n") + "\n"
 
 def generateBundledPluginCatalogTask =
     tasks.register("generateBundledPluginCatalog") {
+        inputs.property("cliVersion", cliVersion)
+        inputs.property("catalogFormatVersion", bundledPluginCatalogFormatVersion)
+        inputs.property("catalogText", bundledPluginCatalogText)
         outputs.file(bundledPluginCatalogOutput)
         doLast {
             def outputFile = bundledPluginCatalogOutput.get().asFile
@@ -259,8 +262,8 @@ tasks.named("shadowJar") {
 
 def shadowJarTask = tasks.named("shadowJar", ShadowJar)
 def shadowJarArchive = shadowJarTask.flatMap { it.archiveFile }
-def shadowJarArchiveName = "microsmith-cli-${cliVersion}-all.jar"
-def distRootName = "microsmith-cli-${cliVersion}"
+def shadowJarArchiveName = "microsmith-cli-${cliVersion}-all.jar".toString()
+def distRootName = "microsmith-cli-${cliVersion}".toString()
 def distDirectory = layout.buildDirectory.dir("microsmith-cli-dist")
 
 tasks.register("verifyShadowJarServices") {
@@ -341,7 +344,7 @@ tasks.register("prepareDist", Sync) {
 
     from("src/dist/launcher/microsmith") {
         into("bin")
-        filter(ReplaceTokens, tokens: [CLI_JAR: shadowJarArchiveName])
+        filter(ReplaceTokens, tokens: [CLI_JAR: shadowJarArchiveName.toString()])
         filePermissions {
             unix("rwxr-xr-x")
         }
@@ -349,7 +352,7 @@ tasks.register("prepareDist", Sync) {
 
     from("src/dist/launcher/microsmith.bat") {
         into("bin")
-        filter(ReplaceTokens, tokens: [CLI_JAR: shadowJarArchiveName])
+        filter(ReplaceTokens, tokens: [CLI_JAR: shadowJarArchiveName.toString()])
     }
 
     from("src/dist/README.txt") {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,8 +1,147 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.tasks.bundling.Compression
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.apache.tools.tar.TarInputStream
 import java.nio.charset.StandardCharsets
+import java.io.FileInputStream
+import java.util.zip.GZIPInputStream
 import java.util.jar.JarFile
+import java.util.zip.ZipFile
+
+class BundledPluginCatalogVerifier {
+    static void validate(
+        String catalogText,
+        String source,
+        int expectedFormatVersion,
+        String expectedCliVersion,
+        List<String> expectedCoordinates,
+        List<Map<String, String>> expectedServiceEntries
+    ) {
+        String formatValue = null
+        String cliVersion = null
+        def pluginCoordinates = []
+        def serviceEntries = []
+
+        catalogText.readLines().eachWithIndex { rawLine, index ->
+            def line = rawLine.trim()
+            if (line.isEmpty() || line.startsWith("#")) {
+                return
+            }
+
+            if (line.startsWith("format=")) {
+                formatValue = line.substring("format=".length())
+            } else if (line.startsWith("cliVersion=")) {
+                cliVersion = line.substring("cliVersion=".length())
+            } else if (line.startsWith("plugin=")) {
+                pluginCoordinates << line.substring("plugin=".length())
+            } else if (line.startsWith("service=")) {
+                def value = line.substring("service=".length())
+                def components = value.split("\\|", 3)
+                if (components.length != 3 || components.any { it.isEmpty() }) {
+                    throw new GradleException(
+                        "Invalid service declaration at ${source}:${index + 1}. Expected " +
+                            "'service=<coordinate>|<service-path>|<provider>'.",
+                    )
+                }
+                serviceEntries <<
+                    [
+                        coordinate : components[0],
+                        servicePath: components[1],
+                        provider   : components[2],
+                    ]
+            } else {
+                throw new GradleException("Unrecognized bundled plugin catalog entry at ${source}:${index + 1}: '${line}'")
+            }
+        }
+
+        if (formatValue != expectedFormatVersion.toString()) {
+            throw new GradleException(
+                "Bundled plugin catalog '${source}' has format '${formatValue}', expected '${expectedFormatVersion}'.",
+            )
+        }
+
+        if (cliVersion != expectedCliVersion) {
+            throw new GradleException(
+                "Bundled plugin catalog '${source}' has cliVersion '${cliVersion}', expected '${expectedCliVersion}'.",
+            )
+        }
+
+        if (pluginCoordinates != expectedCoordinates) {
+            throw new GradleException(
+                "Bundled plugin catalog '${source}' defines coordinates ${pluginCoordinates}, " +
+                    "expected ${expectedCoordinates}.",
+            )
+        }
+
+        def sortedExpectedEntries = sortServiceEntries(expectedServiceEntries)
+        def sortedActualEntries = sortServiceEntries(serviceEntries)
+        if (sortedActualEntries != sortedExpectedEntries) {
+            throw new GradleException(
+                "Bundled plugin catalog '${source}' service declarations do not match expected providers.",
+            )
+        }
+    }
+
+    private static List<Map<String, String>> sortServiceEntries(List<Map<String, String>> entries) {
+        entries
+            .collect { entry ->
+                [
+                    coordinate : entry.coordinate?.toString(),
+                    servicePath: entry.servicePath?.toString(),
+                    provider   : entry.provider?.toString(),
+                ]
+            }.sort { left, right ->
+                compareEntry(left, right)
+            }
+    }
+
+    private static int compareEntry(Map<String, String> left, Map<String, String> right) {
+        int byCoordinate = left.coordinate <=> right.coordinate
+        if (byCoordinate != 0) {
+            return byCoordinate
+        }
+
+        int byServicePath = left.servicePath <=> right.servicePath
+        if (byServicePath != 0) {
+            return byServicePath
+        }
+
+        left.provider <=> right.provider
+    }
+
+    static Set<String> collectZipEntries(File zipArchive) {
+        def entries = [] as Set
+        ZipFile zipFile = new ZipFile(zipArchive)
+        try {
+            def zipEntries = zipFile.entries()
+            while (zipEntries.hasMoreElements()) {
+                def entry = zipEntries.nextElement()
+                if (!entry.isDirectory()) {
+                    entries << entry.getName()
+                }
+            }
+        } finally {
+            zipFile.close()
+        }
+        entries
+    }
+
+    static Set<String> collectTarGzEntries(File tarGzArchive) {
+        def entries = [] as Set
+        TarInputStream tarStream = new TarInputStream(new GZIPInputStream(new FileInputStream(tarGzArchive)))
+        try {
+            def entry
+            while ((entry = tarStream.getNextEntry()) != null) {
+                if (!entry.isDirectory()) {
+                    entries << entry.getName()
+                }
+            }
+        } finally {
+            tarStream.close()
+        }
+        entries
+    }
+}
 
 apply plugin: 'application'
 
@@ -28,6 +167,85 @@ application {
     mainClass = 'me.liam.microsmith.cli.CliKt'
 }
 
+def cliVersion = project.version.toString()
+def bundledPluginCatalogFormatVersion = 1
+def bundledPluginCatalogFileName = "bundled-plugins.lock"
+def bundledPluginCatalogJarPath = "META-INF/microsmith/${bundledPluginCatalogFileName}"
+def bundledPluginCatalogOutput = layout.buildDirectory.file("generated/microsmith/${bundledPluginCatalogFileName}")
+
+def bundledPlugins = [
+    [
+        coordinate: "me.liam.microsmith:gen-schemas:${cliVersion}",
+        providers : [
+            "META-INF/services/me.liam.microsmith.gen.core.ModelGenerator": "me.liam.microsmith.gen.schemas.SchemasGenerator",
+        ],
+    ],
+    [
+        coordinate: "me.liam.microsmith:gen-schemas-protobuf:${cliVersion}",
+        providers : [
+            "META-INF/services/me.liam.microsmith.gen.schemas.SchemaEmitter":
+                "me.liam.microsmith.gen.schemas.protobuf.emission.ProtobufEmitter",
+        ],
+    ],
+]
+
+def expectedServiceProviders =
+    bundledPlugins.collectMany { plugin ->
+        plugin.providers.collect { servicePath, provider ->
+            [
+                coordinate : plugin.coordinate.toString(),
+                servicePath: servicePath.toString(),
+                provider   : provider.toString(),
+            ]
+        }
+    }
+
+def expectedServiceProvidersByDescriptor =
+    expectedServiceProviders.groupBy { it.servicePath }.collectEntries { servicePath, entries ->
+        [servicePath, entries.collect { it.provider }]
+    }
+
+def expectedBundledPluginCoordinates = bundledPlugins.collect { it.coordinate.toString() }
+def expectedBundledServiceEntries =
+    expectedServiceProviders.collect { entry ->
+        [
+            coordinate : entry.coordinate.toString(),
+            servicePath: entry.servicePath.toString(),
+            provider   : entry.provider.toString(),
+        ]
+    }
+
+def bundledPluginCatalogLines = [
+    "# Microsmith bundled plugin profile",
+    "# Plugin coordinates are pinned to the CLI release version for deterministic runtime behavior.",
+    "format=${bundledPluginCatalogFormatVersion}",
+    "cliVersion=${cliVersion}",
+]
+bundledPlugins.each { plugin ->
+    bundledPluginCatalogLines << "plugin=${plugin.coordinate}"
+    plugin.providers.each { servicePath, provider ->
+        bundledPluginCatalogLines << "service=${plugin.coordinate}|${servicePath}|${provider}"
+    }
+}
+def bundledPluginCatalogText = bundledPluginCatalogLines.join("\n") + "\n"
+
+def generateBundledPluginCatalogTask =
+    tasks.register("generateBundledPluginCatalog") {
+        outputs.file(bundledPluginCatalogOutput)
+        doLast {
+            def outputFile = bundledPluginCatalogOutput.get().asFile
+            outputFile.parentFile.mkdirs()
+            outputFile.setText(bundledPluginCatalogText, StandardCharsets.UTF_8.name())
+        }
+    }
+
+tasks.named("processResources") {
+    dependsOn(generateBundledPluginCatalogTask)
+    from(bundledPluginCatalogOutput) {
+        into("META-INF/microsmith")
+    }
+}
+
 tasks.named("shadowJar") {
     archiveBaseName.set("microsmith-cli")
     archiveClassifier.set("all")
@@ -39,24 +257,30 @@ tasks.named("shadowJar") {
     }
 }
 
-def expectedServiceProviders = [
-    "META-INF/services/me.liam.microsmith.gen.core.ModelGenerator" : "me.liam.microsmith.gen.schemas.SchemasGenerator",
-    "META-INF/services/me.liam.microsmith.gen.schemas.SchemaEmitter": "me.liam.microsmith.gen.schemas.protobuf.emission.ProtobufEmitter",
-]
-
 def shadowJarTask = tasks.named("shadowJar", ShadowJar)
 def shadowJarArchive = shadowJarTask.flatMap { it.archiveFile }
-def shadowJarArchiveName = "microsmith-cli-${project.version}-all.jar".toString()
-def distRootName = "microsmith-cli-${project.version}"
+def shadowJarArchiveName = "microsmith-cli-${cliVersion}-all.jar"
+def distRootName = "microsmith-cli-${cliVersion}"
+def distDirectory = layout.buildDirectory.dir("microsmith-cli-dist")
 
 tasks.register("verifyShadowJarServices") {
-    dependsOn(shadowJarTask)
+    dependsOn(shadowJarTask, generateBundledPluginCatalogTask)
     inputs.file(shadowJarArchive)
+    inputs.file(bundledPluginCatalogOutput)
     doLast {
         File shadedJar = shadowJarArchive.get().asFile
+        String expectedCatalogText = bundledPluginCatalogOutput.get().asFile.getText(StandardCharsets.UTF_8.name())
+        BundledPluginCatalogVerifier.validate(
+            expectedCatalogText,
+            bundledPluginCatalogOutput.get().asFile.path,
+            bundledPluginCatalogFormatVersion,
+            cliVersion,
+            expectedBundledPluginCoordinates,
+            expectedBundledServiceEntries,
+        )
         JarFile jarFile = new JarFile(shadedJar)
         try {
-            expectedServiceProviders.each { servicePath, provider ->
+            expectedServiceProvidersByDescriptor.each { servicePath, expectedProviders ->
                 def entry = jarFile.getJarEntry(servicePath)
                 if (entry == null) {
                     throw new GradleException("Missing merged service descriptor '${servicePath}' in ${shadedJar.name}.")
@@ -67,12 +291,36 @@ tasks.register("verifyShadowJarServices") {
                         .readLines()
                         .collect { it.trim() }
                         .findAll { !it.isEmpty() && !it.startsWith("#") }
-                if (!providers.contains(provider)) {
-                    throw new GradleException(
-                        "Service '${servicePath}' is missing expected provider '${provider}' in ${shadedJar.name}.",
-                    )
+                expectedProviders.each { expectedProvider ->
+                    if (!providers.contains(expectedProvider)) {
+                        throw new GradleException(
+                            "Service '${servicePath}' is missing expected provider '${expectedProvider}' in ${shadedJar.name}.",
+                        )
+                    }
                 }
             }
+
+            def catalogEntry = jarFile.getJarEntry(bundledPluginCatalogJarPath)
+            if (catalogEntry == null) {
+                throw new GradleException(
+                    "Missing bundled plugin catalog '${bundledPluginCatalogJarPath}' in ${shadedJar.name}.",
+                )
+            }
+
+            String actualCatalogText = jarFile.getInputStream(catalogEntry).getText(StandardCharsets.UTF_8.name())
+            if (actualCatalogText != expectedCatalogText) {
+                throw new GradleException(
+                    "Bundled plugin catalog in ${shadedJar.name} does not match generated metadata.",
+                )
+            }
+            BundledPluginCatalogVerifier.validate(
+                actualCatalogText,
+                "${shadedJar.name}!/${bundledPluginCatalogJarPath}",
+                bundledPluginCatalogFormatVersion,
+                cliVersion,
+                expectedBundledPluginCoordinates,
+                expectedBundledServiceEntries,
+            )
         } finally {
             jarFile.close()
         }
@@ -84,8 +332,8 @@ tasks.named("check") {
 }
 
 tasks.register("prepareDist", Sync) {
-    dependsOn(shadowJarTask)
-    into(layout.buildDirectory.dir("microsmith-cli-dist"))
+    dependsOn(shadowJarTask, generateBundledPluginCatalogTask)
+    into(distDirectory)
 
     from(shadowJarArchive) {
         into("lib")
@@ -107,15 +355,19 @@ tasks.register("prepareDist", Sync) {
     from("src/dist/README.txt") {
         into(".")
     }
+
+    from(bundledPluginCatalogOutput) {
+        into(".")
+    }
 }
 
 tasks.register("cliDistZip", Zip) {
     dependsOn(tasks.named("prepareDist"))
     archiveBaseName.set("microsmith-cli")
-    archiveVersion.set(project.version.toString())
+    archiveVersion.set(cliVersion)
     archiveClassifier.set("dist")
     destinationDirectory.set(layout.buildDirectory.dir("distributions"))
-    from(layout.buildDirectory.dir("microsmith-cli-dist")) {
+    from(distDirectory) {
         into(distRootName)
     }
 }
@@ -124,19 +376,96 @@ tasks.register("cliDistTar", Tar) {
     dependsOn(tasks.named("prepareDist"))
     compression = Compression.GZIP
     archiveBaseName.set("microsmith-cli")
-    archiveVersion.set(project.version.toString())
+    archiveVersion.set(cliVersion)
     archiveClassifier.set("dist")
     archiveExtension.set("tar.gz")
     destinationDirectory.set(layout.buildDirectory.dir("distributions"))
-    from(layout.buildDirectory.dir("microsmith-cli-dist")) {
+    from(distDirectory) {
         into(distRootName)
     }
 }
 
+def cliDistZipTask = tasks.named("cliDistZip", Zip)
+def cliDistTarTask = tasks.named("cliDistTar", Tar)
+def cliDistZipArchive = cliDistZipTask.flatMap { it.archiveFile }
+def cliDistTarArchive = cliDistTarTask.flatMap { it.archiveFile }
+
+tasks.register("verifyDistLayout") {
+    dependsOn(tasks.named("prepareDist"), cliDistZipTask, cliDistTarTask, generateBundledPluginCatalogTask)
+    inputs.dir(distDirectory)
+    inputs.file(bundledPluginCatalogOutput)
+    inputs.file(cliDistZipArchive)
+    inputs.file(cliDistTarArchive)
+    doLast {
+        String expectedCatalogText = bundledPluginCatalogOutput.get().asFile.getText(StandardCharsets.UTF_8.name())
+        File distRootDirectory = distDirectory.get().asFile
+        File distCatalogFile = new File(distRootDirectory, bundledPluginCatalogFileName)
+        if (!distCatalogFile.isFile()) {
+            throw new GradleException(
+                "Distribution directory is missing '${bundledPluginCatalogFileName}' at ${distCatalogFile.path}.",
+            )
+        }
+        String distCatalogText = distCatalogFile.getText(StandardCharsets.UTF_8.name())
+        if (distCatalogText != expectedCatalogText) {
+            throw new GradleException(
+                "Distribution catalog '${distCatalogFile.path}' does not match generated bundled plugin metadata.",
+            )
+        }
+        BundledPluginCatalogVerifier.validate(
+            distCatalogText,
+            distCatalogFile.path,
+            bundledPluginCatalogFormatVersion,
+            cliVersion,
+            expectedBundledPluginCoordinates,
+            expectedBundledServiceEntries,
+        )
+
+        [
+            new File(distRootDirectory, "bin/microsmith"),
+            new File(distRootDirectory, "bin/microsmith.bat"),
+        ].each { launcher ->
+            if (!launcher.isFile()) {
+                throw new GradleException("Distribution launcher is missing at ${launcher.path}.")
+            }
+            String launcherText = launcher.getText(StandardCharsets.UTF_8.name())
+            if (launcherText.contains("@CLI_JAR@")) {
+                throw new GradleException("Launcher '${launcher.path}' still contains unresolved @CLI_JAR@ token.")
+            }
+            if (!launcherText.contains(shadowJarArchiveName)) {
+                throw new GradleException(
+                    "Launcher '${launcher.path}' does not reference '${shadowJarArchiveName}'.",
+                )
+            }
+        }
+
+        def expectedEntries =
+            [
+                "${distRootName}/${bundledPluginCatalogFileName}".toString(),
+                "${distRootName}/README.txt".toString(),
+                "${distRootName}/bin/microsmith".toString(),
+                "${distRootName}/bin/microsmith.bat".toString(),
+                "${distRootName}/lib/${shadowJarArchiveName}".toString(),
+            ] as Set
+
+        def archiveEntriesByName = [
+            "zip"   : BundledPluginCatalogVerifier.collectZipEntries(cliDistZipArchive.get().asFile),
+            "tar.gz": BundledPluginCatalogVerifier.collectTarGzEntries(cliDistTarArchive.get().asFile),
+        ]
+        archiveEntriesByName.each { archiveName, entries ->
+            def missingEntries = expectedEntries.findAll { expected -> !entries.contains(expected) }
+            if (!missingEntries.isEmpty()) {
+                throw new GradleException(
+                    "Archive ${archiveName} is missing expected distribution entries: ${missingEntries.join(', ')}",
+                )
+            }
+        }
+    }
+}
+
 tasks.register("distArtifacts", Sync) {
-    dependsOn(tasks.named("verifyShadowJarServices"), tasks.named("cliDistZip"), tasks.named("cliDistTar"))
+    dependsOn(tasks.named("verifyShadowJarServices"), tasks.named("verifyDistLayout"))
     into(layout.buildDirectory.dir("release-assets"))
     from(shadowJarArchive)
-    from(tasks.named("cliDistZip"))
-    from(tasks.named("cliDistTar"))
+    from(cliDistZipTask)
+    from(cliDistTarTask)
 }

--- a/cli/src/dist/README.txt
+++ b/cli/src/dist/README.txt
@@ -5,6 +5,7 @@ Contents:
 - lib/ : executable fat jar with built-in generators and emitters
 - bin/microsmith : launcher for Linux/macOS
 - bin/microsmith.bat : launcher for Windows
+- bundled-plugins.lock : bundled plugin profile (pinned to this CLI release version)
 
 Runtime requirements:
 - Java 24+ (Temurin 24 recommended)
@@ -12,3 +13,8 @@ Runtime requirements:
 Quick checks:
 - bin/microsmith --help
 - bin/microsmith run schema.microsmith.kts --out ./generated
+- cat bundled-plugins.lock
+
+Bundled vs external plugins:
+- bundled plugins run without network and do not require --plugin flags
+- external plugins remain optional via --plugin <group:artifact:version> or --plugin-jar <path>

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -9,8 +9,10 @@ Phase 5 documentation for distribution and adoption lives in this folder.
 
 Distribution build outputs:
 
+- `:cli:generateBundledPluginCatalog` -> `cli/build/generated/microsmith/bundled-plugins.lock`
 - `:cli:shadowJar` -> `cli/build/libs/microsmith-cli-<version>-all.jar`
 - `:cli:prepareDist` -> `cli/build/microsmith-cli-dist/`
 - `:cli:cliDistZip` -> `cli/build/distributions/microsmith-cli-<version>-dist.zip`
 - `:cli:cliDistTar` -> `cli/build/distributions/microsmith-cli-<version>-dist.tar.gz`
+- `:cli:verifyDistLayout` -> validates bundled profile + launcher wiring in directory/zip/tar artifacts
 - `:cli:distArtifacts` -> `cli/build/release-assets/`

--- a/docs/cli/migration-from-gradle.md
+++ b/docs/cli/migration-from-gradle.md
@@ -12,6 +12,7 @@ This guide helps teams move generation workflows from Gradle tasks to the standa
 
 - No project-local Gradle wrapper required in consuming repositories
 - Generation entrypoint becomes `microsmith run <script.microsmith.kts> --out <dir>`
+- Common built-in plugins are bundled/pinned in official distributions (`bundled-plugins.lock`)
 - plugin dependency resolution is explicit (`--plugin`, `--plugin-jar`)
 
 ## Command mapping

--- a/docs/cli/quickstart-non-gradle.md
+++ b/docs/cli/quickstart-non-gradle.md
@@ -46,6 +46,15 @@ Windows:
 
 ## Plugin extension workflow
 
+Bundled plugin workflow (no network required):
+
+```bash
+microsmith run schema.microsmith.kts --out ./generated --offline
+```
+
+The official distribution includes a pinned bundled plugin profile in `bundled-plugins.lock`.
+It contains the built-in providers required for schema/protobuf generation and is versioned with the CLI release.
+
 Remote plugin coordinate:
 
 ```bash
@@ -65,6 +74,7 @@ microsmith run schema.microsmith.kts --out ./generated --offline
 ```
 
 Notes:
+- Bundled plugin workflows do not require repository access.
 - Run once without `--offline` first to generate lockfile metadata and warm the plugin cache.
 - Offline remote plugin resolution requires lockfile v2 and a complete cached dependency graph.
 

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -63,4 +63,6 @@ Symptom:
 Actions:
 - use official CLI distribution/fat jar
 - run build integrity task in this repository: `./gradlew :cli:verifyShadowJarServices`
+- run distribution integrity task when validating release assets: `./gradlew :cli:verifyDistLayout`
+- inspect `bundled-plugins.lock` in the unpacked distribution and confirm it lists expected bundled providers
 - avoid manually repackaging runtime jars without merged service descriptors

--- a/docs/release/cli-runtime-notes.md
+++ b/docs/release/cli-runtime-notes.md
@@ -3,11 +3,20 @@
 - CLI artifacts include:
   - executable fat jar (`microsmith-cli-<version>-all.jar`)
   - distribution archives with launchers for Linux/macOS (`bin/microsmith`) and Windows (`bin/microsmith.bat`)
+  - bundled plugin profile (`bundled-plugins.lock`)
 - Java 24 or newer is required when using non-bundled distributions.
 - Installation options:
   - run fat jar directly: `java -jar microsmith-cli-<version>-all.jar --help`
   - unpack distribution archive and run launcher script
+- Bundled plugin policy:
+  - bundled plugin coordinates are pinned to the CLI release version
+  - bundled profile content must stay checksum-verifiable and deterministic across artifacts
 - Security defaults remain enabled in CLI runtime:
   - script dependency directives blocked by default
   - repository policy and checksum controls for plugin resolution
   - output boundary enforcement under configured `--out` path
+
+Release checklist additions:
+- review bundled plugin composition before cutting release artifacts
+- run `./gradlew :cli:distArtifacts` (includes bundled metadata and archive integrity checks)
+- confirm release notes document bundled-vs-external plugin behavior changes


### PR DESCRIPTION
## Summary
This PR implements issue #46 by shipping an explicit bundled plugin profile in official CLI artifacts and adding deterministic integrity checks across shaded jar and distribution archives.

Closes #46.

## What Changed
- Added a generated bundled plugin catalog: `bundled-plugins.lock`.
- Pinned bundled plugin coordinates to the CLI release version.
- Packaged catalog in both:
  - shaded jar at `META-INF/microsmith/bundled-plugins.lock`
  - distribution root as `bundled-plugins.lock`
- Extended runtime packaging validation:
  - verifies expected `ServiceLoader` providers in shaded jar
  - verifies bundled catalog presence and exact content in shaded jar
- Added distribution integrity verification task (`:cli:verifyDistLayout`) that validates:
  - distribution layout for unpacked directory, zip, and tar.gz artifacts
  - launcher token replacement and jar wiring
  - bundled catalog presence/content
- Wired `:cli:distArtifacts` to depend on distribution integrity validation.
- Updated docs for bundled-vs-external behavior, pinning policy, release checklist expectations, and troubleshooting.

## Validation
- `./gradlew :cli:verifyDistLayout --configuration-cache` (configuration cache reuse verified)
- `./gradlew :cli:check :cli:distArtifacts --configuration-cache`
- `./gradlew :cli:build --configuration-cache`
  - `:cli:jvmKotest`: 66 passed, 0 failed

## Notes
- External resolver workflows remain unchanged (`--plugin` / `--plugin-jar`).
- Built-in bundled workflows remain network-independent for default schema/protobuf providers.
