### PR TITLE
feat(cli-ux): finalize init and ide contract for one-command onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ flowchart TD
 ## CLI Scripting Runtime
 Run generation from a script file without embedding Gradle in the consumer project:
 
+One-command bootstrap (recommended):
+
+```bash
+microsmith init
+microsmith run build.microsmith.kts --out ./generated
+```
+
+CI-safe bootstrap:
+
+```bash
+microsmith init --non-interactive --yes --diagnostics json --verbose
+```
+
+Direct script execution:
+
 ```bash
 microsmith run schema.microsmith.kts --out ./generated
 ```
@@ -177,6 +192,12 @@ JetBrains IDE helper refresh:
 
 ```bash
 microsmith ide refresh
+```
+
+JetBrains IDE helper health check:
+
+```bash
+microsmith ide doctor --diagnostics json --verbose
 ```
 
 ### Security boundaries and defaults
@@ -219,6 +240,7 @@ Inside .microsmith.kts scripts:
 
 ### Adoption docs
 - `docs/cli/README.md`
+- `docs/cli/command-contract.md`
 - `docs/cli/quickstart-non-gradle.md`
 - `docs/cli/jetbrains-ide-helper.md`
 - `docs/cli/migration-from-gradle.md`

--- a/cli/src/dist/README.txt
+++ b/cli/src/dist/README.txt
@@ -12,8 +12,11 @@ Runtime requirements:
 
 Quick checks:
 - bin/microsmith --help
+- bin/microsmith init
+- bin/microsmith run build.microsmith.kts --out ./generated
 - bin/microsmith run schema.microsmith.kts --out ./generated
 - bin/microsmith ide refresh
+- bin/microsmith ide doctor
 - cat bundled-plugins.lock
 
 Bundled vs external plugins:

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
@@ -4,11 +4,14 @@ internal const val HELP_TEXT = """
 Microsmith CLI
 
 Usage:
+  microsmith init [--repo-root <path>] [--non-interactive] [--yes]
+                 [--diagnostics <text|json>] [--verbose]
   microsmith run <script.microsmith.kts> --out <output-dir> [--var <name=value>]... [--flag <name>]...
                  [--plugin <group:artifact:version>]... [--plugin-jar <path>]...
                  [--offline] [--repository <uri>] [--isolation <classloader|process>]
                  [--diagnostics <text|json>] [--verbose] [--event-log <path>]
   microsmith ide refresh [--repo-root <path>] [--diagnostics <text|json>] [--verbose]
+  microsmith ide doctor [--repo-root <path>] [--diagnostics <text|json>] [--verbose]
   microsmith doctor [--diagnostics <text|json>] [--verbose]
   microsmith --help
 

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
@@ -3,7 +3,9 @@ package me.liam.microsmith.cli
 import me.liam.microsmith.cli.command.DoctorCommand
 import me.liam.microsmith.cli.command.ErrorCommand
 import me.liam.microsmith.cli.command.HelpCommand
+import me.liam.microsmith.cli.command.IdeDoctorCommand
 import me.liam.microsmith.cli.command.IdeRefreshCommand
+import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.command.RunCommand
 import me.liam.microsmith.cli.diagnostics.CliDiagnosticEmitter
 import me.liam.microsmith.cli.diagnostics.CliFailureCode
@@ -13,8 +15,13 @@ import me.liam.microsmith.cli.doctor.DoctorResult
 import me.liam.microsmith.cli.doctor.runDoctorChecks
 import me.liam.microsmith.cli.eventlog.EventLogWriter
 import me.liam.microsmith.cli.eventlog.RunEventLogEntry
+import me.liam.microsmith.cli.ide.IdeDoctorResult
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
 import me.liam.microsmith.cli.ide.refreshIdeHelperProject
+import me.liam.microsmith.cli.ide.runIdeHelperDoctor
+import me.liam.microsmith.cli.init.InitBootstrapResult
+import me.liam.microsmith.cli.init.InitConflictException
+import me.liam.microsmith.cli.init.runInitBootstrap
 import me.liam.microsmith.cli.parsing.parseCliArgs
 import me.liam.microsmith.cli.plugins.PluginResolutionResult
 import me.liam.microsmith.cli.plugins.resolvePlugins
@@ -51,7 +58,9 @@ internal class MicrosmithCli(
     private val doctorRunner: ((() -> List<String>) -> DoctorResult) = { validator ->
         runDoctorChecks(providerValidator = validator)
     },
+    private val initRunner: (InitCommand) -> InitBootstrapResult = ::runInitBootstrap,
     private val ideRefreshRunner: (IdeRefreshCommand) -> IdeHelperRefreshResult = ::refreshIdeHelperProject,
+    private val ideDoctorRunner: (IdeDoctorCommand) -> IdeDoctorResult = ::runIdeHelperDoctor,
     private val eventLogWriter: (Path, RunEventLogEntry) -> Unit = EventLogWriter::writeEventLog,
 ) {
     fun run(args: Array<String>): Int = when (val parsed = parseCliArgs(args.toList())) {
@@ -78,7 +87,11 @@ internal class MicrosmithCli(
 
         is DoctorCommand -> runDoctor(parsed)
 
+        is InitCommand -> runInit(parsed)
+
         is IdeRefreshCommand -> runIdeRefresh(parsed)
+
+        is IdeDoctorCommand -> runIdeDoctor(parsed)
     }
 
     private fun runCommand(command: RunCommand): Int {
@@ -156,6 +169,73 @@ internal class MicrosmithCli(
         emitter.info(
             "Import '${helperRoot.resolve("build.gradle.kts")}' as a Gradle project in JetBrains IDEs.",
         )
+        return 0
+    }
+
+    private fun runIdeDoctor(command: IdeDoctorCommand): Int {
+        val emitter = createEmitter(command.diagnosticsFormat, command.verbose)
+        val result =
+            runCatching {
+                ideDoctorRunner(command)
+            }.getOrElse { error ->
+                emitter.error(
+                    CliFailureCode.IDE_DOCTOR_FAILED,
+                    error.message ?: "JetBrains IDE helper doctor failed unexpectedly.",
+                )
+                return CliFailureCode.IDE_DOCTOR_FAILED.exitCode
+            }
+
+        result.checks.forEach { check ->
+            if (check.passed) {
+                emitter.info("ide-doctor/${check.id}: ${check.message}", check.details)
+            } else {
+                emitter.error(
+                    CliFailureCode.IDE_DOCTOR_FAILED,
+                    "ide-doctor/${check.id}: ${check.message}",
+                    check.details,
+                )
+            }
+        }
+
+        return if (result.hasFailures) {
+            emitter.error(CliFailureCode.IDE_DOCTOR_FAILED, "JetBrains IDE helper doctor detected issues.")
+            CliFailureCode.IDE_DOCTOR_FAILED.exitCode
+        } else {
+            emitter.info("JetBrains IDE helper doctor checks passed.")
+            0
+        }
+    }
+
+    private fun runInit(command: InitCommand): Int {
+        val emitter = createEmitter(command.diagnosticsFormat, command.verbose)
+        val result =
+            runCatching {
+                initRunner(command)
+            }.getOrElse { error ->
+                val code =
+                    when (error) {
+                        is InitConflictException -> CliFailureCode.INIT_CONFLICT
+                        is IllegalArgumentException -> CliFailureCode.INIT_VALIDATION_FAILED
+                        else -> CliFailureCode.INIT_RUNTIME_FAILED
+                    }
+                emitter.error(code, error.message ?: "Microsmith init failed.")
+                return code.exitCode
+            }
+
+        val projectRoot = result.projectRoot.toAbsolutePath().normalize()
+        emitter.info(
+            "Microsmith init completed at '$projectRoot'.",
+            details =
+            mapOf(
+                "projectRoot" to projectRoot.toString(),
+                "createdFiles" to result.createdFiles.size.toString(),
+                "preservedFiles" to result.preservedFiles.size.toString(),
+                "ideHelperUpdatedFiles" to result.ideHelperResult.updatedFiles.size.toString(),
+                "nonInteractive" to command.nonInteractive.toString(),
+                "assumeYes" to command.assumeYes.toString(),
+            ),
+        )
+        emitter.info("Next: microsmith run build.microsmith.kts --out ./generated")
         return 0
     }
 

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/command/IdeDoctorCommand.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/command/IdeDoctorCommand.kt
@@ -1,0 +1,10 @@
+package me.liam.microsmith.cli.command
+
+import me.liam.microsmith.cli.diagnostics.DiagnosticFormat
+import java.nio.file.Path
+
+internal data class IdeDoctorCommand(
+    val projectRoot: Path = Path.of("."),
+    val diagnosticsFormat: DiagnosticFormat = DiagnosticFormat.TEXT,
+    val verbose: Boolean = false,
+) : CliCommand

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/command/InitCommand.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/command/InitCommand.kt
@@ -1,0 +1,12 @@
+package me.liam.microsmith.cli.command
+
+import me.liam.microsmith.cli.diagnostics.DiagnosticFormat
+import java.nio.file.Path
+
+internal data class InitCommand(
+    val projectRoot: Path = Path.of("."),
+    val diagnosticsFormat: DiagnosticFormat = DiagnosticFormat.TEXT,
+    val verbose: Boolean = false,
+    val nonInteractive: Boolean = false,
+    val assumeYes: Boolean = false,
+) : CliCommand

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/diagnostics/CliDiagnostics.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/diagnostics/CliDiagnostics.kt
@@ -22,6 +22,10 @@ internal enum class CliFailureCode(val id: String, val exitCode: Int) {
     SCRIPT_HOST_FAILED(id = "MS-CLI-2004", exitCode = 23),
     DOCTOR_FAILED(id = "MS-CLI-3001", exitCode = 30),
     IDE_HELPER_FAILED(id = "MS-CLI-4001", exitCode = 40),
+    IDE_DOCTOR_FAILED(id = "MS-CLI-4101", exitCode = 41),
+    INIT_CONFLICT(id = "MS-CLI-5001", exitCode = 50),
+    INIT_VALIDATION_FAILED(id = "MS-CLI-5002", exitCode = 51),
+    INIT_RUNTIME_FAILED(id = "MS-CLI-5003", exitCode = 52),
 }
 
 internal enum class DiagnosticLevel {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctor.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctor.kt
@@ -1,0 +1,177 @@
+package me.liam.microsmith.cli.ide
+
+import me.liam.microsmith.cli.command.IdeDoctorCommand
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal data class IdeDoctorCheckResult(
+    val id: String,
+    val passed: Boolean,
+    val message: String,
+    val details: Map<String, String> = emptyMap(),
+)
+
+internal data class IdeDoctorResult(
+    val projectRoot: Path,
+    val helperRoot: Path,
+    val checks: List<IdeDoctorCheckResult>,
+) {
+    val hasFailures: Boolean = checks.any { check -> !check.passed }
+}
+
+internal fun runIdeHelperDoctor(
+    command: IdeDoctorCommand,
+    classpathResolver: () -> List<Path> = ::resolveIdeHelperClasspathEntries,
+): IdeDoctorResult {
+    val projectRoot = command.projectRoot.toAbsolutePath().normalize()
+    val helperRoot = projectRoot.resolve(IDE_HELPER_DIRECTORY).toAbsolutePath().normalize()
+    validateRepoRoot(projectRoot, helperRoot)?.let { return it }
+
+    val classpathEntries = resolveClasspathEntries(classpathResolver)
+    val runtimeClasspathCheck = runtimeClasspathCheck(classpathEntries)
+    val checks =
+        listOf(
+            helperDirectoryCheck(helperRoot),
+            requiredFilesCheck(helperRoot),
+            runtimeClasspathCheck,
+            classpathSyncCheck(helperRoot, classpathEntries),
+        )
+
+    return IdeDoctorResult(projectRoot = projectRoot, helperRoot = helperRoot, checks = checks)
+}
+
+private fun validateRepoRoot(projectRoot: Path, helperRoot: Path): IdeDoctorResult? {
+    if (!Files.exists(projectRoot)) {
+        return IdeDoctorResult(
+            projectRoot = projectRoot,
+            helperRoot = helperRoot,
+            checks =
+            listOf(
+                IdeDoctorCheckResult(
+                    id = "repo-root",
+                    passed = false,
+                    message = "Repository root '$projectRoot' does not exist.",
+                ),
+            ),
+        )
+    }
+
+    if (!Files.isDirectory(projectRoot)) {
+        return IdeDoctorResult(
+            projectRoot = projectRoot,
+            helperRoot = helperRoot,
+            checks =
+            listOf(
+                IdeDoctorCheckResult(
+                    id = "repo-root",
+                    passed = false,
+                    message = "Repository root '$projectRoot' is not a directory.",
+                ),
+            ),
+        )
+    }
+
+    return null
+}
+
+private fun helperDirectoryCheck(helperRoot: Path): IdeDoctorCheckResult = if (Files.isDirectory(helperRoot)) {
+    IdeDoctorCheckResult(
+        id = "helper-directory",
+        passed = true,
+        message = "IDE helper directory exists.",
+        details = mapOf("helperRoot" to helperRoot.toString()),
+    )
+} else {
+    IdeDoctorCheckResult(
+        id = "helper-directory",
+        passed = false,
+        message = "IDE helper directory is missing. Run 'microsmith ide refresh'.",
+        details = mapOf("helperRoot" to helperRoot.toString()),
+    )
+}
+
+private fun requiredFilesCheck(helperRoot: Path): IdeDoctorCheckResult {
+    val requiredFiles =
+        listOf(
+            helperRoot.resolve(IDE_HELPER_SETTINGS_FILE_NAME),
+            helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME),
+            helperRoot.resolve(IDE_HELPER_README_FILE_NAME),
+        )
+    val missingFiles = requiredFiles.filterNot(Files::isRegularFile).sortedBy(Path::toString)
+    return if (missingFiles.isEmpty()) {
+        IdeDoctorCheckResult(
+            id = "required-files",
+            passed = true,
+            message = "All required IDE helper files are present.",
+            details = mapOf("fileCount" to requiredFiles.size.toString()),
+        )
+    } else {
+        IdeDoctorCheckResult(
+            id = "required-files",
+            passed = false,
+            message = "IDE helper files are missing. Run 'microsmith ide refresh'.",
+            details =
+            mapOf(
+                "missingCount" to missingFiles.size.toString(),
+                "missingFiles" to missingFiles.joinToString(separator = ","),
+            ),
+        )
+    }
+}
+
+private fun resolveClasspathEntries(classpathResolver: () -> List<Path>): List<Path> = classpathResolver()
+    .map { path -> path.toAbsolutePath().normalize() }
+    .filter(Files::exists)
+    .distinctBy(Path::toString)
+    .sortedBy(Path::toString)
+
+private fun runtimeClasspathCheck(classpathEntries: List<Path>): IdeDoctorCheckResult =
+    if (classpathEntries.isEmpty()) {
+        IdeDoctorCheckResult(
+            id = "runtime-classpath",
+            passed = false,
+            message = "Could not resolve runtime classpath entries for IDE helper validation.",
+        )
+    } else {
+        IdeDoctorCheckResult(
+            id = "runtime-classpath",
+            passed = true,
+            message = "Resolved runtime classpath entries.",
+            details = mapOf("classpathEntries" to classpathEntries.size.toString()),
+        )
+    }
+
+private fun classpathSyncCheck(helperRoot: Path, classpathEntries: List<Path>): IdeDoctorCheckResult {
+    val buildFile = helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME)
+    val buildFileContent =
+        if (Files.isRegularFile(buildFile)) {
+            Files.readString(buildFile, StandardCharsets.UTF_8).replace("\r\n", "\n")
+        } else {
+            null
+        }
+    val missingClasspathEntries =
+        if (buildFileContent == null) {
+            classpathEntries
+        } else {
+            classpathEntries.filterNot { entry -> buildFileContent.contains(entry.toKotlinPathLiteral()) }
+        }
+    return if (missingClasspathEntries.isEmpty()) {
+        IdeDoctorCheckResult(
+            id = "classpath-sync",
+            passed = true,
+            message = "IDE helper build file is synchronized with runtime classpath.",
+        )
+    } else {
+        IdeDoctorCheckResult(
+            id = "classpath-sync",
+            passed = false,
+            message = "IDE helper build file is stale. Run 'microsmith ide refresh'.",
+            details =
+            mapOf(
+                "missingClasspathEntries" to missingClasspathEntries.size.toString(),
+                "firstMissingClasspathEntry" to missingClasspathEntries.first().toString(),
+            ),
+        )
+    }
+}

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperGenerator.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperGenerator.kt
@@ -32,9 +32,9 @@ internal fun refreshIdeHelperProject(
 
     val targetFiles =
         linkedMapOf(
-            helperRoot.resolve(SETTINGS_FILE_NAME) to renderSettingsGradle(),
-            helperRoot.resolve(BUILD_FILE_NAME) to renderBuildGradle(classpathEntries),
-            helperRoot.resolve(README_FILE_NAME) to renderReadme(),
+            helperRoot.resolve(IDE_HELPER_SETTINGS_FILE_NAME) to renderSettingsGradle(),
+            helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME) to renderBuildGradle(classpathEntries),
+            helperRoot.resolve(IDE_HELPER_README_FILE_NAME) to renderReadme(),
         )
 
     val updatedFiles =
@@ -126,7 +126,7 @@ private fun writeFileIfChanged(path: Path, content: String): Boolean {
     return true
 }
 
-private fun Path.toKotlinPathLiteral(): String = toAbsolutePath()
+internal fun Path.toKotlinPathLiteral(): String = toAbsolutePath()
     .normalize()
     .toString()
     .replace('\\', '/')
@@ -147,8 +147,8 @@ private fun String.toKotlinStringLiteralContent(): String {
     return builder.toString()
 }
 
-private const val IDE_HELPER_DIRECTORY = ".microsmith/ide"
-private const val SETTINGS_FILE_NAME = "settings.gradle.kts"
-private const val BUILD_FILE_NAME = "build.gradle.kts"
-private const val README_FILE_NAME = "README.md"
+internal const val IDE_HELPER_DIRECTORY = ".microsmith/ide"
+internal const val IDE_HELPER_SETTINGS_FILE_NAME = "settings.gradle.kts"
+internal const val IDE_HELPER_BUILD_FILE_NAME = "build.gradle.kts"
+internal const val IDE_HELPER_README_FILE_NAME = "README.md"
 private const val KOTLIN_ESCAPE_BUFFER_PADDING = 8

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
@@ -1,0 +1,88 @@
+package me.liam.microsmith.cli.init
+
+import me.liam.microsmith.cli.command.IdeRefreshCommand
+import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import me.liam.microsmith.cli.ide.refreshIdeHelperProject
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal data class InitBootstrapResult(
+    val projectRoot: Path,
+    val createdFiles: List<Path>,
+    val preservedFiles: List<Path>,
+    val ideHelperResult: IdeHelperRefreshResult,
+)
+
+internal class InitConflictException(message: String) : IllegalStateException(message)
+
+internal fun runInitBootstrap(
+    command: InitCommand,
+    ideRefreshRunner: (IdeRefreshCommand) -> IdeHelperRefreshResult = ::refreshIdeHelperProject,
+): InitBootstrapResult {
+    val projectRoot = command.projectRoot.toAbsolutePath().normalize()
+    require(Files.exists(projectRoot)) {
+        "Repository root '$projectRoot' does not exist."
+    }
+    require(Files.isDirectory(projectRoot)) {
+        "Repository root '$projectRoot' is not a directory."
+    }
+
+    val createdFiles = mutableListOf<Path>()
+    val preservedFiles = mutableListOf<Path>()
+    DEFAULT_BOOTSTRAP_FILES.forEach { (relativePath, content) ->
+        val path = projectRoot.resolve(relativePath)
+        when {
+            Files.exists(path) && Files.isRegularFile(path) -> preservedFiles.add(path)
+            Files.exists(path) ->
+                throw InitConflictException("Bootstrap path '$path' exists but is not a regular file.")
+
+            else -> {
+                Files.createDirectories(path.parent)
+                Files.writeString(path, content, StandardCharsets.UTF_8)
+                createdFiles.add(path)
+            }
+        }
+    }
+
+    val ideHelperResult =
+        ideRefreshRunner(
+            IdeRefreshCommand(
+                projectRoot = projectRoot,
+                diagnosticsFormat = command.diagnosticsFormat,
+                verbose = command.verbose,
+            ),
+        )
+
+    return InitBootstrapResult(
+        projectRoot = projectRoot,
+        createdFiles = createdFiles.sortedBy(Path::toString),
+        preservedFiles = preservedFiles.sortedBy(Path::toString),
+        ideHelperResult = ideHelperResult,
+    )
+}
+
+private val DEFAULT_BOOTSTRAP_FILES =
+    linkedMapOf(
+        "settings.microsmith.kts" to renderDefaultSettingsScript(),
+        "build.microsmith.kts" to renderDefaultBuildScript(),
+    )
+
+private fun renderDefaultSettingsScript(): String = """
+// Microsmith repository settings.
+// Add shared script configuration here as your repository grows.
+""".trimIndent() + "\n"
+
+private fun renderDefaultBuildScript(): String = """
+microsmith {
+    schemas {
+        protobuf {
+            message("UserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}
+""".trimIndent() + "\n"

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
@@ -4,15 +4,19 @@ import me.liam.microsmith.cli.command.CliCommand
 import me.liam.microsmith.cli.command.DoctorCommand
 import me.liam.microsmith.cli.command.ErrorCommand
 import me.liam.microsmith.cli.command.HelpCommand
+import me.liam.microsmith.cli.command.IdeDoctorCommand
 import me.liam.microsmith.cli.command.IdeRefreshCommand
+import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.command.RunCommand
 import me.liam.microsmith.cli.diagnostics.DiagnosticFormat
 import java.nio.file.Path
 
+internal const val INIT_COMMAND = "init"
 internal const val RUN_COMMAND = "run"
 internal const val DOCTOR_COMMAND = "doctor"
 internal const val IDE_COMMAND = "ide"
 internal const val IDE_REFRESH_SUBCOMMAND = "refresh"
+internal const val IDE_DOCTOR_SUBCOMMAND = "doctor"
 internal const val OUTPUT_OPTION = "--out"
 internal const val VARIABLE_OPTION = "--var"
 internal const val FLAG_OPTION = "--flag"
@@ -25,11 +29,14 @@ internal const val DIAGNOSTICS_OPTION = "--diagnostics"
 internal const val VERBOSE_OPTION = "--verbose"
 internal const val EVENT_LOG_OPTION = "--event-log"
 internal const val REPO_ROOT_OPTION = "--repo-root"
+internal const val NON_INTERACTIVE_OPTION = "--non-interactive"
+internal const val YES_OPTION = "--yes"
 private const val SCRIPT_EXTENSION = ".microsmith.kts"
 private val HELP_COMMANDS = setOf("--help", "-h", "help")
 
 internal fun parseCliArgs(args: List<String>): CliCommand = when (val command = args.firstOrNull()) {
     null, in HELP_COMMANDS -> HelpCommand
+    INIT_COMMAND -> parseInitCommand(args)
     RUN_COMMAND -> parseRunCommand(args)
     DOCTOR_COMMAND -> parseDoctorCommand(args)
     IDE_COMMAND -> parseIdeCommand(args)
@@ -100,17 +107,19 @@ private fun parseIdeCommand(args: List<String>): CliCommand {
     val subcommand = args.getOrNull(1)
     return when {
         subcommand == null || subcommand in HELP_COMMANDS ->
-            ErrorCommand("Missing <refresh> subcommand for ide command.")
+            ErrorCommand("Missing <refresh|doctor> subcommand for ide command.")
 
-        subcommand != IDE_REFRESH_SUBCOMMAND ->
-            ErrorCommand("Unknown ide subcommand '$subcommand'. Expected 'refresh'.")
+        subcommand == IDE_REFRESH_SUBCOMMAND -> parseIdeRefreshCommand(args = args, startIndex = 2)
 
-        else -> parseIdeRefreshCommand(args = args, startIndex = 2)
+        subcommand == IDE_DOCTOR_SUBCOMMAND -> parseIdeDoctorCommand(args = args, startIndex = 2)
+
+        else ->
+            ErrorCommand("Unknown ide subcommand '$subcommand'. Expected 'refresh' or 'doctor'.")
     }
 }
 
 private fun parseIdeRefreshCommand(args: List<String>, startIndex: Int): CliCommand {
-    val parsed = parseIdeRefreshOptions(args = args, startIndex = startIndex)
+    val parsed = parseIdeOptions(args = args, startIndex = startIndex)
     return if (parsed.error != null) {
         ErrorCommand(parsed.error)
     } else {
@@ -122,8 +131,21 @@ private fun parseIdeRefreshCommand(args: List<String>, startIndex: Int): CliComm
     }
 }
 
-private fun parseIdeRefreshOptions(args: List<String>, startIndex: Int): ParsedIdeRefreshOptions {
-    val state = IdeRefreshOptionsState()
+private fun parseIdeDoctorCommand(args: List<String>, startIndex: Int): CliCommand {
+    val parsed = parseIdeOptions(args = args, startIndex = startIndex)
+    return if (parsed.error != null) {
+        ErrorCommand(parsed.error)
+    } else {
+        IdeDoctorCommand(
+            projectRoot = parsed.projectRoot,
+            diagnosticsFormat = parsed.diagnosticsFormat,
+            verbose = parsed.verbose,
+        )
+    }
+}
+
+private fun parseIdeOptions(args: List<String>, startIndex: Int): ParsedIdeOptions {
+    val state = IdeOptionsState()
     var index = startIndex
 
     while (index < args.size && state.error == null) {
@@ -143,7 +165,48 @@ private fun parseIdeRefreshOptions(args: List<String>, startIndex: Int): ParsedI
         index += consumed
     }
 
-    return state.toParsedIdeRefreshOptions()
+    return state.toParsedIdeOptions()
+}
+
+private fun parseInitCommand(args: List<String>): CliCommand {
+    val parsed = parseInitOptions(args = args, startIndex = 1)
+    return if (parsed.error != null) {
+        ErrorCommand(parsed.error)
+    } else {
+        InitCommand(
+            projectRoot = parsed.projectRoot,
+            diagnosticsFormat = parsed.diagnosticsFormat,
+            verbose = parsed.verbose,
+            nonInteractive = parsed.nonInteractive,
+            assumeYes = parsed.assumeYes,
+        )
+    }
+}
+
+private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOptions {
+    val state = InitOptionsState()
+    var index = startIndex
+
+    while (index < args.size && state.error == null) {
+        val consumed =
+            when (val token = args[index]) {
+                DIAGNOSTICS_OPTION -> state.consumeDiagnostics(args = args, index = index)
+                VERBOSE_OPTION -> state.consumeVerbose()
+                REPO_ROOT_OPTION -> state.consumeRepoRoot(args = args, index = index)
+                NON_INTERACTIVE_OPTION -> state.consumeNonInteractive()
+                YES_OPTION -> state.consumeAssumeYes()
+                else -> {
+                    state.consumeUnknownOption(token)
+                    0
+                }
+            }
+        if (consumed <= 0) {
+            break
+        }
+        index += consumed
+    }
+
+    return state.toParsedInitOptions()
 }
 
 private fun parseDoctorOptions(args: List<String>, startIndex: Int): ParsedDoctorOptions {
@@ -202,7 +265,7 @@ private data class ParsedDoctorOptions(
     val error: String?,
 )
 
-private class IdeRefreshOptionsState {
+private class IdeOptionsState {
     private var diagnosticsFormat = DiagnosticFormat.TEXT
     private var diagnosticsSpecified = false
     private var verbose = false
@@ -264,8 +327,8 @@ private class IdeRefreshOptionsState {
         error = "Unknown option '$token'."
     }
 
-    fun toParsedIdeRefreshOptions(): ParsedIdeRefreshOptions {
-        return ParsedIdeRefreshOptions(
+    fun toParsedIdeOptions(): ParsedIdeOptions {
+        return ParsedIdeOptions(
             projectRoot = projectRoot,
             diagnosticsFormat = diagnosticsFormat,
             verbose = verbose,
@@ -274,9 +337,114 @@ private class IdeRefreshOptionsState {
     }
 }
 
-private data class ParsedIdeRefreshOptions(
+private class InitOptionsState {
+    private var diagnosticsFormat = DiagnosticFormat.TEXT
+    private var diagnosticsSpecified = false
+    private var verbose = false
+    private var nonInteractive = false
+    private var assumeYes = false
+    private var projectRoot = Path.of(".")
+    private var projectRootSpecified = false
+
+    var error: String? = null
+        private set
+
+    fun consumeDiagnostics(args: List<String>, index: Int): Int {
+        val value = args.getOrNull(index + 1)
+        val parsedFormat = parseDiagnosticFormat(value)
+        error =
+            when {
+                value == null || value.startsWith("--") -> "Missing value for --diagnostics option."
+                diagnosticsSpecified -> "--diagnostics may only be specified once."
+                parsedFormat == null -> "Invalid --diagnostics value '$value'. Expected 'text' or 'json'."
+                else -> null
+            }
+
+        if (error != null) {
+            return 0
+        }
+
+        diagnosticsFormat = requireNotNull(parsedFormat)
+        diagnosticsSpecified = true
+        return 2
+    }
+
+    fun consumeVerbose(): Int {
+        if (verbose) {
+            error = "--verbose may only be specified once."
+            return 0
+        }
+
+        verbose = true
+        return 1
+    }
+
+    fun consumeRepoRoot(args: List<String>, index: Int): Int {
+        val value = args.getOrNull(index + 1)
+        error =
+            when {
+                value == null || value.startsWith("--") -> "Missing value for --repo-root option."
+                projectRootSpecified -> "--repo-root may only be specified once."
+                else -> null
+            }
+
+        if (error != null) {
+            return 0
+        }
+
+        projectRoot = Path.of(value)
+        projectRootSpecified = true
+        return 2
+    }
+
+    fun consumeNonInteractive(): Int {
+        if (nonInteractive) {
+            error = "--non-interactive may only be specified once."
+            return 0
+        }
+
+        nonInteractive = true
+        return 1
+    }
+
+    fun consumeAssumeYes(): Int {
+        if (assumeYes) {
+            error = "--yes may only be specified once."
+            return 0
+        }
+
+        assumeYes = true
+        return 1
+    }
+
+    fun consumeUnknownOption(token: String) {
+        error = "Unknown option '$token'."
+    }
+
+    fun toParsedInitOptions(): ParsedInitOptions {
+        return ParsedInitOptions(
+            projectRoot = projectRoot,
+            diagnosticsFormat = diagnosticsFormat,
+            verbose = verbose,
+            nonInteractive = nonInteractive,
+            assumeYes = assumeYes,
+            error = error,
+        )
+    }
+}
+
+private data class ParsedIdeOptions(
     val projectRoot: Path,
     val diagnosticsFormat: DiagnosticFormat,
     val verbose: Boolean,
+    val error: String?,
+)
+
+private data class ParsedInitOptions(
+    val projectRoot: Path,
+    val diagnosticsFormat: DiagnosticFormat,
+    val verbose: Boolean,
+    val nonInteractive: Boolean,
+    val assumeYes: Boolean,
     val error: String?,
 )

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliTests.kt
@@ -3,11 +3,17 @@ package me.liam.microsmith.cli
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.cli.command.IdeDoctorCommand
 import me.liam.microsmith.cli.command.IdeRefreshCommand
+import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.doctor.DoctorCheckResult
 import me.liam.microsmith.cli.doctor.DoctorCheckStatus
 import me.liam.microsmith.cli.doctor.DoctorResult
+import me.liam.microsmith.cli.ide.IdeDoctorCheckResult
+import me.liam.microsmith.cli.ide.IdeDoctorResult
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import me.liam.microsmith.cli.init.InitBootstrapResult
+import me.liam.microsmith.cli.init.InitConflictException
 import me.liam.microsmith.cli.plugins.PluginResolutionResult
 import me.liam.microsmith.runtime.scripting.model.ScriptFailureType
 import me.liam.microsmith.runtime.scripting.model.ScriptRunFailure
@@ -364,5 +370,275 @@ class MicrosmithCliTests :
             err.joinToString("\n").shouldContain("MS-CLI-4001")
             err.joinToString("\n").shouldContain("simulated helper generation failure")
             out shouldBe emptyList()
+        }
+
+        "ide doctor command returns success when checks pass" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-ide-doctor-success")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        ideDoctorRunner = { command: IdeDoctorCommand ->
+                            IdeDoctorResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                checks =
+                                listOf(
+                                    IdeDoctorCheckResult(
+                                        id = "helper-directory",
+                                        passed = true,
+                                        message = "IDE helper directory exists.",
+                                    ),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("ide", "doctor", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("JetBrains IDE helper doctor checks passed")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "ide doctor command returns deterministic failure code when checks fail" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val projectRoot = createTempDirectory("microsmith-cli-ide-doctor-failure")
+            val helperRoot = createTempDirectory("microsmith-cli-ide-doctor-helper")
+            try {
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        ideDoctorRunner = {
+                            IdeDoctorResult(
+                                projectRoot = projectRoot,
+                                helperRoot = helperRoot,
+                                checks =
+                                listOf(
+                                    IdeDoctorCheckResult(
+                                        id = "classpath-sync",
+                                        passed = false,
+                                        message = "IDE helper build file is stale.",
+                                    ),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("ide", "doctor"))
+
+                exitCode shouldBe 41
+                err.joinToString("\n").shouldContain("MS-CLI-4101")
+                err.joinToString("\n").shouldContain("JetBrains IDE helper doctor detected issues")
+                out shouldBe emptyList()
+            } finally {
+                runCatching { projectRoot.deleteRecursively() }
+                runCatching { helperRoot.deleteRecursively() }
+            }
+        }
+
+        "init command returns success and emits next run command when bootstrap succeeds" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-success")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                createdFiles =
+                                listOf(
+                                    tempDir.resolve("build.microsmith.kts"),
+                                    tempDir.resolve("settings.microsmith.kts"),
+                                ),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Microsmith init completed")
+                out.joinToString("\n").shouldContain("build.microsmith.kts")
+                out.joinToString("\n").shouldContain("microsmith run build.microsmith.kts --out ./generated")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command returns deterministic conflict failure code when bootstrap detects conflicting path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    initRunner = {
+                        throw InitConflictException("Bootstrap path is not a regular file.")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("init"))
+
+            exitCode shouldBe 50
+            err.joinToString("\n").shouldContain("MS-CLI-5001")
+            err.joinToString("\n").shouldContain("Bootstrap path is not a regular file")
+            out shouldBe emptyList()
+        }
+
+        "init command returns deterministic validation failure code when bootstrap validation fails" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    initRunner = {
+                        throw IllegalArgumentException("Repository root does not exist.")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("init", "--repo-root", "/path/does/not/exist"))
+
+            exitCode shouldBe 51
+            err.joinToString("\n").shouldContain("MS-CLI-5002")
+            err.joinToString("\n").shouldContain("Repository root does not exist.")
+            out shouldBe emptyList()
+        }
+
+        "init command returns deterministic runtime failure code for unexpected bootstrap errors" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    initRunner = {
+                        throw IllegalStateException("Unexpected init failure.")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("init"))
+
+            exitCode shouldBe 52
+            err.joinToString("\n").shouldContain("MS-CLI-5003")
+            err.joinToString("\n").shouldContain("Unexpected init failure.")
+            out shouldBe emptyList()
+        }
+
+        "init command emits json diagnostics payload when requested" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-json")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                preservedFiles = listOf(tempDir.resolve("settings.microsmith.kts")),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode =
+                    cli.run(
+                        arrayOf(
+                            "init",
+                            "--repo-root",
+                            tempDir.toString(),
+                            "--diagnostics",
+                            "json",
+                            "--verbose",
+                        ),
+                    )
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("\"level\":\"info\"")
+                out.joinToString("\n").shouldContain("Microsmith init completed")
+                out.joinToString("\n").shouldContain("\"details\"")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "ide doctor command emits json error diagnostics payload when checks fail" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-ide-doctor-json-failure")
+            try {
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        ideDoctorRunner = { command ->
+                            IdeDoctorResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = tempDir.resolve(".microsmith/ide"),
+                                checks =
+                                listOf(
+                                    IdeDoctorCheckResult(
+                                        id = "classpath-sync",
+                                        passed = false,
+                                        message = "IDE helper build file is stale.",
+                                    ),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode =
+                    cli.run(
+                        arrayOf(
+                            "ide",
+                            "doctor",
+                            "--repo-root",
+                            tempDir.toString(),
+                            "--diagnostics",
+                            "json",
+                        ),
+                    )
+
+                exitCode shouldBe 41
+                err.joinToString("\n").shouldContain("\"code\":\"MS-CLI-4101\"")
+                err.joinToString("\n").shouldContain("\"level\":\"error\"")
+                out shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
         }
     })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorTests.kt
@@ -1,0 +1,86 @@
+package me.liam.microsmith.cli.ide
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.cli.command.IdeDoctorCommand
+import me.liam.microsmith.cli.command.IdeRefreshCommand
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class IdeHelperDoctorTests :
+    StringSpec({
+        "passes when helper files exist and classpath is synchronized" {
+            val repoRoot = createTempDirectory("microsmith-ide-doctor-pass")
+            val runtimeJar = repoRoot.resolve("runtime/microsmith-cli-all.jar")
+            runtimeJar.parent.createDirectories()
+            runtimeJar.writeText("jar-binary-placeholder")
+            try {
+                refreshIdeHelperProject(
+                    command = IdeRefreshCommand(projectRoot = repoRoot),
+                    classpathResolver = { listOf(runtimeJar) },
+                )
+
+                val result =
+                    runIdeHelperDoctor(
+                        command = IdeDoctorCommand(projectRoot = repoRoot),
+                        classpathResolver = { listOf(runtimeJar) },
+                    )
+
+                result.hasFailures shouldBe false
+                result.checks.filter { !it.passed } shouldBe emptyList()
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "reports missing helper directory when ide refresh has not been run" {
+            val repoRoot = createTempDirectory("microsmith-ide-doctor-missing-helper")
+            try {
+                val result =
+                    runIdeHelperDoctor(
+                        command = IdeDoctorCommand(projectRoot = repoRoot),
+                        classpathResolver = { emptyList() },
+                    )
+
+                result.hasFailures shouldBe true
+                result.checks.map { check -> check.id }.shouldContain("helper-directory")
+                result.checks.first { check -> check.id == "helper-directory" }.message.shouldContain("missing")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "reports stale classpath when helper build file does not include current runtime jars" {
+            val repoRoot = createTempDirectory("microsmith-ide-doctor-stale-classpath")
+            val runtimeJarV1 = repoRoot.resolve("runtime/microsmith-cli-v1.jar")
+            val runtimeJarV2 = repoRoot.resolve("runtime/microsmith-cli-v2.jar")
+            runtimeJarV1.parent.createDirectories()
+            runtimeJarV1.writeText("jar-binary-placeholder-v1")
+            runtimeJarV2.writeText("jar-binary-placeholder-v2")
+            try {
+                refreshIdeHelperProject(
+                    command = IdeRefreshCommand(projectRoot = repoRoot),
+                    classpathResolver = { listOf(runtimeJarV1) },
+                )
+
+                val result =
+                    runIdeHelperDoctor(
+                        command = IdeDoctorCommand(projectRoot = repoRoot),
+                        classpathResolver = { listOf(runtimeJarV2) },
+                    )
+
+                result.hasFailures shouldBe true
+                val classpathSyncCheck = result.checks.first { check -> check.id == "classpath-sync" }
+                classpathSyncCheck.passed shouldBe false
+                classpathSyncCheck.message.shouldContain("stale")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
@@ -1,0 +1,113 @@
+package me.liam.microsmith.cli.init
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class InitBootstrapTests :
+    StringSpec({
+        "creates default bootstrap files and invokes IDE helper refresh" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-create")
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.createdFiles.shouldHaveSize(2)
+                result.createdFiles.shouldContain(repoRoot.resolve("build.microsmith.kts"))
+                result.createdFiles.shouldContain(repoRoot.resolve("settings.microsmith.kts"))
+                result.preservedFiles shouldBe emptyList()
+                repoRoot.resolve("build.microsmith.kts").isRegularFile() shouldBe true
+                repoRoot.resolve("settings.microsmith.kts").isRegularFile() shouldBe true
+                repoRoot.resolve("build.microsmith.kts").readText().shouldContain("microsmith {")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "preserves existing bootstrap files on repeated init runs" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-idempotent")
+            val existingBuild = repoRoot.resolve("build.microsmith.kts")
+            existingBuild.writeText("// existing build script")
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = emptyList(),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.createdFiles.shouldHaveSize(1)
+                result.createdFiles.single() shouldBe repoRoot.resolve("settings.microsmith.kts")
+                result.preservedFiles.shouldContain(existingBuild)
+                existingBuild.readText() shouldBe "// existing build script"
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "throws conflict when bootstrap path exists and is not a regular file" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-conflict")
+            repoRoot.resolve("build.microsmith.kts").createDirectories()
+            try {
+                val error =
+                    shouldThrow<InitConflictException> {
+                        runInitBootstrap(
+                            command = InitCommand(projectRoot = repoRoot),
+                            ideRefreshRunner = { error("should not refresh IDE helper when conflict exists") },
+                        )
+                    }
+
+                error.message.shouldContain("exists but is not a regular file")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "throws validation error when repository root does not exist" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-missing")
+            repoRoot.deleteRecursively()
+
+            val error =
+                shouldThrow<IllegalArgumentException> {
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { error("should not refresh IDE helper when root is missing") },
+                    )
+                }
+
+            error.message.shouldContain("does not exist")
+            repoRoot.exists() shouldBe false
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/parsing/CliParserTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/parsing/CliParserTests.kt
@@ -5,7 +5,9 @@ import io.kotest.matchers.shouldBe
 import me.liam.microsmith.cli.command.DoctorCommand
 import me.liam.microsmith.cli.command.ErrorCommand
 import me.liam.microsmith.cli.command.HelpCommand
+import me.liam.microsmith.cli.command.IdeDoctorCommand
 import me.liam.microsmith.cli.command.IdeRefreshCommand
+import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.command.RunCommand
 import me.liam.microsmith.cli.diagnostics.DiagnosticFormat
 import me.liam.microsmith.runtime.scripting.model.ScriptIsolationMode
@@ -29,6 +31,32 @@ class CliParserTests :
                 )
         }
 
+        "parses init command with defaults" {
+            parseCliArgs(listOf("init")) shouldBe InitCommand()
+        }
+
+        "parses init command options" {
+            parseCliArgs(
+                listOf(
+                    "init",
+                    "--repo-root",
+                    "examples/go-service",
+                    "--non-interactive",
+                    "--yes",
+                    "--diagnostics",
+                    "json",
+                    "--verbose",
+                ),
+            ) shouldBe
+                InitCommand(
+                    projectRoot = Path("examples/go-service"),
+                    diagnosticsFormat = DiagnosticFormat.JSON,
+                    verbose = true,
+                    nonInteractive = true,
+                    assumeYes = true,
+                )
+        }
+
         "parses ide refresh command with defaults" {
             parseCliArgs(listOf("ide", "refresh")) shouldBe IdeRefreshCommand()
         }
@@ -47,6 +75,25 @@ class CliParserTests :
             ) shouldBe
                 IdeRefreshCommand(
                     projectRoot = Path("examples/go-service"),
+                    diagnosticsFormat = DiagnosticFormat.JSON,
+                    verbose = true,
+                )
+        }
+
+        "parses ide doctor command options" {
+            parseCliArgs(
+                listOf(
+                    "ide",
+                    "doctor",
+                    "--repo-root",
+                    "examples/dotnet-service",
+                    "--diagnostics",
+                    "json",
+                    "--verbose",
+                ),
+            ) shouldBe
+                IdeDoctorCommand(
+                    projectRoot = Path("examples/dotnet-service"),
                     diagnosticsFormat = DiagnosticFormat.JSON,
                     verbose = true,
                 )
@@ -206,12 +253,12 @@ class CliParserTests :
         }
 
         "returns error when ide subcommand is missing" {
-            parseCliArgs(listOf("ide")) shouldBe ErrorCommand("Missing <refresh> subcommand for ide command.")
+            parseCliArgs(listOf("ide")) shouldBe ErrorCommand("Missing <refresh|doctor> subcommand for ide command.")
         }
 
         "returns error for unknown ide subcommand" {
-            parseCliArgs(listOf("ide", "doctor")) shouldBe
-                ErrorCommand("Unknown ide subcommand 'doctor'. Expected 'refresh'.")
+            parseCliArgs(listOf("ide", "lint")) shouldBe
+                ErrorCommand("Unknown ide subcommand 'lint'. Expected 'refresh' or 'doctor'.")
         }
 
         "returns error for unknown ide option" {
@@ -245,6 +292,42 @@ class CliParserTests :
         "returns error when ide verbose is specified multiple times" {
             parseCliArgs(listOf("ide", "refresh", "--verbose", "--verbose")) shouldBe
                 ErrorCommand("--verbose may only be specified once.")
+        }
+
+        "returns error for unknown ide doctor option" {
+            parseCliArgs(listOf("ide", "doctor", "--event-log", "build/event-log.jsonl")) shouldBe
+                ErrorCommand("Unknown option '--event-log'.")
+        }
+
+        "returns error for unknown init option" {
+            parseCliArgs(listOf("init", "--event-log", "build/event-log.jsonl")) shouldBe
+                ErrorCommand("Unknown option '--event-log'.")
+        }
+
+        "returns error when init diagnostics format is invalid" {
+            parseCliArgs(listOf("init", "--diagnostics", "yaml")) shouldBe
+                ErrorCommand("Invalid --diagnostics value 'yaml'. Expected 'text' or 'json'.")
+        }
+
+        "returns error when init repo-root value is missing" {
+            parseCliArgs(listOf("init", "--repo-root")) shouldBe
+                ErrorCommand("Missing value for --repo-root option.")
+        }
+
+        "returns error when init repo-root is specified multiple times" {
+            parseCliArgs(
+                listOf("init", "--repo-root", "one", "--repo-root", "two"),
+            ) shouldBe ErrorCommand("--repo-root may only be specified once.")
+        }
+
+        "returns error when init non-interactive is specified multiple times" {
+            parseCliArgs(listOf("init", "--non-interactive", "--non-interactive")) shouldBe
+                ErrorCommand("--non-interactive may only be specified once.")
+        }
+
+        "returns error when init yes is specified multiple times" {
+            parseCliArgs(listOf("init", "--yes", "--yes")) shouldBe
+                ErrorCommand("--yes may only be specified once.")
         }
 
         "returns error for unknown doctor option" {

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -2,6 +2,7 @@
 
 Phase 5 documentation for distribution and adoption lives in this folder.
 
+- `command-contract.md`: canonical setup/IDE command behavior, non-interactive contract, and exit-code table.
 - `quickstart-non-gradle.md`: fast setup for Node, Go, and .NET repositories, including CI snippets.
 - `jetbrains-ide-helper.md`: `.microsmith/ide` helper generation and indexing guidance for JetBrains IDEs.
 - `migration-from-gradle.md`: migration guide for existing Gradle-centric users.

--- a/docs/cli/command-contract.md
+++ b/docs/cli/command-contract.md
@@ -1,0 +1,73 @@
+# CLI Command Contract (`init` + `ide`)
+
+This document is the source of truth for setup and IDE workflow command behavior.
+
+## Canonical command surface
+
+- `microsmith init [--repo-root <path>] [--non-interactive] [--yes] [--diagnostics <text|json>] [--verbose]`
+- `microsmith ide refresh [--repo-root <path>] [--diagnostics <text|json>] [--verbose]`
+- `microsmith ide doctor [--repo-root <path>] [--diagnostics <text|json>] [--verbose]`
+
+## Default `init` behavior
+
+`microsmith init` is deterministic and non-destructive by default:
+
+- creates `settings.microsmith.kts` when missing
+- creates `build.microsmith.kts` when missing
+- preserves existing bootstrap files (does not overwrite)
+- refreshes `.microsmith/ide/*` helper metadata
+- prints exact immediate next generation command
+
+After successful init, no mandatory IDE follow-up command is required for the default flow.
+
+## Canonical happy paths
+
+Local:
+
+```bash
+microsmith init
+microsmith run build.microsmith.kts --out ./generated
+```
+
+CI non-interactive:
+
+```bash
+microsmith init --non-interactive --yes --diagnostics json --verbose
+microsmith run build.microsmith.kts --out ./generated --diagnostics json --verbose
+```
+
+Maintenance:
+
+```bash
+microsmith ide doctor --diagnostics json --verbose
+microsmith ide refresh
+```
+
+## Non-interactive contract
+
+- `--non-interactive` and `--yes` are supported for CI automation.
+- No interactive prompts are emitted in non-interactive mode.
+- Diagnostics output remains deterministic with `--diagnostics json`.
+
+## Exit codes
+
+| Category | Code | Exit | Meaning |
+|---|---|---:|---|
+| Usage | `MS-CLI-0001` | `2` | Invalid command/flags. |
+| IDE refresh failure | `MS-CLI-4001` | `40` | `ide refresh` failed. |
+| IDE doctor failure | `MS-CLI-4101` | `41` | `ide doctor` detected issues or failed. |
+| Init conflict | `MS-CLI-5001` | `50` | `init` detected conflicting filesystem state. |
+| Init validation failure | `MS-CLI-5002` | `51` | `init` input/environment validation failed. |
+| Init runtime failure | `MS-CLI-5003` | `52` | `init` failed unexpectedly at runtime. |
+
+## Machine-readable diagnostics contract
+
+When `--diagnostics json` is used, each event is a single JSON line with:
+
+- `timestamp` (UTC instant)
+- `level` (`info`, `warn`, `error`)
+- `message`
+- `code` (for error events)
+- `details` (included when `--verbose` is enabled)
+
+This contract is stable for automation and CI parsing.

--- a/docs/cli/jetbrains-ide-helper.md
+++ b/docs/cli/jetbrains-ide-helper.md
@@ -17,6 +17,15 @@ Optional flags:
 - `--diagnostics <text|json>`: choose output format.
 - `--verbose`: include additional diagnostic details.
 
+## Validate helper health
+
+```bash
+microsmith ide doctor --diagnostics json --verbose
+```
+
+`ide doctor` validates helper directory/file presence and classpath synchronization, then reports
+actionable remediation when helper metadata is stale.
+
 ## Generated files
 
 Command output is constrained to `.microsmith/ide`:

--- a/docs/cli/quickstart-non-gradle.md
+++ b/docs/cli/quickstart-non-gradle.md
@@ -9,7 +9,27 @@ This guide shows how to run Microsmith CLI from repositories that do not use Gra
   - `microsmith-cli-<version>-all.jar`, or
   - `microsmith-cli-<version>-dist.zip` / `microsmith-cli-<version>-dist.tar.gz`.
 
-## Minimal script
+## Recommended bootstrap path
+
+Initialize repository defaults and IDE helper metadata:
+
+```bash
+microsmith init
+```
+
+Then run generation from the default bootstrap script:
+
+```bash
+microsmith run build.microsmith.kts --out ./generated
+```
+
+For CI:
+
+```bash
+microsmith init --non-interactive --yes --diagnostics json --verbose
+```
+
+## Manual script path
 
 Create `schema.microsmith.kts`:
 
@@ -50,6 +70,12 @@ Generate helper project metadata for JetBrains IDE indexing:
 
 ```bash
 microsmith ide refresh
+```
+
+Validate helper state and detect stale classpath metadata:
+
+```bash
+microsmith ide doctor --diagnostics json --verbose
 ```
 
 If your repository root is not the current working directory:

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -21,6 +21,18 @@ Actions:
 - use deterministic diagnostics in CLI output (`[error] file:line:column`)
 - fix unknown DSL calls and missing imports
 
+## Init/bootstrap issues
+
+Symptom:
+- `microsmith init` exits non-zero
+- expected bootstrap files are not created
+
+Actions:
+- run `microsmith init --diagnostics json --verbose` and inspect the `code` field
+- verify repository root path (or pass `--repo-root <path>`)
+- resolve filesystem conflicts (for example, `build.microsmith.kts` exists as a directory)
+- rerun `microsmith init` after conflict cleanup
+
 ## Resolver and plugin failures
 
 Symptom:
@@ -75,6 +87,7 @@ Symptom:
 
 Actions:
 - run `microsmith ide refresh` from repository root
+- run `microsmith ide doctor --diagnostics json --verbose` to validate helper health
 - in JetBrains IDE, re-import or refresh `.microsmith/ide/build.gradle.kts`
 - verify helper files exist under `.microsmith/ide/` and were updated
 - if repository root is non-standard, rerun with `--repo-root <path>`

--- a/docs/release/cli-runtime-notes.md
+++ b/docs/release/cli-runtime-notes.md
@@ -8,7 +8,9 @@
 - Installation options:
   - run fat jar directly: `java -jar microsmith-cli-<version>-all.jar --help`
   - unpack distribution archive and run launcher script
+  - bootstrap repository defaults: `microsmith init`
   - generate JetBrains IDE helper metadata: `microsmith ide refresh`
+  - validate JetBrains IDE helper health: `microsmith ide doctor`
 - Bundled plugin policy:
   - bundled plugin coordinates are pinned to the CLI release version
   - bundled profile content must stay checksum-verifiable and deterministic across artifacts


### PR DESCRIPTION
## Summary
Implements #54 by finalizing the CLI setup + IDE contract around `init` and `ide` workflows.

This PR introduces canonical command surfaces, deterministic exit-code categories for setup/IDE lifecycle failures, CI-safe non-interactive flags, and authoritative documentation for local + CI command sequences.

Closes #54.

## What Changed

### 1) Canonical command surface implemented
- Added `microsmith init`
  - options: `--repo-root`, `--non-interactive`, `--yes`, `--diagnostics`, `--verbose`
- Added `microsmith ide doctor`
  - options: `--repo-root`, `--diagnostics`, `--verbose`
- Retained `microsmith ide refresh` as lifecycle command.

### 2) Deterministic setup/IDE command behavior
- `init` now performs deterministic bootstrap:
  - validates repository root
  - creates `settings.microsmith.kts` and `build.microsmith.kts` when missing
  - preserves existing bootstrap files (non-destructive default)
  - refreshes `.microsmith/ide` helper metadata
  - emits canonical next-run command (`microsmith run build.microsmith.kts --out ./generated`)
- `ide doctor` validates helper lifecycle state:
  - helper directory presence
  - required helper files presence
  - runtime classpath resolvability
  - classpath sync between runtime and helper `build.gradle.kts`

### 3) Exit-code contract finalized for setup/IDE categories
- Added failure codes:
  - `MS-CLI-4101` / exit `41` (`IDE_DOCTOR_FAILED`)
  - `MS-CLI-5001` / exit `50` (`INIT_CONFLICT`)
  - `MS-CLI-5002` / exit `51` (`INIT_VALIDATION_FAILED`)
  - `MS-CLI-5003` / exit `52` (`INIT_RUNTIME_FAILED`)
- Existing `MS-CLI-4001` (`ide refresh`) remains unchanged.

### 4) Parser + CLI contract enforcement
- Parser supports full init + ide doctor option sets.
- Duplicate/missing/invalid option states are explicitly validated and deterministic.
- `ide` subcommand contract now supports `refresh|doctor`.

### 5) Documentation contract (single source of truth)
- Added `docs/cli/command-contract.md` covering:
  - canonical local + CI sequences
  - non-interactive behavior
  - stable JSON diagnostics payload contract
  - exit-code table
- Updated docs and quickstart/release notes for discoverability and consistency.

## Files of Interest
- CLI contract and execution:
  - `cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt`
  - `cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt`
  - `cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt`
  - `cli/src/main/kotlin/me/liam/microsmith/cli/diagnostics/CliDiagnostics.kt`
- New command models:
  - `cli/src/main/kotlin/me/liam/microsmith/cli/command/InitCommand.kt`
  - `cli/src/main/kotlin/me/liam/microsmith/cli/command/IdeDoctorCommand.kt`
- New lifecycle/bootstrap logic:
  - `cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt`
  - `cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctor.kt`
- Shared helper constants/utilities:
  - `cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperGenerator.kt`
- Tests:
  - `cli/src/test/kotlin/me/liam/microsmith/cli/parsing/CliParserTests.kt`
  - `cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliTests.kt`
  - `cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt`
  - `cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorTests.kt`
- Docs:
  - `docs/cli/command-contract.md`
  - `docs/cli/README.md`
  - `docs/cli/quickstart-non-gradle.md`
  - `docs/cli/jetbrains-ide-helper.md`
  - `docs/cli/troubleshooting.md`
  - `docs/release/cli-runtime-notes.md`
  - `README.md`

## Validation
- `./gradlew :cli:check :cli:jvmKotest`
- Manual smoke (fat jar):
  - `microsmith init --repo-root <tmp> --non-interactive --yes --diagnostics json --verbose`
  - verified generated assets:
    - `build.microsmith.kts`
    - `settings.microsmith.kts`
    - `.microsmith/ide/{settings.gradle.kts,build.gradle.kts,README.md}`
  - `microsmith ide doctor --repo-root <tmp> --diagnostics json --verbose` returns success.

## Notes
- This PR finalizes command contract behavior and deterministic failure taxonomy; issue #52 can now build on this contract for deeper onboarding defaults and repo-type specialization.
