### PR TITLE
feat(onboarding): add one-command bootstrap for non-JVM repositories

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -222,6 +222,24 @@ jobs:
           test -f install-smoke-repo/settings.microsmith.kts
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
           test -f install-smoke-repo/generated/proto/UserCreated.proto
+      - name: Smoke test Node and Go onboarding fixtures (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          set -eu
+          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node
+          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node --non-interactive --yes
+          test -f examples/non-gradle/node/build.microsmith.kts
+          test -f examples/non-gradle/node/settings.microsmith.kts
+          test -f examples/non-gradle/node/.microsmith/ide/build.gradle.kts
+          ./.microsmith-bin/microsmith run examples/non-gradle/node/build.microsmith.kts --out examples/non-gradle/node/generated
+          test -f examples/non-gradle/node/generated/proto/NodeUserCreated.proto
+          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go --non-interactive --yes
+          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go
+          test -f examples/non-gradle/go/build.microsmith.kts
+          test -f examples/non-gradle/go/settings.microsmith.kts
+          test -f examples/non-gradle/go/.microsmith/ide/build.gradle.kts
+          ./.microsmith-bin/microsmith run examples/non-gradle/go/build.microsmith.kts --out examples/non-gradle/go/internal/gen
+          test -f examples/non-gradle/go/internal/gen/proto/GoUserCreated.proto
       - name: Install and verify from installer (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -272,5 +290,37 @@ jobs:
           }
           if (-not (Test-Path .\install-smoke-repo\generated\proto\UserCreated.proto)) {
             Write-Error "Expected generated\\proto\\UserCreated.proto to exist after run."
+            exit 1
+          }
+      - name: Smoke test .NET onboarding fixture (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          & .\.microsmith-bin\microsmith.cmd init --repo-root examples/non-gradle/dotnet
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          & .\.microsmith-bin\microsmith.cmd init --repo-root examples/non-gradle/dotnet --non-interactive --yes
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          if (-not (Test-Path .\examples\non-gradle\dotnet\build.microsmith.kts)) {
+            Write-Error "Expected build.microsmith.kts to exist for the .NET fixture."
+            exit 1
+          }
+          if (-not (Test-Path .\examples\non-gradle\dotnet\settings.microsmith.kts)) {
+            Write-Error "Expected settings.microsmith.kts to exist for the .NET fixture."
+            exit 1
+          }
+          if (-not (Test-Path .\examples\non-gradle\dotnet\.microsmith\ide\build.gradle.kts)) {
+            Write-Error "Expected IDE helper build.gradle.kts to exist for the .NET fixture."
+            exit 1
+          }
+          & .\.microsmith-bin\microsmith.cmd run examples/non-gradle/dotnet/build.microsmith.kts --out examples/non-gradle/dotnet/Generated
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          if (-not (Test-Path .\examples\non-gradle\dotnet\Generated\proto\DotnetUserCreated.proto)) {
+            Write-Error "Expected Generated\\proto\\DotnetUserCreated.proto to exist for the .NET fixture."
             exit 1
           }

--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -217,7 +217,7 @@ jobs:
             --no-profile-update
           ./.microsmith-bin/microsmith --version
           mkdir -p install-smoke-repo
-          ./.microsmith-bin/microsmith init --repo-root install-smoke-repo --non-interactive --yes
+          ./.microsmith-bin/microsmith init --repo-root install-smoke-repo
           test -f install-smoke-repo/build.microsmith.kts
           test -f install-smoke-repo/settings.microsmith.kts
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
@@ -227,13 +227,13 @@ jobs:
         run: |
           set -eu
           ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node
-          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node --non-interactive --yes
+          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node
           test -f examples/non-gradle/node/build.microsmith.kts
           test -f examples/non-gradle/node/settings.microsmith.kts
           test -f examples/non-gradle/node/.microsmith/ide/build.gradle.kts
           ./.microsmith-bin/microsmith run examples/non-gradle/node/build.microsmith.kts --out examples/non-gradle/node/generated
           test -f examples/non-gradle/node/generated/proto/NodeUserCreated.proto
-          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go --non-interactive --yes
+          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go
           ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go
           test -f examples/non-gradle/go/build.microsmith.kts
           test -f examples/non-gradle/go/settings.microsmith.kts
@@ -272,7 +272,7 @@ jobs:
             exit $LASTEXITCODE
           }
           New-Item -ItemType Directory -Path install-smoke-repo -Force | Out-Null
-          & .\.microsmith-bin\microsmith.cmd init --repo-root install-smoke-repo --non-interactive --yes
+          & .\.microsmith-bin\microsmith.cmd init --repo-root install-smoke-repo
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -300,7 +300,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
-          & .\.microsmith-bin\microsmith.cmd init --repo-root examples/non-gradle/dotnet --non-interactive --yes
+          & .\.microsmith-bin\microsmith.cmd init --repo-root examples/non-gradle/dotnet
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }

--- a/README.md
+++ b/README.md
@@ -133,16 +133,26 @@ microsmith run build.microsmith.kts --out ./generated
 
 `microsmith init` is deterministic and non-destructive by default:
 
+- it detects Node, Go, and .NET repositories from `package.json`, `go.mod`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
 - it creates `settings.microsmith.kts` when missing
 - it creates `build.microsmith.kts` when missing
-- it preserves existing bootstrap files instead of overwriting them
-- it refreshes `.microsmith/ide/*` helper metadata
-- it prints the next generation command to run
+- it preserves existing regular bootstrap files instead of overwriting them
+- it refreshes `.microsmith/ide/*` helper metadata by default
+- it prints configured assets and the exact next generation command to run
 
 Important behavior:
 
 - if you pass `--repo-root <path>`, that directory must already exist
+- pass `--force` when you want the managed bootstrap scripts to replace existing regular files
+- pass `--skip-ide-helper` when you do not want `.microsmith/ide/*` generated during `init`
+- if you skip IDE helper generation, `microsmith doctor` will continue to report bootstrap as incomplete until you run `microsmith ide refresh`
 - after a successful `init`, no additional IDE command is required for the default path
+
+After the canonical first run succeeds, you can switch to a repository-native output layout if you prefer:
+
+- Node: `microsmith run build.microsmith.kts --out ./generated`
+- Go: `microsmith run build.microsmith.kts --out ./internal/gen`
+- .NET: `microsmith run build.microsmith.kts --out ./Generated`
 
 ### Direct script execution
 
@@ -203,12 +213,16 @@ Use the installed shim path before opening a new shell:
 
 ```bash
 "$HOME/.microsmith/bin/microsmith" --version
-"$HOME/.microsmith/bin/microsmith" init --non-interactive --yes
+mkdir -p ./microsmith-smoke
+"$HOME/.microsmith/bin/microsmith" init --repo-root ./microsmith-smoke --non-interactive --yes
+"$HOME/.microsmith/bin/microsmith" run ./microsmith-smoke/build.microsmith.kts --out ./microsmith-smoke/generated
 ```
 
 ```powershell
 & (Join-Path $HOME ".microsmith\bin\microsmith.cmd") --version
-& (Join-Path $HOME ".microsmith\bin\microsmith.cmd") init --non-interactive --yes
+New-Item -ItemType Directory -Path .\microsmith-smoke -Force | Out-Null
+& (Join-Path $HOME ".microsmith\bin\microsmith.cmd") init --repo-root .\microsmith-smoke --non-interactive --yes
+& (Join-Path $HOME ".microsmith\bin\microsmith.cmd") run .\microsmith-smoke\build.microsmith.kts --out .\microsmith-smoke\generated
 ```
 
 After opening a new shell, the bare `microsmith` command is available on `PATH`.
@@ -271,8 +285,8 @@ Current CLI usage:
 Microsmith CLI
 
 Usage:
-  microsmith init [--repo-root <path>] [--non-interactive] [--yes]
-                 [--diagnostics <text|json>] [--verbose]
+  microsmith init [--repo-root <path>] [--non-interactive] [--yes] [--force]
+                 [--skip-ide-helper] [--diagnostics <text|json>] [--verbose]
   microsmith run <script.microsmith.kts> --out <output-dir> [--var <name=value>]... [--flag <name>]...
                  [--plugin <group:artifact:version>]... [--plugin-jar <path>]...
                  [--offline] [--repository <uri>] [--isolation <classloader|process>]
@@ -313,8 +327,10 @@ microsmith ide refresh
 `microsmith init`
 
 - bootstraps `settings.microsmith.kts` and `build.microsmith.kts`
-- refreshes `.microsmith/ide`
-- supports `--repo-root`, `--non-interactive`, `--yes`, `--diagnostics`, and `--verbose`
+- detects Node, Go, .NET, or generic repository shape and emits a matching starter script
+- refreshes `.microsmith/ide` by default
+- preserves existing regular bootstrap files unless `--force` is provided
+- supports `--repo-root`, `--non-interactive`, `--yes`, `--force`, `--skip-ide-helper`, `--diagnostics`, and `--verbose`
 
 `microsmith run`
 
@@ -325,7 +341,7 @@ microsmith ide refresh
 `microsmith doctor`
 
 - validates the runtime environment
-- checks Java runtime availability, built-in provider discovery, script cache writability, plugin cache writability, and repository policy initialization
+- checks Java runtime availability, built-in provider discovery, script cache writability, plugin cache writability, repository policy initialization, and incomplete bootstrap state in the current working directory
 
 `microsmith ide refresh`
 
@@ -369,6 +385,8 @@ When `--diagnostics json` is used, each event is emitted as one JSON line with:
 
 Use the helper project when your repository is not Gradle-based and you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, and Rider.
 
+`microsmith init` already refreshes the helper by default. Use `microsmith ide refresh` when you skipped helper generation during init or need to repair or resynchronize the helper later.
+
 Generate or refresh the helper:
 
 ```bash
@@ -395,7 +413,7 @@ Generated files:
 
 JetBrains workflow:
 
-1. Run `microsmith ide refresh` from the repository root.
+1. Run `microsmith init` from the repository root, or `microsmith ide refresh` if helper generation was skipped earlier.
 2. Link or import `.microsmith/ide/build.gradle.kts` as a Gradle project in the IDE.
 3. Refresh Gradle indexing.
 4. Rerun `microsmith ide refresh` after upgrading the Microsmith CLI or changing plugin dependencies.
@@ -516,8 +534,10 @@ jobs:
           curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
           sh microsmith-install.sh --version "$MICROSMITH_VERSION"
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        run: microsmith init --non-interactive --yes
       - name: Run Microsmith
-        run: microsmith run schema.microsmith.kts --out generated/proto
+        run: microsmith run build.microsmith.kts --out generated
 ```
 
 ### Go repository
@@ -536,8 +556,10 @@ jobs:
           curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
           sh microsmith-install.sh --version "$MICROSMITH_VERSION"
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        run: microsmith init --non-interactive --yes
       - name: Generate protobuf
-        run: microsmith run schema.microsmith.kts --out internal/gen/proto
+        run: microsmith run build.microsmith.kts --out internal/gen
 ```
 
 ### .NET repository
@@ -557,21 +579,24 @@ jobs:
           Invoke-WebRequest -Uri $env:MICROSMITH_INSTALLER_PS1_URL -OutFile microsmith-install.ps1
           .\microsmith-install.ps1 -Version $env:MICROSMITH_VERSION
           Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $HOME ".microsmith\bin")
+      - name: Bootstrap Microsmith
+        shell: pwsh
+        run: microsmith init --non-interactive --yes
       - name: Run Microsmith
         shell: pwsh
-        run: microsmith run schema.microsmith.kts --out .\Generated\Proto
+        run: microsmith run build.microsmith.kts --out .\Generated
 ```
 
 ## Example fixtures
 
 The repository includes non-Gradle fixture repositories under `examples/non-gradle/`.
-Each fixture contains a `schema.microsmith.kts` and a GitHub Actions example.
+Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.microsmith.kts` manual example, and a GitHub Actions example that exercises the init-first path.
 
 | Fixture | Directory | Local command from fixture root | CI workflow |
 | --- | --- | --- | --- |
-| Node | `examples/non-gradle/node` | `microsmith run schema.microsmith.kts --out ./generated/proto` | `examples/non-gradle/node/.github/workflows/microsmith.yml` |
-| Go | `examples/non-gradle/go` | `microsmith run schema.microsmith.kts --out ./internal/gen/proto` | `examples/non-gradle/go/.github/workflows/microsmith.yml` |
-| .NET | `examples/non-gradle/dotnet` | `microsmith run schema.microsmith.kts --out .\Generated\Proto` | `examples/non-gradle/dotnet/.github/workflows/microsmith.yml` |
+| Node | `examples/non-gradle/node` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated` | `examples/non-gradle/node/.github/workflows/microsmith.yml` |
+| Go | `examples/non-gradle/go` | `microsmith init` then `microsmith run build.microsmith.kts --out ./internal/gen` | `examples/non-gradle/go/.github/workflows/microsmith.yml` |
+| .NET | `examples/non-gradle/dotnet` | `microsmith init` then `microsmith run build.microsmith.kts --out .\Generated` | `examples/non-gradle/dotnet/.github/workflows/microsmith.yml` |
 
 ## Troubleshooting
 
@@ -616,7 +641,10 @@ What to do:
 - confirm the script file ends with `.microsmith.kts`
 - rerun with `--diagnostics json --verbose`
 - ensure `--repo-root` points to an existing directory
+- run `microsmith doctor --diagnostics json --verbose` to detect incomplete bootstrap state
 - resolve filesystem conflicts such as a directory already existing at `build.microsmith.kts`
+- rerun `microsmith init --force` if you want the managed bootstrap scripts to replace existing regular files
+- if helper generation was skipped earlier, run `microsmith ide refresh` before importing `.microsmith/ide` into JetBrains IDEs
 
 ### Resolver, credentials, and offline failures
 

--- a/README.md
+++ b/README.md
@@ -214,14 +214,14 @@ Use the installed shim path before opening a new shell:
 ```bash
 "$HOME/.microsmith/bin/microsmith" --version
 mkdir -p ./microsmith-smoke
-"$HOME/.microsmith/bin/microsmith" init --repo-root ./microsmith-smoke --non-interactive --yes
+"$HOME/.microsmith/bin/microsmith" init --repo-root ./microsmith-smoke
 "$HOME/.microsmith/bin/microsmith" run ./microsmith-smoke/build.microsmith.kts --out ./microsmith-smoke/generated
 ```
 
 ```powershell
 & (Join-Path $HOME ".microsmith\bin\microsmith.cmd") --version
 New-Item -ItemType Directory -Path .\microsmith-smoke -Force | Out-Null
-& (Join-Path $HOME ".microsmith\bin\microsmith.cmd") init --repo-root .\microsmith-smoke --non-interactive --yes
+& (Join-Path $HOME ".microsmith\bin\microsmith.cmd") init --repo-root .\microsmith-smoke
 & (Join-Path $HOME ".microsmith\bin\microsmith.cmd") run .\microsmith-smoke\build.microsmith.kts --out .\microsmith-smoke\generated
 ```
 
@@ -285,8 +285,8 @@ Current CLI usage:
 Microsmith CLI
 
 Usage:
-  microsmith init [--repo-root <path>] [--non-interactive] [--yes] [--force]
-                 [--skip-ide-helper] [--diagnostics <text|json>] [--verbose]
+  microsmith init [--repo-root <path>] [--force] [--skip-ide-helper]
+                 [--diagnostics <text|json>] [--verbose]
   microsmith run <script.microsmith.kts> --out <output-dir> [--var <name=value>]... [--flag <name>]...
                  [--plugin <group:artifact:version>]... [--plugin-jar <path>]...
                  [--offline] [--repository <uri>] [--isolation <classloader|process>]
@@ -310,7 +310,7 @@ microsmith run build.microsmith.kts --out ./generated
 CI:
 
 ```bash
-microsmith init --non-interactive --yes --diagnostics json --verbose
+microsmith init --diagnostics json --verbose
 microsmith run build.microsmith.kts --out ./generated --diagnostics json --verbose
 ```
 
@@ -330,7 +330,7 @@ microsmith ide refresh
 - detects Node, Go, .NET, or generic repository shape and emits a matching starter script
 - refreshes `.microsmith/ide` by default
 - preserves existing regular bootstrap files unless `--force` is provided
-- supports `--repo-root`, `--non-interactive`, `--yes`, `--force`, `--skip-ide-helper`, `--diagnostics`, and `--verbose`
+- supports `--repo-root`, `--force`, `--skip-ide-helper`, `--diagnostics`, and `--verbose`
 
 `microsmith run`
 
@@ -535,7 +535,7 @@ jobs:
           sh microsmith-install.sh --version "$MICROSMITH_VERSION"
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
       - name: Bootstrap Microsmith
-        run: microsmith init --non-interactive --yes
+        run: microsmith init
       - name: Run Microsmith
         run: microsmith run build.microsmith.kts --out generated
 ```
@@ -557,7 +557,7 @@ jobs:
           sh microsmith-install.sh --version "$MICROSMITH_VERSION"
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
       - name: Bootstrap Microsmith
-        run: microsmith init --non-interactive --yes
+        run: microsmith init
       - name: Generate protobuf
         run: microsmith run build.microsmith.kts --out internal/gen
 ```
@@ -581,7 +581,7 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $HOME ".microsmith\bin")
       - name: Bootstrap Microsmith
         shell: pwsh
-        run: microsmith init --non-interactive --yes
+        run: microsmith init
       - name: Run Microsmith
         shell: pwsh
         run: microsmith run build.microsmith.kts --out .\Generated

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
@@ -4,8 +4,8 @@ internal const val HELP_TEXT = """
 Microsmith CLI
 
 Usage:
-  microsmith init [--repo-root <path>] [--non-interactive] [--yes] [--force]
-                 [--skip-ide-helper] [--diagnostics <text|json>] [--verbose]
+  microsmith init [--repo-root <path>] [--force] [--skip-ide-helper]
+                 [--diagnostics <text|json>] [--verbose]
   microsmith run <script.microsmith.kts> --out <output-dir> [--var <name=value>]... [--flag <name>]...
                  [--plugin <group:artifact:version>]... [--plugin-jar <path>]...
                  [--offline] [--repository <uri>] [--isolation <classloader|process>]

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/CliHelpText.kt
@@ -4,8 +4,8 @@ internal const val HELP_TEXT = """
 Microsmith CLI
 
 Usage:
-  microsmith init [--repo-root <path>] [--non-interactive] [--yes]
-                 [--diagnostics <text|json>] [--verbose]
+  microsmith init [--repo-root <path>] [--non-interactive] [--yes] [--force]
+                 [--skip-ide-helper] [--diagnostics <text|json>] [--verbose]
   microsmith run <script.microsmith.kts> --out <output-dir> [--var <name=value>]... [--flag <name>]...
                  [--plugin <group:artifact:version>]... [--plugin-jar <path>]...
                  [--offline] [--repository <uri>] [--isolation <classloader|process>]

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
@@ -22,6 +22,7 @@ import me.liam.microsmith.cli.ide.refreshIdeHelperProject
 import me.liam.microsmith.cli.ide.runIdeHelperDoctor
 import me.liam.microsmith.cli.init.InitBootstrapResult
 import me.liam.microsmith.cli.init.InitConflictException
+import me.liam.microsmith.cli.init.InitValidationException
 import me.liam.microsmith.cli.init.describeForSummary
 import me.liam.microsmith.cli.init.runInitBootstrap
 import me.liam.microsmith.cli.parsing.parseCliArgs
@@ -223,7 +224,7 @@ internal class MicrosmithCli(
                 val code =
                     when (error) {
                         is InitConflictException -> CliFailureCode.INIT_CONFLICT
-                        is IllegalArgumentException -> CliFailureCode.INIT_VALIDATION_FAILED
+                        is InitValidationException -> CliFailureCode.INIT_VALIDATION_FAILED
                         else -> CliFailureCode.INIT_RUNTIME_FAILED
                     }
                 emitter.error(code, error.message ?: "Microsmith init failed.")
@@ -243,8 +244,6 @@ internal class MicrosmithCli(
                 "preservedFiles" to result.preservedFiles.size.toString(),
                 "ideHelperUpdatedFiles" to (result.ideHelperResult?.updatedFiles?.size ?: 0).toString(),
                 "ideHelperSkipped" to command.skipIdeHelper.toString(),
-                "nonInteractive" to command.nonInteractive.toString(),
-                "assumeYes" to command.assumeYes.toString(),
                 "force" to command.force.toString(),
             ),
         )

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/MicrosmithCli.kt
@@ -22,6 +22,7 @@ import me.liam.microsmith.cli.ide.refreshIdeHelperProject
 import me.liam.microsmith.cli.ide.runIdeHelperDoctor
 import me.liam.microsmith.cli.init.InitBootstrapResult
 import me.liam.microsmith.cli.init.InitConflictException
+import me.liam.microsmith.cli.init.describeForSummary
 import me.liam.microsmith.cli.init.runInitBootstrap
 import me.liam.microsmith.cli.parsing.parseCliArgs
 import me.liam.microsmith.cli.plugins.PluginResolutionResult
@@ -235,15 +236,84 @@ internal class MicrosmithCli(
             details =
             mapOf(
                 "projectRoot" to projectRoot.toString(),
+                "repositoryType" to result.repositoryDetection.type.displayName,
+                "matchedMarkers" to result.repositoryDetection.matchedMarkers.joinToString(separator = ","),
                 "createdFiles" to result.createdFiles.size.toString(),
+                "overwrittenFiles" to result.overwrittenFiles.size.toString(),
                 "preservedFiles" to result.preservedFiles.size.toString(),
-                "ideHelperUpdatedFiles" to result.ideHelperResult.updatedFiles.size.toString(),
+                "ideHelperUpdatedFiles" to (result.ideHelperResult?.updatedFiles?.size ?: 0).toString(),
+                "ideHelperSkipped" to command.skipIdeHelper.toString(),
                 "nonInteractive" to command.nonInteractive.toString(),
                 "assumeYes" to command.assumeYes.toString(),
+                "force" to command.force.toString(),
             ),
         )
+        emitter.info("Detected repository type: ${result.repositoryDetection.describeForSummary()}.")
+        emitInitBootstrapSummary(emitter = emitter, command = command, result = result)
+        emitIdeHelperSummary(emitter = emitter, result = result)
         emitter.info("Next: microsmith run build.microsmith.kts --out ./generated")
+        result.repositoryDetection.type.repoNativeOutputDirectory?.let { outputDirectory ->
+            emitter.info(
+                "Optional repository-native output path: " +
+                    "microsmith run build.microsmith.kts --out $outputDirectory",
+            )
+        }
         return 0
+    }
+
+    private fun emitInitBootstrapSummary(
+        emitter: CliDiagnosticEmitter,
+        command: InitCommand,
+        result: InitBootstrapResult,
+    ) {
+        if (result.createdFiles.isNotEmpty()) {
+            emitter.info(
+                "Created bootstrap files: ${result.createdFiles.formatForDisplay(result.projectRoot)}",
+            )
+        }
+        if (result.overwrittenFiles.isNotEmpty()) {
+            emitter.info(
+                "Overwrote bootstrap files: ${result.overwrittenFiles.formatForDisplay(result.projectRoot)}",
+            )
+        }
+        if (result.preservedFiles.isNotEmpty()) {
+            val message =
+                if (command.force) {
+                    "Preserved bootstrap files already matching the managed templates"
+                } else {
+                    "Preserved existing bootstrap files"
+                }
+            emitter.info("$message: ${result.preservedFiles.formatForDisplay(result.projectRoot)}")
+            if (!command.force) {
+                emitter.info(
+                    "Re-run with --force to replace existing regular bootstrap files " +
+                        "with the managed templates.",
+                )
+            }
+        }
+        if (
+            result.createdFiles.isEmpty() &&
+            result.overwrittenFiles.isEmpty() &&
+            result.preservedFiles.isEmpty()
+        ) {
+            emitter.info("Bootstrap completed with no managed file changes.")
+        }
+    }
+
+    private fun emitIdeHelperSummary(emitter: CliDiagnosticEmitter, result: InitBootstrapResult) {
+        val ideHelperResult = result.ideHelperResult
+        if (ideHelperResult == null) {
+            emitter.info(
+                "JetBrains IDE helper generation was skipped. " +
+                    "Run 'microsmith ide refresh' when you want IDE indexing.",
+            )
+            return
+        }
+
+        val helperRoot = ideHelperResult.helperRoot.toAbsolutePath().normalize()
+        val state = if (ideHelperResult.updatedFiles.isEmpty()) "already current" else "updated"
+        emitter.info("JetBrains IDE helper is $state at '$helperRoot'.")
+        emitter.info("Import '${helperRoot.resolve("build.gradle.kts")}' as a Gradle project in JetBrains IDEs.")
     }
 
     private fun prepareRun(
@@ -433,6 +503,10 @@ internal class MicrosmithCli(
         ScriptFailureType.EVALUATION -> CliFailureCode.SCRIPT_EVALUATION_FAILED
         ScriptFailureType.HOST -> CliFailureCode.SCRIPT_HOST_FAILED
     }
+}
+
+private fun List<Path>.formatForDisplay(projectRoot: Path): String = joinToString(separator = ", ") { path ->
+    projectRoot.relativize(path.toAbsolutePath().normalize()).toString()
 }
 
 private sealed interface PreparedRun {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/command/InitCommand.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/command/InitCommand.kt
@@ -7,8 +7,6 @@ internal data class InitCommand(
     val projectRoot: Path = Path.of("."),
     val diagnosticsFormat: DiagnosticFormat = DiagnosticFormat.TEXT,
     val verbose: Boolean = false,
-    val nonInteractive: Boolean = false,
-    val assumeYes: Boolean = false,
     val force: Boolean = false,
     val skipIdeHelper: Boolean = false,
 ) : CliCommand

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/command/InitCommand.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/command/InitCommand.kt
@@ -9,4 +9,6 @@ internal data class InitCommand(
     val verbose: Boolean = false,
     val nonInteractive: Boolean = false,
     val assumeYes: Boolean = false,
+    val force: Boolean = false,
+    val skipIdeHelper: Boolean = false,
 ) : CliCommand

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
@@ -7,6 +7,7 @@ import me.liam.microsmith.cli.ide.IDE_HELPER_SETTINGS_FILE_NAME
 import me.liam.microsmith.cli.plugins.defaultPluginCacheDirectory
 import me.liam.microsmith.cli.plugins.defaultRepositoryAllowlistPolicy
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.util.ServiceConfigurationError
 import kotlin.io.path.deleteIfExists
@@ -142,9 +143,23 @@ private fun checkBootstrapState(projectRoot: Path): DoctorCheckResult {
         settingsScript = settingsScript,
         helperRoot = helperRoot,
     )?.let { return it }
+    val invalidHelperFiles = invalidIdeHelperFiles(projectRoot = projectRoot, helperRoot = helperRoot)
     val missingHelperFiles = missingIdeHelperFiles(projectRoot = projectRoot, helperRoot = helperRoot)
 
     return when {
+        invalidHelperFiles.isNotEmpty() ->
+            DoctorCheckResult(
+                id = "bootstrap-state",
+                status = DoctorCheckStatus.FAIL,
+                message =
+                "JetBrains IDE helper contains conflicting managed paths. " +
+                    "Remove them and run 'microsmith ide refresh' to repair it.",
+                details =
+                mapOf(
+                    "invalidIdeHelperFiles" to invalidHelperFiles.joinToString(separator = ","),
+                ),
+            )
+
         missingHelperFiles.isNotEmpty() ->
             DoctorCheckResult(
                 id = "bootstrap-state",
@@ -156,7 +171,7 @@ private fun checkBootstrapState(projectRoot: Path): DoctorCheckResult {
                 ),
             )
 
-        Files.isDirectory(helperRoot) ->
+        Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) ->
             DoctorCheckResult(
                 id = "bootstrap-state",
                 status = DoctorCheckStatus.PASS,
@@ -183,9 +198,9 @@ private fun validateBootstrapSurface(
     helperRoot: Path,
 ): DoctorCheckResult? {
     val hasManagedSurface =
-        Files.exists(buildScript) ||
-            Files.exists(settingsScript) ||
-            Files.exists(helperRoot)
+        Files.exists(buildScript, LinkOption.NOFOLLOW_LINKS) ||
+            Files.exists(settingsScript, LinkOption.NOFOLLOW_LINKS) ||
+            Files.exists(helperRoot, LinkOption.NOFOLLOW_LINKS)
     if (!hasManagedSurface) {
         return DoctorCheckResult(
             id = "bootstrap-state",
@@ -195,12 +210,22 @@ private fun validateBootstrapSurface(
         )
     }
 
-    val missingBootstrapFiles =
-        listOf(buildScript, settingsScript)
-            .filterNot(Files::isRegularFile)
-            .map(projectRoot::relativize)
-            .map(Path::toString)
-            .sorted()
+    val bootstrapFiles = listOf(buildScript, settingsScript)
+    val invalidBootstrapFiles = invalidManagedFiles(projectRoot = projectRoot, managedFiles = bootstrapFiles)
+    if (invalidBootstrapFiles.isNotEmpty()) {
+        return DoctorCheckResult(
+            id = "bootstrap-state",
+            status = DoctorCheckStatus.FAIL,
+            message =
+            "Bootstrap paths are invalid. Remove the conflicting paths and run 'microsmith init' to repair them.",
+            details =
+            mapOf(
+                "invalidBootstrapFiles" to invalidBootstrapFiles.joinToString(separator = ","),
+            ),
+        )
+    }
+
+    val missingBootstrapFiles = missingManagedFiles(projectRoot = projectRoot, managedFiles = bootstrapFiles)
     if (missingBootstrapFiles.isNotEmpty()) {
         return DoctorCheckResult(
             id = "bootstrap-state",
@@ -213,7 +238,10 @@ private fun validateBootstrapSurface(
         )
     }
 
-    return if (Files.exists(helperRoot) && !Files.isDirectory(helperRoot)) {
+    return if (
+        Files.exists(helperRoot, LinkOption.NOFOLLOW_LINKS) &&
+        !Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS)
+    ) {
         DoctorCheckResult(
             id = "bootstrap-state",
             status = DoctorCheckStatus.FAIL,
@@ -228,18 +256,41 @@ private fun validateBootstrapSurface(
 }
 
 private fun missingIdeHelperFiles(projectRoot: Path, helperRoot: Path): List<String> =
-    if (Files.isDirectory(helperRoot)) {
-        listOf(
-            helperRoot.resolve(IDE_HELPER_SETTINGS_FILE_NAME),
-            helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME),
-            helperRoot.resolve(IDE_HELPER_README_FILE_NAME),
-        ).filterNot(Files::isRegularFile)
-            .map(projectRoot::relativize)
-            .map(Path::toString)
-            .sorted()
-    } else {
-        emptyList()
-    }
+    requiredIdeHelperFiles(helperRoot)
+        .takeIf { Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) }
+        ?.let { managedFiles ->
+            missingManagedFiles(projectRoot = projectRoot, managedFiles = managedFiles)
+        } ?: emptyList()
+
+private fun invalidIdeHelperFiles(projectRoot: Path, helperRoot: Path): List<String> =
+    requiredIdeHelperFiles(helperRoot)
+        .takeIf { Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) }
+        ?.let { managedFiles ->
+            invalidManagedFiles(projectRoot = projectRoot, managedFiles = managedFiles)
+        } ?: emptyList()
+
+private fun requiredIdeHelperFiles(helperRoot: Path): List<Path> = listOf(
+    helperRoot.resolve(IDE_HELPER_SETTINGS_FILE_NAME),
+    helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME),
+    helperRoot.resolve(IDE_HELPER_README_FILE_NAME),
+)
+
+private fun missingManagedFiles(projectRoot: Path, managedFiles: List<Path>): List<String> = managedFiles
+    .filterNot(::managedPathExists)
+    .map(projectRoot::relativize)
+    .map(Path::toString)
+    .sorted()
+
+private fun invalidManagedFiles(projectRoot: Path, managedFiles: List<Path>): List<String> = managedFiles
+    .filter(::managedPathExists)
+    .filterNot(::isManagedRegularFile)
+    .map(projectRoot::relativize)
+    .map(Path::toString)
+    .sorted()
+
+private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
+
+private fun isManagedRegularFile(path: Path): Boolean = Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
 
 private fun defaultScriptCacheDirectory(): Path {
     val envPath = System.getenv("MICROSMITH_SCRIPT_CACHE_DIR")?.trim()?.takeIf { it.isNotEmpty() }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
@@ -212,46 +212,43 @@ private fun validateBootstrapSurface(
 
     val bootstrapFiles = listOf(buildScript, settingsScript)
     val invalidBootstrapFiles = invalidManagedFiles(projectRoot = projectRoot, managedFiles = bootstrapFiles)
-    if (invalidBootstrapFiles.isNotEmpty()) {
-        return DoctorCheckResult(
-            id = "bootstrap-state",
-            status = DoctorCheckStatus.FAIL,
-            message =
-            "Bootstrap paths are invalid. Remove the conflicting paths and run 'microsmith init' to repair them.",
-            details =
-            mapOf(
-                "invalidBootstrapFiles" to invalidBootstrapFiles.joinToString(separator = ","),
-            ),
-        )
-    }
-
     val missingBootstrapFiles = missingManagedFiles(projectRoot = projectRoot, managedFiles = bootstrapFiles)
-    if (missingBootstrapFiles.isNotEmpty()) {
-        return DoctorCheckResult(
-            id = "bootstrap-state",
-            status = DoctorCheckStatus.FAIL,
-            message = "Bootstrap state is incomplete. Run 'microsmith init' to repair it.",
-            details =
-            mapOf(
-                "missingBootstrapFiles" to missingBootstrapFiles.joinToString(separator = ","),
-            ),
-        )
-    }
+    return when {
+        invalidBootstrapFiles.isNotEmpty() ->
+            DoctorCheckResult(
+                id = "bootstrap-state",
+                status = DoctorCheckStatus.FAIL,
+                message =
+                "Bootstrap paths are invalid. Remove the conflicting paths. " +
+                    "Run 'microsmith init' to repair them.",
+                details =
+                mapOf(
+                    "invalidBootstrapFiles" to invalidBootstrapFiles.joinToString(separator = ","),
+                ),
+            )
 
-    return if (
-        Files.exists(helperRoot, LinkOption.NOFOLLOW_LINKS) &&
-        !Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS)
-    ) {
-        DoctorCheckResult(
-            id = "bootstrap-state",
-            status = DoctorCheckStatus.FAIL,
-            message =
-            "JetBrains IDE helper path is invalid. " +
-                "Run 'microsmith ide refresh' after removing the conflicting path.",
-            details = mapOf("helperRoot" to helperRoot.toString()),
-        )
-    } else {
-        null
+        missingBootstrapFiles.isNotEmpty() ->
+            DoctorCheckResult(
+                id = "bootstrap-state",
+                status = DoctorCheckStatus.FAIL,
+                message = "Bootstrap state is incomplete. Run 'microsmith init' to repair it.",
+                details =
+                mapOf(
+                    "missingBootstrapFiles" to missingBootstrapFiles.joinToString(separator = ","),
+                ),
+            )
+
+        managedPathExists(helperRoot) && !Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) ->
+            DoctorCheckResult(
+                id = "bootstrap-state",
+                status = DoctorCheckStatus.FAIL,
+                message =
+                "JetBrains IDE helper path is invalid. " +
+                    "Run 'microsmith ide refresh' after removing the conflicting path.",
+                details = mapOf("helperRoot" to helperRoot.toString()),
+            )
+
+        else -> null
     }
 }
 
@@ -260,14 +257,14 @@ private fun missingIdeHelperFiles(projectRoot: Path, helperRoot: Path): List<Str
         .takeIf { Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) }
         ?.let { managedFiles ->
             missingManagedFiles(projectRoot = projectRoot, managedFiles = managedFiles)
-        } ?: emptyList()
+        }.orEmpty()
 
 private fun invalidIdeHelperFiles(projectRoot: Path, helperRoot: Path): List<String> =
     requiredIdeHelperFiles(helperRoot)
         .takeIf { Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) }
         ?.let { managedFiles ->
             invalidManagedFiles(projectRoot = projectRoot, managedFiles = managedFiles)
-        } ?: emptyList()
+        }.orEmpty()
 
 private fun requiredIdeHelperFiles(helperRoot: Path): List<Path> = listOf(
     helperRoot.resolve(IDE_HELPER_SETTINGS_FILE_NAME),

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorRunner.kt
@@ -1,5 +1,9 @@
 package me.liam.microsmith.cli.doctor
 
+import me.liam.microsmith.cli.ide.IDE_HELPER_BUILD_FILE_NAME
+import me.liam.microsmith.cli.ide.IDE_HELPER_DIRECTORY
+import me.liam.microsmith.cli.ide.IDE_HELPER_README_FILE_NAME
+import me.liam.microsmith.cli.ide.IDE_HELPER_SETTINGS_FILE_NAME
 import me.liam.microsmith.cli.plugins.defaultPluginCacheDirectory
 import me.liam.microsmith.cli.plugins.defaultRepositoryAllowlistPolicy
 import java.nio.file.Files
@@ -28,6 +32,7 @@ internal fun runDoctorChecks(
     providerValidator: () -> List<String>,
     scriptCacheDirectory: Path = defaultScriptCacheDirectory(),
     pluginCacheDirectory: Path = defaultPluginCacheDirectory(),
+    projectRoot: Path = Path.of(".").toAbsolutePath().normalize(),
 ): DoctorResult {
     val checks =
         listOf(
@@ -36,6 +41,7 @@ internal fun runDoctorChecks(
             checkDirectoryWritable(id = "script-cache", directory = scriptCacheDirectory),
             checkDirectoryWritable(id = "plugin-cache", directory = pluginCacheDirectory),
             checkRepositoryPolicy(),
+            checkBootstrapState(projectRoot),
         )
     return DoctorResult(checks)
 }
@@ -126,6 +132,115 @@ private fun checkRepositoryPolicy(): DoctorCheckResult = runCatching {
     )
 }
 
+private fun checkBootstrapState(projectRoot: Path): DoctorCheckResult {
+    val buildScript = projectRoot.resolve(INIT_BUILD_FILE_NAME)
+    val settingsScript = projectRoot.resolve(INIT_SETTINGS_FILE_NAME)
+    val helperRoot = projectRoot.resolve(IDE_HELPER_DIRECTORY)
+    validateBootstrapSurface(
+        projectRoot = projectRoot,
+        buildScript = buildScript,
+        settingsScript = settingsScript,
+        helperRoot = helperRoot,
+    )?.let { return it }
+    val missingHelperFiles = missingIdeHelperFiles(projectRoot = projectRoot, helperRoot = helperRoot)
+
+    return when {
+        missingHelperFiles.isNotEmpty() ->
+            DoctorCheckResult(
+                id = "bootstrap-state",
+                status = DoctorCheckStatus.FAIL,
+                message = "JetBrains IDE helper is incomplete. Run 'microsmith ide refresh' to repair it.",
+                details =
+                mapOf(
+                    "missingIdeHelperFiles" to missingHelperFiles.joinToString(separator = ","),
+                ),
+            )
+
+        Files.isDirectory(helperRoot) ->
+            DoctorCheckResult(
+                id = "bootstrap-state",
+                status = DoctorCheckStatus.PASS,
+                message = "Bootstrap files and JetBrains IDE helper are present.",
+                details = mapOf("projectRoot" to projectRoot.toString()),
+            )
+
+        else ->
+            DoctorCheckResult(
+                id = "bootstrap-state",
+                status = DoctorCheckStatus.FAIL,
+                message =
+                "Bootstrap files are present, but the JetBrains IDE helper is missing. " +
+                    "Run 'microsmith ide refresh' to restore the default onboarding surface.",
+                details = mapOf("projectRoot" to projectRoot.toString()),
+            )
+    }
+}
+
+private fun validateBootstrapSurface(
+    projectRoot: Path,
+    buildScript: Path,
+    settingsScript: Path,
+    helperRoot: Path,
+): DoctorCheckResult? {
+    val hasManagedSurface =
+        Files.exists(buildScript) ||
+            Files.exists(settingsScript) ||
+            Files.exists(helperRoot)
+    if (!hasManagedSurface) {
+        return DoctorCheckResult(
+            id = "bootstrap-state",
+            status = DoctorCheckStatus.PASS,
+            message = "Bootstrap files were not detected in the current working directory.",
+            details = mapOf("projectRoot" to projectRoot.toString()),
+        )
+    }
+
+    val missingBootstrapFiles =
+        listOf(buildScript, settingsScript)
+            .filterNot(Files::isRegularFile)
+            .map(projectRoot::relativize)
+            .map(Path::toString)
+            .sorted()
+    if (missingBootstrapFiles.isNotEmpty()) {
+        return DoctorCheckResult(
+            id = "bootstrap-state",
+            status = DoctorCheckStatus.FAIL,
+            message = "Bootstrap state is incomplete. Run 'microsmith init' to repair it.",
+            details =
+            mapOf(
+                "missingBootstrapFiles" to missingBootstrapFiles.joinToString(separator = ","),
+            ),
+        )
+    }
+
+    return if (Files.exists(helperRoot) && !Files.isDirectory(helperRoot)) {
+        DoctorCheckResult(
+            id = "bootstrap-state",
+            status = DoctorCheckStatus.FAIL,
+            message =
+            "JetBrains IDE helper path is invalid. " +
+                "Run 'microsmith ide refresh' after removing the conflicting path.",
+            details = mapOf("helperRoot" to helperRoot.toString()),
+        )
+    } else {
+        null
+    }
+}
+
+private fun missingIdeHelperFiles(projectRoot: Path, helperRoot: Path): List<String> =
+    if (Files.isDirectory(helperRoot)) {
+        listOf(
+            helperRoot.resolve(IDE_HELPER_SETTINGS_FILE_NAME),
+            helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME),
+            helperRoot.resolve(IDE_HELPER_README_FILE_NAME),
+        ).filterNot(Files::isRegularFile)
+            .map(projectRoot::relativize)
+            .map(Path::toString)
+            .sorted()
+    } else {
+        emptyList()
+    }
+
 private fun defaultScriptCacheDirectory(): Path {
     val envPath = System.getenv("MICROSMITH_SCRIPT_CACHE_DIR")?.trim()?.takeIf { it.isNotEmpty() }
     return if (envPath != null) {
@@ -135,4 +250,6 @@ private fun defaultScriptCacheDirectory(): Path {
     }
 }
 
+private const val INIT_BUILD_FILE_NAME = "build.microsmith.kts"
+private const val INIT_SETTINGS_FILE_NAME = "settings.microsmith.kts"
 private const val MIN_SUPPORTED_JAVA_FEATURE = 24

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperConflictException.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperConflictException.kt
@@ -1,0 +1,3 @@
+package me.liam.microsmith.cli.ide
+
+internal class IdeHelperConflictException(message: String) : IllegalStateException(message)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctor.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctor.kt
@@ -1,6 +1,7 @@
 package me.liam.microsmith.cli.ide
 
 import me.liam.microsmith.cli.command.IdeDoctorCommand
+import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.LinkOption
@@ -175,12 +176,7 @@ private fun runtimeClasspathCheck(classpathEntries: List<Path>): IdeDoctorCheckR
 
 private fun classpathSyncCheck(helperRoot: Path, classpathEntries: List<Path>): IdeDoctorCheckResult {
     val buildFile = helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME)
-    val buildFileContent =
-        if (isManagedRegularFile(buildFile)) {
-            Files.readString(buildFile, StandardCharsets.UTF_8).replace("\r\n", "\n")
-        } else {
-            null
-        }
+    val buildFileContent = readManagedUtf8TextOrNull(buildFile)
     val missingClasspathEntries =
         if (buildFileContent == null) {
             classpathEntries
@@ -210,3 +206,17 @@ private fun classpathSyncCheck(helperRoot: Path, classpathEntries: List<Path>): 
 private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
 
 private fun isManagedRegularFile(path: Path): Boolean = Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
+
+private fun readManagedUtf8TextOrNull(path: Path): String? {
+    return try {
+        if (!isManagedRegularFile(path)) {
+            null
+        } else {
+            Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n")
+        }
+    } catch (_: IOException) {
+        null
+    } catch (_: SecurityException) {
+        null
+    }
+}

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctor.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctor.kt
@@ -3,6 +3,7 @@ package me.liam.microsmith.cli.ide
 import me.liam.microsmith.cli.command.IdeDoctorCommand
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 internal data class IdeDoctorCheckResult(
@@ -75,20 +76,30 @@ private fun validateRepoRoot(projectRoot: Path, helperRoot: Path): IdeDoctorResu
     return null
 }
 
-private fun helperDirectoryCheck(helperRoot: Path): IdeDoctorCheckResult = if (Files.isDirectory(helperRoot)) {
-    IdeDoctorCheckResult(
-        id = "helper-directory",
-        passed = true,
-        message = "IDE helper directory exists.",
-        details = mapOf("helperRoot" to helperRoot.toString()),
-    )
-} else {
-    IdeDoctorCheckResult(
-        id = "helper-directory",
-        passed = false,
-        message = "IDE helper directory is missing. Run 'microsmith ide refresh'.",
-        details = mapOf("helperRoot" to helperRoot.toString()),
-    )
+private fun helperDirectoryCheck(helperRoot: Path): IdeDoctorCheckResult = when {
+    managedPathExists(helperRoot) && Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) ->
+        IdeDoctorCheckResult(
+            id = "helper-directory",
+            passed = true,
+            message = "IDE helper directory exists.",
+            details = mapOf("helperRoot" to helperRoot.toString()),
+        )
+
+    managedPathExists(helperRoot) ->
+        IdeDoctorCheckResult(
+            id = "helper-directory",
+            passed = false,
+            message = "IDE helper path is invalid. Remove the conflicting path and run 'microsmith ide refresh'.",
+            details = mapOf("helperRoot" to helperRoot.toString()),
+        )
+
+    else ->
+        IdeDoctorCheckResult(
+            id = "helper-directory",
+            passed = false,
+            message = "IDE helper directory is missing. Run 'microsmith ide refresh'.",
+            details = mapOf("helperRoot" to helperRoot.toString()),
+        )
 }
 
 private fun requiredFilesCheck(helperRoot: Path): IdeDoctorCheckResult {
@@ -98,25 +109,45 @@ private fun requiredFilesCheck(helperRoot: Path): IdeDoctorCheckResult {
             helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME),
             helperRoot.resolve(IDE_HELPER_README_FILE_NAME),
         )
-    val missingFiles = requiredFiles.filterNot(Files::isRegularFile).sortedBy(Path::toString)
-    return if (missingFiles.isEmpty()) {
-        IdeDoctorCheckResult(
-            id = "required-files",
-            passed = true,
-            message = "All required IDE helper files are present.",
-            details = mapOf("fileCount" to requiredFiles.size.toString()),
-        )
-    } else {
-        IdeDoctorCheckResult(
-            id = "required-files",
-            passed = false,
-            message = "IDE helper files are missing. Run 'microsmith ide refresh'.",
-            details =
-            mapOf(
-                "missingCount" to missingFiles.size.toString(),
-                "missingFiles" to missingFiles.joinToString(separator = ","),
-            ),
-        )
+    val invalidFiles =
+        requiredFiles
+            .filter(::managedPathExists)
+            .filterNot(::isManagedRegularFile)
+            .sortedBy(Path::toString)
+    val missingFiles = requiredFiles.filterNot(::managedPathExists).sortedBy(Path::toString)
+    return when {
+        invalidFiles.isNotEmpty() ->
+            IdeDoctorCheckResult(
+                id = "required-files",
+                passed = false,
+                message =
+                "IDE helper contains conflicting managed paths. Remove them and run 'microsmith ide refresh'.",
+                details =
+                mapOf(
+                    "invalidCount" to invalidFiles.size.toString(),
+                    "invalidFiles" to invalidFiles.joinToString(separator = ","),
+                ),
+            )
+
+        missingFiles.isEmpty() ->
+            IdeDoctorCheckResult(
+                id = "required-files",
+                passed = true,
+                message = "All required IDE helper files are present.",
+                details = mapOf("fileCount" to requiredFiles.size.toString()),
+            )
+
+        else ->
+            IdeDoctorCheckResult(
+                id = "required-files",
+                passed = false,
+                message = "IDE helper files are missing. Run 'microsmith ide refresh'.",
+                details =
+                mapOf(
+                    "missingCount" to missingFiles.size.toString(),
+                    "missingFiles" to missingFiles.joinToString(separator = ","),
+                ),
+            )
     }
 }
 
@@ -145,7 +176,7 @@ private fun runtimeClasspathCheck(classpathEntries: List<Path>): IdeDoctorCheckR
 private fun classpathSyncCheck(helperRoot: Path, classpathEntries: List<Path>): IdeDoctorCheckResult {
     val buildFile = helperRoot.resolve(IDE_HELPER_BUILD_FILE_NAME)
     val buildFileContent =
-        if (Files.isRegularFile(buildFile)) {
+        if (isManagedRegularFile(buildFile)) {
             Files.readString(buildFile, StandardCharsets.UTF_8).replace("\r\n", "\n")
         } else {
             null
@@ -175,3 +206,7 @@ private fun classpathSyncCheck(helperRoot: Path, classpathEntries: List<Path>): 
         )
     }
 }
+
+private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
+
+private fun isManagedRegularFile(path: Path): Boolean = Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperGenerator.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperGenerator.kt
@@ -2,6 +2,7 @@ package me.liam.microsmith.cli.ide
 
 import me.liam.microsmith.cli.command.IdeRefreshCommand
 import java.io.File
+import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.LinkOption
@@ -118,14 +119,11 @@ Regeneration:
 
 private fun writeFileIfChanged(path: Path, content: String): Boolean {
     val normalizedContent = content.replace("\r\n", "\n")
-    if (managedPathExists(path)) {
-        if (!isManagedRegularFile(path)) {
+    when {
+        managedPathExists(path) && !isManagedRegularFile(path) ->
             throw IdeHelperConflictException("IDE helper path '$path' exists but is not a regular file.")
-        }
-        val existing = Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n")
-        if (existing == normalizedContent) {
-            return false
-        }
+
+        managedFileContentMatches(path, normalizedContent) -> return false
     }
 
     Files.writeString(path, normalizedContent, StandardCharsets.UTF_8)
@@ -143,6 +141,20 @@ private fun ensureManagedDirectory(path: Path) {
 }
 
 private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
+
+private fun managedFileContentMatches(path: Path, normalizedContent: String): Boolean {
+    return try {
+        if (!isManagedRegularFile(path)) {
+            false
+        } else {
+            Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n") == normalizedContent
+        }
+    } catch (_: IOException) {
+        false
+    } catch (_: SecurityException) {
+        false
+    }
+}
 
 private fun isManagedDirectory(path: Path): Boolean = Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)
 

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperGenerator.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperGenerator.kt
@@ -4,6 +4,7 @@ import me.liam.microsmith.cli.command.IdeRefreshCommand
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 internal fun refreshIdeHelperProject(
@@ -29,6 +30,9 @@ internal fun refreshIdeHelperProject(
     require(classpathEntries.isNotEmpty()) {
         "Could not resolve runtime classpath entries for IDE helper generation."
     }
+
+    ensureManagedDirectory(projectRoot.resolve(".microsmith").toAbsolutePath().normalize())
+    ensureManagedDirectory(helperRoot)
 
     val targetFiles =
         linkedMapOf(
@@ -113,9 +117,11 @@ Regeneration:
 """.trimIndent() + "\n"
 
 private fun writeFileIfChanged(path: Path, content: String): Boolean {
-    Files.createDirectories(path.parent)
     val normalizedContent = content.replace("\r\n", "\n")
-    if (Files.exists(path)) {
+    if (managedPathExists(path)) {
+        if (!isManagedRegularFile(path)) {
+            throw IdeHelperConflictException("IDE helper path '$path' exists but is not a regular file.")
+        }
         val existing = Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n")
         if (existing == normalizedContent) {
             return false
@@ -125,6 +131,22 @@ private fun writeFileIfChanged(path: Path, content: String): Boolean {
     Files.writeString(path, normalizedContent, StandardCharsets.UTF_8)
     return true
 }
+
+private fun ensureManagedDirectory(path: Path) {
+    when {
+        managedPathExists(path) && isManagedDirectory(path) -> return
+        managedPathExists(path) ->
+            throw IdeHelperConflictException("IDE helper directory '$path' exists but is not a directory.")
+
+        else -> Files.createDirectory(path)
+    }
+}
+
+private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
+
+private fun isManagedDirectory(path: Path): Boolean = Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)
+
+private fun isManagedRegularFile(path: Path): Boolean = Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
 
 internal fun Path.toKotlinPathLiteral(): String = toAbsolutePath()
     .normalize()

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
@@ -27,12 +27,7 @@ internal fun runInitBootstrap(
     ideRefreshRunner: (IdeRefreshCommand) -> IdeHelperRefreshResult = ::refreshIdeHelperProject,
 ): InitBootstrapResult {
     val projectRoot = command.projectRoot.toAbsolutePath().normalize()
-    requireInit(Files.exists(projectRoot)) {
-        "Repository root '$projectRoot' does not exist."
-    }
-    requireInit(Files.isDirectory(projectRoot)) {
-        "Repository root '$projectRoot' is not a directory."
-    }
+    validateProjectRoot(projectRoot)
 
     val repositoryDetection = detectOnboardingRepositoryType(projectRoot)
     val createdFiles = mutableListOf<Path>()
@@ -40,48 +35,20 @@ internal fun runInitBootstrap(
     val preservedFiles = mutableListOf<Path>()
 
     bootstrapFilesFor(repositoryDetection).forEach { (relativePath, content) ->
-        val path = projectRoot.resolve(relativePath)
-        when {
-            Files.exists(path, LinkOption.NOFOLLOW_LINKS) && Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) -> {
-                val existingContent = Files.readString(path, StandardCharsets.UTF_8)
-                if (command.force && existingContent.normalizeLineEndings() != content.normalizeLineEndings()) {
-                    Files.writeString(path, content, StandardCharsets.UTF_8)
-                    overwrittenFiles.add(path)
-                } else {
-                    preservedFiles.add(path)
-                }
-            }
-
-            Files.exists(path, LinkOption.NOFOLLOW_LINKS) ->
-                throw InitConflictException("Bootstrap path '$path' exists but is not a regular file.")
-
-            else -> {
-                Files.createDirectories(path.parent)
-                Files.writeString(path, content, StandardCharsets.UTF_8)
-                createdFiles.add(path)
-            }
+        val fileWriteResult =
+            writeBootstrapFile(
+                path = projectRoot.resolve(relativePath),
+                content = content,
+                force = command.force,
+            )
+        when (fileWriteResult) {
+            is BootstrapFileWriteResult.Created -> createdFiles.add(fileWriteResult.path)
+            is BootstrapFileWriteResult.Overwritten -> overwrittenFiles.add(fileWriteResult.path)
+            is BootstrapFileWriteResult.Preserved -> preservedFiles.add(fileWriteResult.path)
         }
     }
 
-    val ideHelperResult =
-        if (command.skipIdeHelper) {
-            null
-        } else {
-            runCatching {
-                ideRefreshRunner(
-                    IdeRefreshCommand(
-                        projectRoot = projectRoot,
-                        diagnosticsFormat = command.diagnosticsFormat,
-                        verbose = command.verbose,
-                    ),
-                )
-            }.getOrElse { error ->
-                when (error) {
-                    is IdeHelperConflictException -> throw InitConflictException(error.message ?: "IDE helper path is invalid.")
-                    else -> throw error
-                }
-            }
-        }
+    val ideHelperResult = refreshIdeHelperIfEnabled(command, projectRoot, ideRefreshRunner)
 
     return InitBootstrapResult(
         projectRoot = projectRoot,
@@ -135,6 +102,77 @@ private fun renderDefaultBuildScript(repositoryType: OnboardingRepositoryType): 
 }
 
 private fun String.normalizeLineEndings(): String = replace("\r\n", "\n")
+
+private fun validateProjectRoot(projectRoot: Path) {
+    requireInit(Files.exists(projectRoot)) {
+        "Repository root '$projectRoot' does not exist."
+    }
+    requireInit(Files.isDirectory(projectRoot)) {
+        "Repository root '$projectRoot' is not a directory."
+    }
+}
+
+private fun writeBootstrapFile(path: Path, content: String, force: Boolean): BootstrapFileWriteResult = when {
+    managedPathExists(path) && Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) -> {
+        if (force && managedFileContentDiffers(path, content)) {
+            Files.writeString(path, content, StandardCharsets.UTF_8)
+            BootstrapFileWriteResult.Overwritten(path)
+        } else {
+            BootstrapFileWriteResult.Preserved(path)
+        }
+    }
+
+    managedPathExists(path) ->
+        throw InitConflictException("Bootstrap path '$path' exists but is not a regular file.")
+
+    else -> {
+        Files.createDirectories(path.parent)
+        Files.writeString(path, content, StandardCharsets.UTF_8)
+        BootstrapFileWriteResult.Created(path)
+    }
+}
+
+private fun refreshIdeHelperIfEnabled(
+    command: InitCommand,
+    projectRoot: Path,
+    ideRefreshRunner: (IdeRefreshCommand) -> IdeHelperRefreshResult,
+): IdeHelperRefreshResult? {
+    if (command.skipIdeHelper) {
+        return null
+    }
+
+    return runCatching {
+        ideRefreshRunner(
+            IdeRefreshCommand(
+                projectRoot = projectRoot,
+                diagnosticsFormat = command.diagnosticsFormat,
+                verbose = command.verbose,
+            ),
+        )
+    }.getOrElse { error ->
+        when (error) {
+            is IdeHelperConflictException ->
+                throw InitConflictException(error.message ?: "IDE helper path is invalid.")
+
+            else -> throw error
+        }
+    }
+}
+
+private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
+
+private fun managedFileContentDiffers(path: Path, expectedContent: String): Boolean {
+    val existingContent = Files.readString(path, StandardCharsets.UTF_8)
+    return existingContent.normalizeLineEndings() != expectedContent.normalizeLineEndings()
+}
+
+private sealed interface BootstrapFileWriteResult {
+    data class Created(val path: Path) : BootstrapFileWriteResult
+
+    data class Overwritten(val path: Path) : BootstrapFileWriteResult
+
+    data class Preserved(val path: Path) : BootstrapFileWriteResult
+}
 
 private inline fun requireInit(value: Boolean, lazyMessage: () -> String) {
     if (!value) {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
@@ -5,6 +5,7 @@ import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.ide.IdeHelperConflictException
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
 import me.liam.microsmith.cli.ide.refreshIdeHelperProject
+import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.LinkOption
@@ -161,9 +162,13 @@ private fun refreshIdeHelperIfEnabled(
 
 private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
 
-private fun managedFileContentDiffers(path: Path, expectedContent: String): Boolean {
+private fun managedFileContentDiffers(path: Path, expectedContent: String): Boolean = try {
     val existingContent = Files.readString(path, StandardCharsets.UTF_8)
-    return existingContent.normalizeLineEndings() != expectedContent.normalizeLineEndings()
+    existingContent.normalizeLineEndings() != expectedContent.normalizeLineEndings()
+} catch (_: IOException) {
+    true
+} catch (_: SecurityException) {
+    true
 }
 
 private sealed interface BootstrapFileWriteResult {

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
@@ -10,9 +10,11 @@ import java.nio.file.Path
 
 internal data class InitBootstrapResult(
     val projectRoot: Path,
+    val repositoryDetection: OnboardingRepositoryDetection,
     val createdFiles: List<Path>,
+    val overwrittenFiles: List<Path>,
     val preservedFiles: List<Path>,
-    val ideHelperResult: IdeHelperRefreshResult,
+    val ideHelperResult: IdeHelperRefreshResult?,
 )
 
 internal class InitConflictException(message: String) : IllegalStateException(message)
@@ -29,12 +31,24 @@ internal fun runInitBootstrap(
         "Repository root '$projectRoot' is not a directory."
     }
 
+    val repositoryDetection = detectOnboardingRepositoryType(projectRoot)
     val createdFiles = mutableListOf<Path>()
+    val overwrittenFiles = mutableListOf<Path>()
     val preservedFiles = mutableListOf<Path>()
-    DEFAULT_BOOTSTRAP_FILES.forEach { (relativePath, content) ->
+
+    bootstrapFilesFor(repositoryDetection).forEach { (relativePath, content) ->
         val path = projectRoot.resolve(relativePath)
         when {
-            Files.exists(path) && Files.isRegularFile(path) -> preservedFiles.add(path)
+            Files.exists(path) && Files.isRegularFile(path) -> {
+                val existingContent = Files.readString(path, StandardCharsets.UTF_8)
+                if (command.force && existingContent.normalizeLineEndings() != content.normalizeLineEndings()) {
+                    Files.writeString(path, content, StandardCharsets.UTF_8)
+                    overwrittenFiles.add(path)
+                } else {
+                    preservedFiles.add(path)
+                }
+            }
+
             Files.exists(path) ->
                 throw InitConflictException("Bootstrap path '$path' exists but is not a regular file.")
 
@@ -47,42 +61,67 @@ internal fun runInitBootstrap(
     }
 
     val ideHelperResult =
-        ideRefreshRunner(
-            IdeRefreshCommand(
-                projectRoot = projectRoot,
-                diagnosticsFormat = command.diagnosticsFormat,
-                verbose = command.verbose,
-            ),
-        )
+        if (command.skipIdeHelper) {
+            null
+        } else {
+            ideRefreshRunner(
+                IdeRefreshCommand(
+                    projectRoot = projectRoot,
+                    diagnosticsFormat = command.diagnosticsFormat,
+                    verbose = command.verbose,
+                ),
+            )
+        }
 
     return InitBootstrapResult(
         projectRoot = projectRoot,
+        repositoryDetection = repositoryDetection,
         createdFiles = createdFiles.sortedBy(Path::toString),
+        overwrittenFiles = overwrittenFiles.sortedBy(Path::toString),
         preservedFiles = preservedFiles.sortedBy(Path::toString),
         ideHelperResult = ideHelperResult,
     )
 }
 
-private val DEFAULT_BOOTSTRAP_FILES =
-    linkedMapOf(
-        "settings.microsmith.kts" to renderDefaultSettingsScript(),
-        "build.microsmith.kts" to renderDefaultBuildScript(),
-    )
+private fun bootstrapFilesFor(repositoryDetection: OnboardingRepositoryDetection): Map<String, String> = linkedMapOf(
+    "settings.microsmith.kts" to renderDefaultSettingsScript(repositoryDetection),
+    "build.microsmith.kts" to renderDefaultBuildScript(repositoryDetection.type),
+)
 
-private fun renderDefaultSettingsScript(): String = """
-// Microsmith repository settings.
-// Add shared script configuration here as your repository grows.
-""".trimIndent() + "\n"
+private fun renderDefaultSettingsScript(repositoryDetection: OnboardingRepositoryDetection): String = buildString {
+    appendLine("// Microsmith repository settings.")
+    appendLine("// ${repositoryDetection.describeForComment()}.")
+    appendLine("// Add shared script configuration here as your repository grows.")
+}
 
-private fun renderDefaultBuildScript(): String = """
-microsmith {
-    schemas {
-        protobuf {
-            message("UserCreated") {
-                int32("id") { index(1) }
-                string("email") { index(2) }
+private fun renderDefaultBuildScript(repositoryType: OnboardingRepositoryType): String = buildString {
+    val displayName =
+        if (repositoryType == OnboardingRepositoryType.OTHER) {
+            "repository"
+        } else {
+            "${repositoryType.displayName} repository"
+        }
+    appendLine("// Bootstrapped Microsmith schema for this $displayName.")
+    appendLine("// Canonical first run:")
+    appendLine("// microsmith run build.microsmith.kts --out ./generated")
+    repositoryType.repoNativeOutputDirectory?.let { outputDirectory ->
+        appendLine("// Common repository-native output path:")
+        appendLine("// microsmith run build.microsmith.kts --out $outputDirectory")
+    }
+    appendLine(
+        """
+        microsmith {
+            schemas {
+                protobuf {
+                    message("${repositoryType.sampleMessageName}") {
+                        int32("id") { index(1) }
+                        string("email") { index(2) }
+                    }
+                }
             }
         }
-    }
+        """.trimIndent(),
+    )
 }
-""".trimIndent() + "\n"
+
+private fun String.normalizeLineEndings(): String = replace("\r\n", "\n")

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/InitBootstrap.kt
@@ -2,10 +2,12 @@ package me.liam.microsmith.cli.init
 
 import me.liam.microsmith.cli.command.IdeRefreshCommand
 import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperConflictException
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
 import me.liam.microsmith.cli.ide.refreshIdeHelperProject
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 internal data class InitBootstrapResult(
@@ -18,16 +20,17 @@ internal data class InitBootstrapResult(
 )
 
 internal class InitConflictException(message: String) : IllegalStateException(message)
+internal class InitValidationException(message: String) : IllegalArgumentException(message)
 
 internal fun runInitBootstrap(
     command: InitCommand,
     ideRefreshRunner: (IdeRefreshCommand) -> IdeHelperRefreshResult = ::refreshIdeHelperProject,
 ): InitBootstrapResult {
     val projectRoot = command.projectRoot.toAbsolutePath().normalize()
-    require(Files.exists(projectRoot)) {
+    requireInit(Files.exists(projectRoot)) {
         "Repository root '$projectRoot' does not exist."
     }
-    require(Files.isDirectory(projectRoot)) {
+    requireInit(Files.isDirectory(projectRoot)) {
         "Repository root '$projectRoot' is not a directory."
     }
 
@@ -39,7 +42,7 @@ internal fun runInitBootstrap(
     bootstrapFilesFor(repositoryDetection).forEach { (relativePath, content) ->
         val path = projectRoot.resolve(relativePath)
         when {
-            Files.exists(path) && Files.isRegularFile(path) -> {
+            Files.exists(path, LinkOption.NOFOLLOW_LINKS) && Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) -> {
                 val existingContent = Files.readString(path, StandardCharsets.UTF_8)
                 if (command.force && existingContent.normalizeLineEndings() != content.normalizeLineEndings()) {
                     Files.writeString(path, content, StandardCharsets.UTF_8)
@@ -49,7 +52,7 @@ internal fun runInitBootstrap(
                 }
             }
 
-            Files.exists(path) ->
+            Files.exists(path, LinkOption.NOFOLLOW_LINKS) ->
                 throw InitConflictException("Bootstrap path '$path' exists but is not a regular file.")
 
             else -> {
@@ -64,13 +67,20 @@ internal fun runInitBootstrap(
         if (command.skipIdeHelper) {
             null
         } else {
-            ideRefreshRunner(
-                IdeRefreshCommand(
-                    projectRoot = projectRoot,
-                    diagnosticsFormat = command.diagnosticsFormat,
-                    verbose = command.verbose,
-                ),
-            )
+            runCatching {
+                ideRefreshRunner(
+                    IdeRefreshCommand(
+                        projectRoot = projectRoot,
+                        diagnosticsFormat = command.diagnosticsFormat,
+                        verbose = command.verbose,
+                    ),
+                )
+            }.getOrElse { error ->
+                when (error) {
+                    is IdeHelperConflictException -> throw InitConflictException(error.message ?: "IDE helper path is invalid.")
+                    else -> throw error
+                }
+            }
         }
 
     return InitBootstrapResult(
@@ -125,3 +135,9 @@ private fun renderDefaultBuildScript(repositoryType: OnboardingRepositoryType): 
 }
 
 private fun String.normalizeLineEndings(): String = replace("\r\n", "\n")
+
+private inline fun requireInit(value: Boolean, lazyMessage: () -> String) {
+    if (!value) {
+        throw InitValidationException(lazyMessage())
+    }
+}

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingRepositoryType.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingRepositoryType.kt
@@ -1,6 +1,7 @@
 package me.liam.microsmith.cli.init
 
 import java.io.IOException
+import java.io.UncheckedIOException
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
@@ -87,6 +88,8 @@ internal fun detectOnboardingRepositoryType(
 private fun safeFindDotnetMarker(projectRoot: Path, dotnetMarkerFinder: (Path) -> String?): String? = try {
     dotnetMarkerFinder(projectRoot)
 } catch (_: IOException) {
+    null
+} catch (_: UncheckedIOException) {
     null
 } catch (_: SecurityException) {
     null

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingRepositoryType.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingRepositoryType.kt
@@ -1,0 +1,97 @@
+package me.liam.microsmith.cli.init
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.isRegularFile
+import kotlin.streams.asSequence
+
+internal enum class OnboardingRepositoryType(
+    val displayName: String,
+    val sampleMessageName: String,
+    val repoNativeOutputDirectory: String?,
+) {
+    NODE(
+        displayName = "Node",
+        sampleMessageName = "NodeUserCreated",
+        repoNativeOutputDirectory = "./generated",
+    ),
+    GO(
+        displayName = "Go",
+        sampleMessageName = "GoUserCreated",
+        repoNativeOutputDirectory = "./internal/gen",
+    ),
+    DOTNET(
+        displayName = ".NET",
+        sampleMessageName = "DotnetUserCreated",
+        repoNativeOutputDirectory = "./Generated",
+    ),
+    OTHER(
+        displayName = "Other",
+        sampleMessageName = "UserCreated",
+        repoNativeOutputDirectory = null,
+    ),
+}
+
+internal data class OnboardingRepositoryDetection(
+    val type: OnboardingRepositoryType,
+    val matchedMarkers: List<String>,
+)
+
+internal fun OnboardingRepositoryDetection.describeForComment(): String = buildString {
+    append("Detected repository type: ${type.displayName}")
+    if (matchedMarkers.isEmpty()) {
+        append(" (no repo markers matched)")
+    } else {
+        append(" via ${matchedMarkers.joinToString(separator = ", ")}")
+    }
+}
+
+internal fun OnboardingRepositoryDetection.describeForSummary(): String = buildString {
+    append(type.displayName)
+    if (matchedMarkers.isNotEmpty()) {
+        append(" (matched ${matchedMarkers.joinToString(separator = ", ")})")
+    }
+}
+
+internal fun detectOnboardingRepositoryType(projectRoot: Path): OnboardingRepositoryDetection {
+    val matchedDetections = buildList {
+        if (projectRoot.resolve("package.json").isRegularFile()) {
+            add(OnboardingRepositoryType.NODE to "package.json")
+        }
+        if (projectRoot.resolve("go.mod").isRegularFile()) {
+            add(OnboardingRepositoryType.GO to "go.mod")
+        }
+        findDotnetMarker(projectRoot)?.let { marker ->
+            add(OnboardingRepositoryType.DOTNET to marker)
+        }
+    }
+
+    val distinctTypes = matchedDetections.map { (type, _) -> type }.distinct()
+    val resolvedType =
+        when (distinctTypes.size) {
+            0 -> OnboardingRepositoryType.OTHER
+            1 -> distinctTypes.single()
+            else -> OnboardingRepositoryType.OTHER
+        }
+
+    return OnboardingRepositoryDetection(
+        type = resolvedType,
+        matchedMarkers = matchedDetections.map { (_, marker) -> marker }.sorted(),
+    )
+}
+
+private fun findDotnetMarker(projectRoot: Path): String? =
+    Files.walk(projectRoot, DOTNET_MARKER_SEARCH_DEPTH).use { stream ->
+        stream
+            .asSequence()
+            .filter(Files::isRegularFile)
+            .map(projectRoot::relativize)
+            .map(Path::toString)
+            .filter { relativePath ->
+                relativePath.endsWith(".sln") || relativePath.endsWith(".csproj")
+            }
+            .sorted()
+            .firstOrNull()
+    }
+
+private const val DOTNET_MARKER_SEARCH_DEPTH = 6

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingRepositoryType.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingRepositoryType.kt
@@ -1,5 +1,6 @@
 package me.liam.microsmith.cli.init
 
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
@@ -53,7 +54,10 @@ internal fun OnboardingRepositoryDetection.describeForSummary(): String = buildS
     }
 }
 
-internal fun detectOnboardingRepositoryType(projectRoot: Path): OnboardingRepositoryDetection {
+internal fun detectOnboardingRepositoryType(
+    projectRoot: Path,
+    dotnetMarkerFinder: (Path) -> String? = ::findDotnetMarker,
+): OnboardingRepositoryDetection {
     val matchedDetections = buildList {
         if (projectRoot.resolve("package.json").isRegularFile()) {
             add(OnboardingRepositoryType.NODE to "package.json")
@@ -61,7 +65,7 @@ internal fun detectOnboardingRepositoryType(projectRoot: Path): OnboardingReposi
         if (projectRoot.resolve("go.mod").isRegularFile()) {
             add(OnboardingRepositoryType.GO to "go.mod")
         }
-        findDotnetMarker(projectRoot)?.let { marker ->
+        safeFindDotnetMarker(projectRoot, dotnetMarkerFinder)?.let { marker ->
             add(OnboardingRepositoryType.DOTNET to marker)
         }
     }
@@ -78,6 +82,14 @@ internal fun detectOnboardingRepositoryType(projectRoot: Path): OnboardingReposi
         type = resolvedType,
         matchedMarkers = matchedDetections.map { (_, marker) -> marker }.sorted(),
     )
+}
+
+private fun safeFindDotnetMarker(projectRoot: Path, dotnetMarkerFinder: (Path) -> String?): String? = try {
+    dotnetMarkerFinder(projectRoot)
+} catch (_: IOException) {
+    null
+} catch (_: SecurityException) {
+    null
 }
 
 private fun findDotnetMarker(projectRoot: Path): String? =

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
@@ -32,6 +32,8 @@ internal const val EVENT_LOG_OPTION = "--event-log"
 internal const val REPO_ROOT_OPTION = "--repo-root"
 internal const val NON_INTERACTIVE_OPTION = "--non-interactive"
 internal const val YES_OPTION = "--yes"
+internal const val FORCE_OPTION = "--force"
+internal const val SKIP_IDE_HELPER_OPTION = "--skip-ide-helper"
 private const val SCRIPT_EXTENSION = ".microsmith.kts"
 private val HELP_COMMANDS = setOf("--help", "-h", "help")
 private val VERSION_COMMANDS = setOf("--version")
@@ -185,6 +187,8 @@ private fun parseInitCommand(args: List<String>): CliCommand {
             verbose = parsed.verbose,
             nonInteractive = parsed.nonInteractive,
             assumeYes = parsed.assumeYes,
+            force = parsed.force,
+            skipIdeHelper = parsed.skipIdeHelper,
         )
     }
 }
@@ -201,6 +205,8 @@ private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOpt
                 REPO_ROOT_OPTION -> state.consumeRepoRoot(args = args, index = index)
                 NON_INTERACTIVE_OPTION -> state.consumeNonInteractive()
                 YES_OPTION -> state.consumeAssumeYes()
+                FORCE_OPTION -> state.consumeForce()
+                SKIP_IDE_HELPER_OPTION -> state.consumeSkipIdeHelper()
                 else -> {
                     state.consumeUnknownOption(token)
                     0
@@ -349,6 +355,8 @@ private class InitOptionsState {
     private var verbose = false
     private var nonInteractive = false
     private var assumeYes = false
+    private var force = false
+    private var skipIdeHelper = false
     private var projectRoot = Path.of(".")
     private var projectRootSpecified = false
 
@@ -423,6 +431,26 @@ private class InitOptionsState {
         return 1
     }
 
+    fun consumeForce(): Int {
+        if (force) {
+            error = "--force may only be specified once."
+            return 0
+        }
+
+        force = true
+        return 1
+    }
+
+    fun consumeSkipIdeHelper(): Int {
+        if (skipIdeHelper) {
+            error = "--skip-ide-helper may only be specified once."
+            return 0
+        }
+
+        skipIdeHelper = true
+        return 1
+    }
+
     fun consumeUnknownOption(token: String) {
         error = "Unknown option '$token'."
     }
@@ -434,6 +462,8 @@ private class InitOptionsState {
             verbose = verbose,
             nonInteractive = nonInteractive,
             assumeYes = assumeYes,
+            force = force,
+            skipIdeHelper = skipIdeHelper,
             error = error,
         )
     }
@@ -452,5 +482,7 @@ private data class ParsedInitOptions(
     val verbose: Boolean,
     val nonInteractive: Boolean,
     val assumeYes: Boolean,
+    val force: Boolean,
+    val skipIdeHelper: Boolean,
     val error: String?,
 )

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliParser.kt
@@ -30,8 +30,6 @@ internal const val DIAGNOSTICS_OPTION = "--diagnostics"
 internal const val VERBOSE_OPTION = "--verbose"
 internal const val EVENT_LOG_OPTION = "--event-log"
 internal const val REPO_ROOT_OPTION = "--repo-root"
-internal const val NON_INTERACTIVE_OPTION = "--non-interactive"
-internal const val YES_OPTION = "--yes"
 internal const val FORCE_OPTION = "--force"
 internal const val SKIP_IDE_HELPER_OPTION = "--skip-ide-helper"
 private const val SCRIPT_EXTENSION = ".microsmith.kts"
@@ -185,8 +183,6 @@ private fun parseInitCommand(args: List<String>): CliCommand {
             projectRoot = parsed.projectRoot,
             diagnosticsFormat = parsed.diagnosticsFormat,
             verbose = parsed.verbose,
-            nonInteractive = parsed.nonInteractive,
-            assumeYes = parsed.assumeYes,
             force = parsed.force,
             skipIdeHelper = parsed.skipIdeHelper,
         )
@@ -203,8 +199,6 @@ private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOpt
                 DIAGNOSTICS_OPTION -> state.consumeDiagnostics(args = args, index = index)
                 VERBOSE_OPTION -> state.consumeVerbose()
                 REPO_ROOT_OPTION -> state.consumeRepoRoot(args = args, index = index)
-                NON_INTERACTIVE_OPTION -> state.consumeNonInteractive()
-                YES_OPTION -> state.consumeAssumeYes()
                 FORCE_OPTION -> state.consumeForce()
                 SKIP_IDE_HELPER_OPTION -> state.consumeSkipIdeHelper()
                 else -> {
@@ -353,8 +347,6 @@ private class InitOptionsState {
     private var diagnosticsFormat = DiagnosticFormat.TEXT
     private var diagnosticsSpecified = false
     private var verbose = false
-    private var nonInteractive = false
-    private var assumeYes = false
     private var force = false
     private var skipIdeHelper = false
     private var projectRoot = Path.of(".")
@@ -411,26 +403,6 @@ private class InitOptionsState {
         return 2
     }
 
-    fun consumeNonInteractive(): Int {
-        if (nonInteractive) {
-            error = "--non-interactive may only be specified once."
-            return 0
-        }
-
-        nonInteractive = true
-        return 1
-    }
-
-    fun consumeAssumeYes(): Int {
-        if (assumeYes) {
-            error = "--yes may only be specified once."
-            return 0
-        }
-
-        assumeYes = true
-        return 1
-    }
-
     fun consumeForce(): Int {
         if (force) {
             error = "--force may only be specified once."
@@ -460,8 +432,6 @@ private class InitOptionsState {
             projectRoot = projectRoot,
             diagnosticsFormat = diagnosticsFormat,
             verbose = verbose,
-            nonInteractive = nonInteractive,
-            assumeYes = assumeYes,
             force = force,
             skipIdeHelper = skipIdeHelper,
             error = error,
@@ -480,8 +450,6 @@ private data class ParsedInitOptions(
     val projectRoot: Path,
     val diagnosticsFormat: DiagnosticFormat,
     val verbose: Boolean,
-    val nonInteractive: Boolean,
-    val assumeYes: Boolean,
     val force: Boolean,
     val skipIdeHelper: Boolean,
     val error: String?,

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -7,6 +7,7 @@ import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
 import me.liam.microsmith.cli.init.InitBootstrapResult
 import me.liam.microsmith.cli.init.InitConflictException
+import me.liam.microsmith.cli.init.InitValidationException
 import me.liam.microsmith.cli.init.OnboardingRepositoryDetection
 import me.liam.microsmith.cli.init.OnboardingRepositoryType
 import kotlin.io.path.ExperimentalPathApi
@@ -95,7 +96,7 @@ class MicrosmithCliInitTests :
                     stdout = out::add,
                     stderr = err::add,
                     initRunner = {
-                        throw IllegalArgumentException("Repository root does not exist.")
+                        throw InitValidationException("Repository root does not exist.")
                     },
                 )
 
@@ -104,6 +105,26 @@ class MicrosmithCliInitTests :
             exitCode shouldBe 51
             err.joinToString("\n").shouldContain("MS-CLI-5002")
             err.joinToString("\n").shouldContain("Repository root does not exist.")
+            out shouldBe emptyList()
+        }
+
+        "init command treats unexpected illegal arguments as runtime failures" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    initRunner = {
+                        throw IllegalArgumentException("IDE helper refresh failed.")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("init"))
+
+            exitCode shouldBe 52
+            err.joinToString("\n").shouldContain("MS-CLI-5003")
+            err.joinToString("\n").shouldContain("IDE helper refresh failed.")
             out shouldBe emptyList()
         }
 

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -1,0 +1,230 @@
+package me.liam.microsmith.cli
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import me.liam.microsmith.cli.init.InitBootstrapResult
+import me.liam.microsmith.cli.init.InitConflictException
+import me.liam.microsmith.cli.init.OnboardingRepositoryDetection
+import me.liam.microsmith.cli.init.OnboardingRepositoryType
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+
+@OptIn(ExperimentalPathApi::class)
+class MicrosmithCliInitTests :
+    StringSpec({
+        "init command returns success and emits next run command when bootstrap succeeds" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-success")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingRepositoryDetection(
+                                    type = OnboardingRepositoryType.GO,
+                                    matchedMarkers = listOf("go.mod"),
+                                ),
+                                createdFiles =
+                                listOf(
+                                    tempDir.resolve("build.microsmith.kts"),
+                                    tempDir.resolve("settings.microsmith.kts"),
+                                ),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Microsmith init completed")
+                out.joinToString("\n").shouldContain("Detected repository type: Go")
+                out.joinToString("\n").shouldContain("build.microsmith.kts")
+                out.joinToString("\n").shouldContain("JetBrains IDE helper is updated")
+                out.joinToString("\n").shouldContain("microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldContain("./internal/gen")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command returns deterministic conflict failure code when bootstrap detects conflicting path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    initRunner = {
+                        throw InitConflictException("Bootstrap path is not a regular file.")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("init"))
+
+            exitCode shouldBe 50
+            err.joinToString("\n").shouldContain("MS-CLI-5001")
+            err.joinToString("\n").shouldContain("Bootstrap path is not a regular file")
+            out shouldBe emptyList()
+        }
+
+        "init command returns deterministic validation failure code when bootstrap validation fails" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    initRunner = {
+                        throw IllegalArgumentException("Repository root does not exist.")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("init", "--repo-root", "/path/does/not/exist"))
+
+            exitCode shouldBe 51
+            err.joinToString("\n").shouldContain("MS-CLI-5002")
+            err.joinToString("\n").shouldContain("Repository root does not exist.")
+            out shouldBe emptyList()
+        }
+
+        "init command returns deterministic runtime failure code for unexpected bootstrap errors" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val cli =
+                MicrosmithCli(
+                    stdout = out::add,
+                    stderr = err::add,
+                    initRunner = {
+                        throw IllegalStateException("Unexpected init failure.")
+                    },
+                )
+
+            val exitCode = cli.run(arrayOf("init"))
+
+            exitCode shouldBe 52
+            err.joinToString("\n").shouldContain("MS-CLI-5003")
+            err.joinToString("\n").shouldContain("Unexpected init failure.")
+            out shouldBe emptyList()
+        }
+
+        "init command emits json diagnostics payload when requested" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-json")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingRepositoryDetection(
+                                    type = OnboardingRepositoryType.NODE,
+                                    matchedMarkers = listOf("package.json"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = listOf(tempDir.resolve("settings.microsmith.kts")),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode =
+                    cli.run(
+                        arrayOf(
+                            "init",
+                            "--repo-root",
+                            tempDir.toString(),
+                            "--diagnostics",
+                            "json",
+                            "--verbose",
+                        ),
+                    )
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("\"level\":\"info\"")
+                out.joinToString("\n").shouldContain("Microsmith init completed")
+                out.joinToString("\n").shouldContain("Detected repository type: Node")
+                out.joinToString("\n").shouldContain("\"details\"")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command reports preserved files and skipped IDE helper when requested" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-skip-ide")
+            try {
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            command.skipIdeHelper shouldBe true
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingRepositoryDetection(
+                                    type = OnboardingRepositoryType.OTHER,
+                                    matchedMarkers = emptyList(),
+                                ),
+                                createdFiles = emptyList(),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                ideHelperResult = null,
+                            )
+                        },
+                    )
+
+                val exitCode =
+                    cli.run(
+                        arrayOf(
+                            "init",
+                            "--skip-ide-helper",
+                            "--repo-root",
+                            tempDir.toString(),
+                        ),
+                    )
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Preserved existing bootstrap files")
+                out.joinToString("\n").shouldContain("Re-run with --force")
+                out.joinToString("\n").shouldContain("JetBrains IDE helper generation was skipped")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliTests.kt
@@ -5,15 +5,12 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.liam.microsmith.cli.command.IdeDoctorCommand
 import me.liam.microsmith.cli.command.IdeRefreshCommand
-import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.doctor.DoctorCheckResult
 import me.liam.microsmith.cli.doctor.DoctorCheckStatus
 import me.liam.microsmith.cli.doctor.DoctorResult
 import me.liam.microsmith.cli.ide.IdeDoctorCheckResult
 import me.liam.microsmith.cli.ide.IdeDoctorResult
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
-import me.liam.microsmith.cli.init.InitBootstrapResult
-import me.liam.microsmith.cli.init.InitConflictException
 import me.liam.microsmith.cli.plugins.PluginResolutionResult
 import me.liam.microsmith.runtime.scripting.model.ScriptFailureType
 import me.liam.microsmith.runtime.scripting.model.ScriptRunFailure
@@ -460,156 +457,6 @@ class MicrosmithCliTests :
             } finally {
                 runCatching { projectRoot.deleteRecursively() }
                 runCatching { helperRoot.deleteRecursively() }
-            }
-        }
-
-        "init command returns success and emits next run command when bootstrap succeeds" {
-            val out = mutableListOf<String>()
-            val err = mutableListOf<String>()
-            val tempDir = createTempDirectory("microsmith-cli-init-success")
-            try {
-                val helperRoot = tempDir.resolve(".microsmith/ide")
-                val cli =
-                    MicrosmithCli(
-                        stdout = out::add,
-                        stderr = err::add,
-                        initRunner = { command: InitCommand ->
-                            InitBootstrapResult(
-                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
-                                createdFiles =
-                                listOf(
-                                    tempDir.resolve("build.microsmith.kts"),
-                                    tempDir.resolve("settings.microsmith.kts"),
-                                ),
-                                preservedFiles = emptyList(),
-                                ideHelperResult =
-                                IdeHelperRefreshResult(
-                                    projectRoot = tempDir,
-                                    helperRoot = helperRoot,
-                                    updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
-                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
-                                ),
-                            )
-                        },
-                    )
-
-                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
-
-                exitCode shouldBe 0
-                out.joinToString("\n").shouldContain("Microsmith init completed")
-                out.joinToString("\n").shouldContain("build.microsmith.kts")
-                out.joinToString("\n").shouldContain("microsmith run build.microsmith.kts --out ./generated")
-                err shouldBe emptyList()
-            } finally {
-                runCatching { tempDir.deleteRecursively() }
-            }
-        }
-
-        "init command returns deterministic conflict failure code when bootstrap detects conflicting path" {
-            val out = mutableListOf<String>()
-            val err = mutableListOf<String>()
-            val cli =
-                MicrosmithCli(
-                    stdout = out::add,
-                    stderr = err::add,
-                    initRunner = {
-                        throw InitConflictException("Bootstrap path is not a regular file.")
-                    },
-                )
-
-            val exitCode = cli.run(arrayOf("init"))
-
-            exitCode shouldBe 50
-            err.joinToString("\n").shouldContain("MS-CLI-5001")
-            err.joinToString("\n").shouldContain("Bootstrap path is not a regular file")
-            out shouldBe emptyList()
-        }
-
-        "init command returns deterministic validation failure code when bootstrap validation fails" {
-            val out = mutableListOf<String>()
-            val err = mutableListOf<String>()
-            val cli =
-                MicrosmithCli(
-                    stdout = out::add,
-                    stderr = err::add,
-                    initRunner = {
-                        throw IllegalArgumentException("Repository root does not exist.")
-                    },
-                )
-
-            val exitCode = cli.run(arrayOf("init", "--repo-root", "/path/does/not/exist"))
-
-            exitCode shouldBe 51
-            err.joinToString("\n").shouldContain("MS-CLI-5002")
-            err.joinToString("\n").shouldContain("Repository root does not exist.")
-            out shouldBe emptyList()
-        }
-
-        "init command returns deterministic runtime failure code for unexpected bootstrap errors" {
-            val out = mutableListOf<String>()
-            val err = mutableListOf<String>()
-            val cli =
-                MicrosmithCli(
-                    stdout = out::add,
-                    stderr = err::add,
-                    initRunner = {
-                        throw IllegalStateException("Unexpected init failure.")
-                    },
-                )
-
-            val exitCode = cli.run(arrayOf("init"))
-
-            exitCode shouldBe 52
-            err.joinToString("\n").shouldContain("MS-CLI-5003")
-            err.joinToString("\n").shouldContain("Unexpected init failure.")
-            out shouldBe emptyList()
-        }
-
-        "init command emits json diagnostics payload when requested" {
-            val out = mutableListOf<String>()
-            val err = mutableListOf<String>()
-            val tempDir = createTempDirectory("microsmith-cli-init-json")
-            try {
-                val helperRoot = tempDir.resolve(".microsmith/ide")
-                val cli =
-                    MicrosmithCli(
-                        stdout = out::add,
-                        stderr = err::add,
-                        initRunner = { command: InitCommand ->
-                            InitBootstrapResult(
-                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
-                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
-                                preservedFiles = listOf(tempDir.resolve("settings.microsmith.kts")),
-                                ideHelperResult =
-                                IdeHelperRefreshResult(
-                                    projectRoot = tempDir,
-                                    helperRoot = helperRoot,
-                                    updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
-                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
-                                ),
-                            )
-                        },
-                    )
-
-                val exitCode =
-                    cli.run(
-                        arrayOf(
-                            "init",
-                            "--repo-root",
-                            tempDir.toString(),
-                            "--diagnostics",
-                            "json",
-                            "--verbose",
-                        ),
-                    )
-
-                exitCode shouldBe 0
-                out.joinToString("\n").shouldContain("\"level\":\"info\"")
-                out.joinToString("\n").shouldContain("Microsmith init completed")
-                out.joinToString("\n").shouldContain("\"details\"")
-                err shouldBe emptyList()
-            } finally {
-                runCatching { tempDir.deleteRecursively() }
             }
         }
 

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/doctor/DoctorRunnerTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/doctor/DoctorRunnerTests.kt
@@ -194,7 +194,7 @@ class DoctorRunnerTests :
                 val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
                 bootstrapCheck.status shouldBe DoctorCheckStatus.FAIL
                 bootstrapCheck.message.shouldContain("Run 'microsmith init'")
-                bootstrapCheck.details["missingBootstrapFiles"] shouldBe "build.microsmith.kts"
+                bootstrapCheck.details["invalidBootstrapFiles"] shouldBe "build.microsmith.kts"
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
                 runCatching { targetRoot.deleteRecursively() }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/doctor/DoctorRunnerTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/doctor/DoctorRunnerTests.kt
@@ -3,6 +3,7 @@ package me.liam.microsmith.cli.doctor
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createTempDirectory
@@ -60,6 +61,32 @@ class DoctorRunnerTests :
             }
         }
 
+        "bootstrap-state fails when bootstrap paths conflict with managed files" {
+            val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-conflict")
+            val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
+            val pluginCache = createTempDirectory("microsmith-doctor-plugin-cache")
+            repoRoot.resolve("build.microsmith.kts").createDirectories()
+            repoRoot.resolve("settings.microsmith.kts").writeText("// settings")
+            try {
+                val result =
+                    runDoctorChecks(
+                        providerValidator = { emptyList() },
+                        scriptCacheDirectory = scriptCache,
+                        pluginCacheDirectory = pluginCache,
+                        projectRoot = repoRoot,
+                    )
+
+                val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
+                bootstrapCheck.status shouldBe DoctorCheckStatus.FAIL
+                bootstrapCheck.message.shouldContain("conflicting paths")
+                bootstrapCheck.details["invalidBootstrapFiles"] shouldBe "build.microsmith.kts"
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { scriptCache.deleteRecursively() }
+                runCatching { pluginCache.deleteRecursively() }
+            }
+        }
+
         "bootstrap-state fails when the IDE helper is incomplete" {
             val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-helper-stale")
             val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
@@ -83,6 +110,37 @@ class DoctorRunnerTests :
                 bootstrapCheck.message.shouldContain("microsmith ide refresh")
                 bootstrapCheck.details["missingIdeHelperFiles"] shouldBe
                     ".microsmith/ide/README.md,.microsmith/ide/build.gradle.kts"
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { scriptCache.deleteRecursively() }
+                runCatching { pluginCache.deleteRecursively() }
+            }
+        }
+
+        "bootstrap-state fails when the IDE helper contains conflicting managed paths" {
+            val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-helper-conflict")
+            val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
+            val pluginCache = createTempDirectory("microsmith-doctor-plugin-cache")
+            val helperRoot = repoRoot.resolve(".microsmith/ide")
+            repoRoot.resolve("build.microsmith.kts").writeText("microsmith { }")
+            repoRoot.resolve("settings.microsmith.kts").writeText("// settings")
+            helperRoot.createDirectories()
+            helperRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"microsmith-ide-helper\"")
+            helperRoot.resolve("README.md").writeText("# helper")
+            helperRoot.resolve("build.gradle.kts").createDirectories()
+            try {
+                val result =
+                    runDoctorChecks(
+                        providerValidator = { emptyList() },
+                        scriptCacheDirectory = scriptCache,
+                        pluginCacheDirectory = pluginCache,
+                        projectRoot = repoRoot,
+                    )
+
+                val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
+                bootstrapCheck.status shouldBe DoctorCheckStatus.FAIL
+                bootstrapCheck.message.shouldContain("conflicting managed paths")
+                bootstrapCheck.details["invalidIdeHelperFiles"] shouldBe ".microsmith/ide/build.gradle.kts"
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
                 runCatching { scriptCache.deleteRecursively() }
@@ -114,4 +172,36 @@ class DoctorRunnerTests :
                 runCatching { pluginCache.deleteRecursively() }
             }
         }
+
+        "bootstrap-state treats symlinked bootstrap files as invalid".config(enabled = !runningOnWindows()) {
+            val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-symlink")
+            val targetRoot = createTempDirectory("microsmith-doctor-bootstrap-symlink-target")
+            val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
+            val pluginCache = createTempDirectory("microsmith-doctor-plugin-cache")
+            val externalBuildScript = targetRoot.resolve("build.microsmith.kts")
+            externalBuildScript.writeText("microsmith { }")
+            Files.createSymbolicLink(repoRoot.resolve("build.microsmith.kts"), externalBuildScript)
+            repoRoot.resolve("settings.microsmith.kts").writeText("// settings")
+            try {
+                val result =
+                    runDoctorChecks(
+                        providerValidator = { emptyList() },
+                        scriptCacheDirectory = scriptCache,
+                        pluginCacheDirectory = pluginCache,
+                        projectRoot = repoRoot,
+                    )
+
+                val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
+                bootstrapCheck.status shouldBe DoctorCheckStatus.FAIL
+                bootstrapCheck.message.shouldContain("Run 'microsmith init'")
+                bootstrapCheck.details["missingBootstrapFiles"] shouldBe "build.microsmith.kts"
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { targetRoot.deleteRecursively() }
+                runCatching { scriptCache.deleteRecursively() }
+                runCatching { pluginCache.deleteRecursively() }
+            }
+        }
     })
+
+private fun runningOnWindows(): Boolean = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/doctor/DoctorRunnerTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/doctor/DoctorRunnerTests.kt
@@ -1,0 +1,117 @@
+package me.liam.microsmith.cli.doctor
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class DoctorRunnerTests :
+    StringSpec({
+        "bootstrap-state passes when init has not been run in the working directory" {
+            val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-absent")
+            val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
+            val pluginCache = createTempDirectory("microsmith-doctor-plugin-cache")
+            try {
+                val result =
+                    runDoctorChecks(
+                        providerValidator = { emptyList() },
+                        scriptCacheDirectory = scriptCache,
+                        pluginCacheDirectory = pluginCache,
+                        projectRoot = repoRoot,
+                    )
+
+                val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
+                bootstrapCheck.status shouldBe DoctorCheckStatus.PASS
+                bootstrapCheck.message.shouldContain("were not detected")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { scriptCache.deleteRecursively() }
+                runCatching { pluginCache.deleteRecursively() }
+            }
+        }
+
+        "bootstrap-state fails when bootstrap scripts are incomplete" {
+            val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-incomplete")
+            val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
+            val pluginCache = createTempDirectory("microsmith-doctor-plugin-cache")
+            repoRoot.resolve("build.microsmith.kts").writeText("microsmith { }")
+            try {
+                val result =
+                    runDoctorChecks(
+                        providerValidator = { emptyList() },
+                        scriptCacheDirectory = scriptCache,
+                        pluginCacheDirectory = pluginCache,
+                        projectRoot = repoRoot,
+                    )
+
+                val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
+                bootstrapCheck.status shouldBe DoctorCheckStatus.FAIL
+                bootstrapCheck.message.shouldContain("Run 'microsmith init'")
+                bootstrapCheck.details["missingBootstrapFiles"] shouldBe "settings.microsmith.kts"
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { scriptCache.deleteRecursively() }
+                runCatching { pluginCache.deleteRecursively() }
+            }
+        }
+
+        "bootstrap-state fails when the IDE helper is incomplete" {
+            val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-helper-stale")
+            val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
+            val pluginCache = createTempDirectory("microsmith-doctor-plugin-cache")
+            repoRoot.resolve("build.microsmith.kts").writeText("microsmith { }")
+            repoRoot.resolve("settings.microsmith.kts").writeText("// settings")
+            repoRoot.resolve(".microsmith/ide").createDirectories()
+            repoRoot.resolve(".microsmith/ide/settings.gradle.kts")
+                .writeText("rootProject.name = \"microsmith-ide-helper\"")
+            try {
+                val result =
+                    runDoctorChecks(
+                        providerValidator = { emptyList() },
+                        scriptCacheDirectory = scriptCache,
+                        pluginCacheDirectory = pluginCache,
+                        projectRoot = repoRoot,
+                    )
+
+                val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
+                bootstrapCheck.status shouldBe DoctorCheckStatus.FAIL
+                bootstrapCheck.message.shouldContain("microsmith ide refresh")
+                bootstrapCheck.details["missingIdeHelperFiles"] shouldBe
+                    ".microsmith/ide/README.md,.microsmith/ide/build.gradle.kts"
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { scriptCache.deleteRecursively() }
+                runCatching { pluginCache.deleteRecursively() }
+            }
+        }
+
+        "bootstrap-state fails when bootstrap files are present but IDE helper is missing" {
+            val repoRoot = createTempDirectory("microsmith-doctor-bootstrap-no-ide")
+            val scriptCache = createTempDirectory("microsmith-doctor-script-cache")
+            val pluginCache = createTempDirectory("microsmith-doctor-plugin-cache")
+            repoRoot.resolve("build.microsmith.kts").writeText("microsmith { }")
+            repoRoot.resolve("settings.microsmith.kts").writeText("// settings")
+            try {
+                val result =
+                    runDoctorChecks(
+                        providerValidator = { emptyList() },
+                        scriptCacheDirectory = scriptCache,
+                        pluginCacheDirectory = pluginCache,
+                        projectRoot = repoRoot,
+                    )
+
+                val bootstrapCheck = result.checks.single { it.id == "bootstrap-state" }
+                bootstrapCheck.status shouldBe DoctorCheckStatus.FAIL
+                bootstrapCheck.message.shouldContain("missing")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { scriptCache.deleteRecursively() }
+                runCatching { pluginCache.deleteRecursively() }
+            }
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorTests.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.liam.microsmith.cli.command.IdeDoctorCommand
 import me.liam.microsmith.cli.command.IdeRefreshCommand
+import java.nio.file.Files
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createTempDirectory
@@ -107,6 +108,34 @@ class IdeHelperDoctorTests :
                 requiredFilesCheck.message.shouldContain("conflicting managed paths")
                 requiredFilesCheck.details["invalidFiles"]
                     .shouldContain(helperRoot.resolve("build.gradle.kts").toString())
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "reports stale helper build file when managed file is undecodable" {
+            val repoRoot = createTempDirectory("microsmith-ide-doctor-invalid-bytes")
+            val runtimeJar = repoRoot.resolve("runtime/microsmith-cli-all.jar")
+            val helperRoot = repoRoot.resolve(".microsmith/ide")
+            runtimeJar.parent.createDirectories()
+            runtimeJar.writeText("jar-binary-placeholder")
+            try {
+                refreshIdeHelperProject(
+                    command = IdeRefreshCommand(projectRoot = repoRoot),
+                    classpathResolver = { listOf(runtimeJar) },
+                )
+                Files.write(helperRoot.resolve("build.gradle.kts"), byteArrayOf(0xC3.toByte(), 0x28))
+
+                val result =
+                    runIdeHelperDoctor(
+                        command = IdeDoctorCommand(projectRoot = repoRoot),
+                        classpathResolver = { listOf(runtimeJar) },
+                    )
+
+                result.hasFailures shouldBe true
+                val classpathSyncCheck = result.checks.first { check -> check.id == "classpath-sync" }
+                classpathSyncCheck.passed shouldBe false
+                classpathSyncCheck.message.shouldContain("stale")
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
             }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorTests.kt
@@ -83,4 +83,32 @@ class IdeHelperDoctorTests :
                 runCatching { repoRoot.deleteRecursively() }
             }
         }
+
+        "reports conflicting managed helper files" {
+            val repoRoot = createTempDirectory("microsmith-ide-doctor-conflicting-helper")
+            val runtimeJar = repoRoot.resolve("runtime/microsmith-cli-all.jar")
+            val helperRoot = repoRoot.resolve(".microsmith/ide")
+            runtimeJar.parent.createDirectories()
+            helperRoot.createDirectories()
+            runtimeJar.writeText("jar-binary-placeholder")
+            helperRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"microsmith-ide-helper\"")
+            helperRoot.resolve("README.md").writeText("# helper")
+            helperRoot.resolve("build.gradle.kts").createDirectories()
+            try {
+                val result =
+                    runIdeHelperDoctor(
+                        command = IdeDoctorCommand(projectRoot = repoRoot),
+                        classpathResolver = { listOf(runtimeJar) },
+                    )
+
+                result.hasFailures shouldBe true
+                val requiredFilesCheck = result.checks.first { check -> check.id == "required-files" }
+                requiredFilesCheck.passed shouldBe false
+                requiredFilesCheck.message.shouldContain("conflicting managed paths")
+                requiredFilesCheck.details["invalidFiles"]
+                    .shouldContain(helperRoot.resolve("build.gradle.kts").toString())
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
     })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
@@ -128,6 +128,29 @@ class IdeHelperGeneratorTests :
             }
         }
 
+        "overwrites undecodable managed helper files" {
+            val repoRoot = createTempDirectory("microsmith-ide-helper-invalid-bytes")
+            val runtimeJar = repoRoot.resolve("runtime/microsmith-cli-all.jar")
+            val helperRoot = repoRoot.resolve(".microsmith/ide")
+            runtimeJar.parent.createDirectories()
+            helperRoot.createDirectories()
+            runtimeJar.writeText("jar-binary-placeholder")
+            Files.write(helperRoot.resolve("build.gradle.kts"), byteArrayOf(0xC3.toByte(), 0x28))
+
+            try {
+                val result =
+                    refreshIdeHelperProject(
+                        command = IdeRefreshCommand(projectRoot = repoRoot),
+                        classpathResolver = { listOf(runtimeJar) },
+                    )
+
+                result.updatedFiles.shouldContain(helperRoot.resolve("build.gradle.kts"))
+                helperRoot.resolve("build.gradle.kts").readText().shouldContain("java-library")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "fails when managed helper root exists as a symlink".config(enabled = !runningOnWindows()) {
             val repoRoot = createTempDirectory("microsmith-ide-helper-root-symlink")
             val externalRoot = createTempDirectory("microsmith-ide-helper-root-symlink-target")

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.liam.microsmith.cli.command.IdeRefreshCommand
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createDirectories
@@ -126,4 +127,58 @@ class IdeHelperGeneratorTests :
                 runCatching { repoRoot.deleteRecursively() }
             }
         }
+
+        "fails when managed helper root exists as a symlink".config(enabled = !runningOnWindows()) {
+            val repoRoot = createTempDirectory("microsmith-ide-helper-root-symlink")
+            val externalRoot = createTempDirectory("microsmith-ide-helper-root-symlink-target")
+            val runtimeJar = repoRoot.resolve("runtime/microsmith-cli-all.jar")
+            runtimeJar.parent.createDirectories()
+            runtimeJar.writeText("jar-binary-placeholder")
+            Files.createSymbolicLink(repoRoot.resolve(".microsmith"), externalRoot)
+
+            try {
+                val error =
+                    shouldThrow<IdeHelperConflictException> {
+                        refreshIdeHelperProject(
+                            command = IdeRefreshCommand(projectRoot = repoRoot),
+                            classpathResolver = { listOf(runtimeJar) },
+                        )
+                    }
+
+                error.message.shouldContain("exists but is not a directory")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { externalRoot.deleteRecursively() }
+            }
+        }
+
+        "fails when managed helper file exists as a symlink".config(enabled = !runningOnWindows()) {
+            val repoRoot = createTempDirectory("microsmith-ide-helper-file-symlink")
+            val externalRoot = createTempDirectory("microsmith-ide-helper-file-symlink-target")
+            val runtimeJar = repoRoot.resolve("runtime/microsmith-cli-all.jar")
+            val helperRoot = repoRoot.resolve(".microsmith/ide")
+            val targetFile = externalRoot.resolve("external-build.gradle.kts")
+            runtimeJar.parent.createDirectories()
+            helperRoot.createDirectories()
+            runtimeJar.writeText("jar-binary-placeholder")
+            targetFile.writeText("// external build file")
+            Files.createSymbolicLink(helperRoot.resolve("build.gradle.kts"), targetFile)
+
+            try {
+                val error =
+                    shouldThrow<IdeHelperConflictException> {
+                        refreshIdeHelperProject(
+                            command = IdeRefreshCommand(projectRoot = repoRoot),
+                            classpathResolver = { listOf(runtimeJar) },
+                        )
+                    }
+
+                error.message.shouldContain("exists but is not a regular file")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { externalRoot.deleteRecursively() }
+            }
+        }
     })
+
+private fun runningOnWindows(): Boolean = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
@@ -11,6 +11,7 @@ import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.ide.IdeHelperConflictException
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
 import java.io.IOException
+import java.io.UncheckedIOException
 import java.nio.file.Files
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createDirectories
@@ -144,6 +145,25 @@ class InitBootstrapTests :
             }
         }
 
+        "overwrites undecodable bootstrap files when force is enabled" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-force-invalid-bytes")
+            val buildScript = repoRoot.resolve("build.microsmith.kts")
+            Files.write(buildScript, byteArrayOf(0xC3.toByte(), 0x28))
+            try {
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot, force = true, skipIdeHelper = true),
+                    )
+
+                result.createdFiles.shouldContainExactly(listOf(repoRoot.resolve("settings.microsmith.kts")))
+                result.overwrittenFiles.shouldContainExactly(listOf(buildScript))
+                result.preservedFiles shouldBe emptyList()
+                buildScript.readText().shouldContain("UserCreated")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "skips IDE helper refresh when explicitly disabled" {
             val repoRoot = createTempDirectory("microsmith-init-bootstrap-skip-ide")
             try {
@@ -187,6 +207,26 @@ class InitBootstrapTests :
                 detectOnboardingRepositoryType(
                     projectRoot = nodeRoot,
                     dotnetMarkerFinder = { throw IOException("permission denied") },
+                ) shouldBe
+                    OnboardingRepositoryDetection(
+                        type = OnboardingRepositoryType.NODE,
+                        matchedMarkers = listOf("package.json"),
+                    )
+            } finally {
+                runCatching { nodeRoot.deleteRecursively() }
+            }
+        }
+
+        "ignores unchecked .NET marker traversal failures while detecting other repository markers" {
+            val nodeRoot = createTempDirectory("microsmith-init-detect-node-unchecked-traversal-failure")
+            try {
+                nodeRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
+
+                detectOnboardingRepositoryType(
+                    projectRoot = nodeRoot,
+                    dotnetMarkerFinder = {
+                        throw UncheckedIOException(IOException("permission denied"))
+                    },
                 ) shouldBe
                     OnboardingRepositoryDetection(
                         type = OnboardingRepositoryType.NODE,

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.string.shouldContain
 import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.ide.IdeHelperConflictException
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import java.io.IOException
 import java.nio.file.Files
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createDirectories
@@ -90,6 +91,26 @@ class InitBootstrapTests :
             }
         }
 
+        "preserves existing regular bootstrap files without reading content when force is disabled" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-preserve-bytes")
+            val buildScript = repoRoot.resolve("build.microsmith.kts")
+            val originalBytes = byteArrayOf(0xC3.toByte(), 0x28)
+            Files.write(buildScript, originalBytes)
+            try {
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot, skipIdeHelper = true),
+                    )
+
+                result.createdFiles.shouldContainExactly(listOf(repoRoot.resolve("settings.microsmith.kts")))
+                result.overwrittenFiles shouldBe emptyList()
+                result.preservedFiles.shouldContainExactly(listOf(buildScript))
+                Files.readAllBytes(buildScript).contentEquals(originalBytes) shouldBe true
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "overwrites existing regular bootstrap files when force is enabled" {
             val repoRoot = createTempDirectory("microsmith-init-bootstrap-force")
             val buildScript = repoRoot.resolve("build.microsmith.kts")
@@ -155,6 +176,24 @@ class InitBootstrapTests :
                 error.message shouldBe "IDE helper path is invalid."
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "ignores .NET marker traversal failures while detecting other repository markers" {
+            val nodeRoot = createTempDirectory("microsmith-init-detect-node-traversal-failure")
+            try {
+                nodeRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
+
+                detectOnboardingRepositoryType(
+                    projectRoot = nodeRoot,
+                    dotnetMarkerFinder = { throw IOException("permission denied") },
+                ) shouldBe
+                    OnboardingRepositoryDetection(
+                        type = OnboardingRepositoryType.NODE,
+                        matchedMarkers = listOf("package.json"),
+                    )
+            } finally {
+                runCatching { nodeRoot.deleteRecursively() }
             }
         }
 

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
@@ -8,7 +8,9 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperConflictException
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import java.nio.file.Files
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createTempDirectory
@@ -137,6 +139,25 @@ class InitBootstrapTests :
             }
         }
 
+        "rethrows IDE helper conflicts as init conflicts" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-ide-conflict")
+            try {
+                val error =
+                    shouldThrow<InitConflictException> {
+                        runInitBootstrap(
+                            command = InitCommand(projectRoot = repoRoot),
+                            ideRefreshRunner = {
+                                throw IdeHelperConflictException("IDE helper path is invalid.")
+                            },
+                        )
+                    }
+
+                error.message shouldBe "IDE helper path is invalid."
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "detects Node, Go, and .NET repositories and falls back to Other for mixed markers" {
             val nodeRoot = createTempDirectory("microsmith-init-detect-node")
             val goRoot = createTempDirectory("microsmith-init-detect-go")
@@ -197,12 +218,34 @@ class InitBootstrapTests :
             }
         }
 
+        "throws conflict when bootstrap path exists as a symlink".config(enabled = !runningOnWindows()) {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-symlink")
+            val targetFile = createTempDirectory("microsmith-init-bootstrap-symlink-target")
+                .resolve("external-build.microsmith.kts")
+            targetFile.writeText("// external build script")
+            Files.createSymbolicLink(repoRoot.resolve("build.microsmith.kts"), targetFile)
+            try {
+                val error =
+                    shouldThrow<InitConflictException> {
+                        runInitBootstrap(
+                            command = InitCommand(projectRoot = repoRoot, force = true),
+                            ideRefreshRunner = { error("should not refresh IDE helper when conflict exists") },
+                        )
+                    }
+
+                error.message.shouldContain("exists but is not a regular file")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+                runCatching { targetFile.parent.deleteRecursively() }
+            }
+        }
+
         "throws validation error when repository root does not exist" {
             val repoRoot = createTempDirectory("microsmith-init-bootstrap-missing")
             repoRoot.deleteRecursively()
 
             val error =
-                shouldThrow<IllegalArgumentException> {
+                shouldThrow<InitValidationException> {
                     runInitBootstrap(
                         command = InitCommand(projectRoot = repoRoot),
                         ideRefreshRunner = { error("should not refresh IDE helper when root is missing") },
@@ -213,3 +256,5 @@ class InitBootstrapTests :
             repoRoot.exists() shouldBe false
         }
     })
+
+private fun runningOnWindows(): Boolean = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
@@ -3,6 +3,7 @@ package me.liam.microsmith.cli.init
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -20,8 +21,9 @@ import kotlin.io.path.writeText
 @OptIn(ExperimentalPathApi::class)
 class InitBootstrapTests :
     StringSpec({
-        "creates default bootstrap files and invokes IDE helper refresh" {
+        "creates repo-aware bootstrap files and invokes IDE helper refresh" {
             val repoRoot = createTempDirectory("microsmith-init-bootstrap-create")
+            repoRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
             try {
                 val helperRoot = repoRoot.resolve(".microsmith/ide")
                 val result =
@@ -37,19 +39,28 @@ class InitBootstrapTests :
                         },
                     )
 
-                result.createdFiles.shouldHaveSize(2)
-                result.createdFiles.shouldContain(repoRoot.resolve("build.microsmith.kts"))
-                result.createdFiles.shouldContain(repoRoot.resolve("settings.microsmith.kts"))
+                result.repositoryDetection.type shouldBe OnboardingRepositoryType.NODE
+                result.repositoryDetection.matchedMarkers shouldBe listOf("package.json")
+                result.createdFiles.shouldContainExactly(
+                    listOf(
+                        repoRoot.resolve("build.microsmith.kts"),
+                        repoRoot.resolve("settings.microsmith.kts"),
+                    ),
+                )
+                result.overwrittenFiles shouldBe emptyList()
                 result.preservedFiles shouldBe emptyList()
+                result.ideHelperResult?.helperRoot shouldBe helperRoot
                 repoRoot.resolve("build.microsmith.kts").isRegularFile() shouldBe true
                 repoRoot.resolve("settings.microsmith.kts").isRegularFile() shouldBe true
-                repoRoot.resolve("build.microsmith.kts").readText().shouldContain("microsmith {")
+                repoRoot.resolve("build.microsmith.kts").readText().shouldContain("NodeUserCreated")
+                repoRoot.resolve("build.microsmith.kts").readText().shouldContain("./generated")
+                repoRoot.resolve("settings.microsmith.kts").readText().shouldContain("Detected repository type: Node")
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
             }
         }
 
-        "preserves existing bootstrap files on repeated init runs" {
+        "preserves existing bootstrap files on repeated init runs by default" {
             val repoRoot = createTempDirectory("microsmith-init-bootstrap-idempotent")
             val existingBuild = repoRoot.resolve("build.microsmith.kts")
             existingBuild.writeText("// existing build script")
@@ -68,12 +79,103 @@ class InitBootstrapTests :
                         },
                     )
 
-                result.createdFiles.shouldHaveSize(1)
-                result.createdFiles.single() shouldBe repoRoot.resolve("settings.microsmith.kts")
-                result.preservedFiles.shouldContain(existingBuild)
+                result.createdFiles.shouldContainExactly(listOf(repoRoot.resolve("settings.microsmith.kts")))
+                result.overwrittenFiles shouldBe emptyList()
+                result.preservedFiles.shouldContainExactly(listOf(existingBuild))
                 existingBuild.readText() shouldBe "// existing build script"
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "overwrites existing regular bootstrap files when force is enabled" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-force")
+            val buildScript = repoRoot.resolve("build.microsmith.kts")
+            val settingsScript = repoRoot.resolve("settings.microsmith.kts")
+            buildScript.writeText("// stale build script")
+            settingsScript.writeText("// stale settings")
+            repoRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot, force = true),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.repositoryDetection.type shouldBe OnboardingRepositoryType.GO
+                result.createdFiles shouldBe emptyList()
+                result.overwrittenFiles.shouldContainExactly(listOf(buildScript, settingsScript))
+                result.preservedFiles shouldBe emptyList()
+                buildScript.readText().shouldContain("GoUserCreated")
+                settingsScript.readText().shouldContain("go.mod")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "skips IDE helper refresh when explicitly disabled" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-skip-ide")
+            try {
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot, skipIdeHelper = true),
+                        ideRefreshRunner = { error("IDE helper refresh should be skipped when disabled") },
+                    )
+
+                result.createdFiles.shouldHaveSize(2)
+                result.ideHelperResult shouldBe null
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Node, Go, and .NET repositories and falls back to Other for mixed markers" {
+            val nodeRoot = createTempDirectory("microsmith-init-detect-node")
+            val goRoot = createTempDirectory("microsmith-init-detect-go")
+            val dotnetRoot = createTempDirectory("microsmith-init-detect-dotnet")
+            val mixedRoot = createTempDirectory("microsmith-init-detect-mixed")
+            try {
+                nodeRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
+                goRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
+                dotnetRoot.resolve("src/apps/service").createDirectories()
+                dotnetRoot.resolve("src/apps/service/Fixture.csproj")
+                    .writeText("<Project Sdk=\"Microsoft.NET.Sdk\" />\n")
+                mixedRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
+                mixedRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
+
+                detectOnboardingRepositoryType(nodeRoot) shouldBe
+                    OnboardingRepositoryDetection(
+                        type = OnboardingRepositoryType.NODE,
+                        matchedMarkers = listOf("package.json"),
+                    )
+                detectOnboardingRepositoryType(goRoot) shouldBe
+                    OnboardingRepositoryDetection(
+                        type = OnboardingRepositoryType.GO,
+                        matchedMarkers = listOf("go.mod"),
+                    )
+                detectOnboardingRepositoryType(dotnetRoot) shouldBe
+                    OnboardingRepositoryDetection(
+                        type = OnboardingRepositoryType.DOTNET,
+                        matchedMarkers = listOf("src/apps/service/Fixture.csproj"),
+                    )
+                detectOnboardingRepositoryType(mixedRoot) shouldBe
+                    OnboardingRepositoryDetection(
+                        type = OnboardingRepositoryType.OTHER,
+                        matchedMarkers = listOf("go.mod", "package.json"),
+                    )
+            } finally {
+                runCatching { nodeRoot.deleteRecursively() }
+                runCatching { goRoot.deleteRecursively() }
+                runCatching { dotnetRoot.deleteRecursively() }
+                runCatching { mixedRoot.deleteRecursively() }
             }
         }
 

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/parsing/CliParserTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/parsing/CliParserTests.kt
@@ -57,6 +57,8 @@ class CliParserTests :
                     "examples/go-service",
                     "--non-interactive",
                     "--yes",
+                    "--force",
+                    "--skip-ide-helper",
                     "--diagnostics",
                     "json",
                     "--verbose",
@@ -68,6 +70,8 @@ class CliParserTests :
                     verbose = true,
                     nonInteractive = true,
                     assumeYes = true,
+                    force = true,
+                    skipIdeHelper = true,
                 )
         }
 
@@ -342,6 +346,16 @@ class CliParserTests :
         "returns error when init yes is specified multiple times" {
             parseCliArgs(listOf("init", "--yes", "--yes")) shouldBe
                 ErrorCommand("--yes may only be specified once.")
+        }
+
+        "returns error when init force is specified multiple times" {
+            parseCliArgs(listOf("init", "--force", "--force")) shouldBe
+                ErrorCommand("--force may only be specified once.")
+        }
+
+        "returns error when init skip-ide-helper is specified multiple times" {
+            parseCliArgs(listOf("init", "--skip-ide-helper", "--skip-ide-helper")) shouldBe
+                ErrorCommand("--skip-ide-helper may only be specified once.")
         }
 
         "returns error for unknown doctor option" {

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/parsing/CliParserTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/parsing/CliParserTests.kt
@@ -55,8 +55,6 @@ class CliParserTests :
                     "init",
                     "--repo-root",
                     "examples/go-service",
-                    "--non-interactive",
-                    "--yes",
                     "--force",
                     "--skip-ide-helper",
                     "--diagnostics",
@@ -68,8 +66,6 @@ class CliParserTests :
                     projectRoot = Path("examples/go-service"),
                     diagnosticsFormat = DiagnosticFormat.JSON,
                     verbose = true,
-                    nonInteractive = true,
-                    assumeYes = true,
                     force = true,
                     skipIdeHelper = true,
                 )
@@ -338,14 +334,14 @@ class CliParserTests :
             ) shouldBe ErrorCommand("--repo-root may only be specified once.")
         }
 
-        "returns error when init non-interactive is specified multiple times" {
-            parseCliArgs(listOf("init", "--non-interactive", "--non-interactive")) shouldBe
-                ErrorCommand("--non-interactive may only be specified once.")
+        "returns error for removed init non-interactive option" {
+            parseCliArgs(listOf("init", "--non-interactive")) shouldBe
+                ErrorCommand("Unknown option '--non-interactive'.")
         }
 
-        "returns error when init yes is specified multiple times" {
-            parseCliArgs(listOf("init", "--yes", "--yes")) shouldBe
-                ErrorCommand("--yes may only be specified once.")
+        "returns error for removed init yes option" {
+            parseCliArgs(listOf("init", "--yes")) shouldBe
+                ErrorCommand("Unknown option '--yes'.")
         }
 
         "returns error when init force is specified multiple times" {

--- a/examples/non-gradle/dotnet/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/dotnet/.github/workflows/microsmith.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Bootstrap Microsmith
         shell: pwsh
         working-directory: examples/non-gradle/dotnet
-        run: microsmith init --non-interactive --yes
+        run: microsmith init
       - name: Generate protobuf
         shell: pwsh
         working-directory: examples/non-gradle/dotnet

--- a/examples/non-gradle/dotnet/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/dotnet/.github/workflows/microsmith.yml
@@ -14,6 +14,16 @@ jobs:
           Invoke-WebRequest -Uri $env:MICROSMITH_INSTALLER_PS1_URL -OutFile microsmith-install.ps1
           .\microsmith-install.ps1 -Version $env:MICROSMITH_VERSION
           Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $HOME ".microsmith\bin")
+      - name: Bootstrap Microsmith
+        shell: pwsh
+        working-directory: examples/non-gradle/dotnet
+        run: microsmith init --non-interactive --yes
       - name: Generate protobuf
         shell: pwsh
-        run: microsmith run schema.microsmith.kts --out .\Generated\Proto
+        working-directory: examples/non-gradle/dotnet
+        run: |
+          microsmith run build.microsmith.kts --out .\Generated
+          if (-not (Test-Path .\Generated\proto\DotnetUserCreated.proto)) {
+            Write-Error "Expected Generated\\proto\\DotnetUserCreated.proto to exist."
+            exit 1
+          }

--- a/examples/non-gradle/dotnet/MicrosmithFixture.csproj
+++ b/examples/non-gradle/dotnet/MicrosmithFixture.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/examples/non-gradle/go/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/go/.github/workflows/microsmith.yml
@@ -13,5 +13,11 @@ jobs:
           curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
           sh microsmith-install.sh --version "$MICROSMITH_VERSION"
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        working-directory: examples/non-gradle/go
+        run: microsmith init --non-interactive --yes
       - name: Generate protobuf
-        run: microsmith run schema.microsmith.kts --out internal/gen/proto
+        working-directory: examples/non-gradle/go
+        run: |
+          microsmith run build.microsmith.kts --out internal/gen
+          test -f internal/gen/proto/GoUserCreated.proto

--- a/examples/non-gradle/go/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/go/.github/workflows/microsmith.yml
@@ -15,7 +15,7 @@ jobs:
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
       - name: Bootstrap Microsmith
         working-directory: examples/non-gradle/go
-        run: microsmith init --non-interactive --yes
+        run: microsmith init
       - name: Generate protobuf
         working-directory: examples/non-gradle/go
         run: |

--- a/examples/non-gradle/go/go.mod
+++ b/examples/non-gradle/go/go.mod
@@ -1,0 +1,3 @@
+module example.com/microsmith/fixture
+
+go 1.24.0

--- a/examples/non-gradle/node/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/node/.github/workflows/microsmith.yml
@@ -13,5 +13,11 @@ jobs:
           curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
           sh microsmith-install.sh --version "$MICROSMITH_VERSION"
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        working-directory: examples/non-gradle/node
+        run: microsmith init --non-interactive --yes
       - name: Generate protobuf
-        run: microsmith run schema.microsmith.kts --out generated/proto
+        working-directory: examples/non-gradle/node
+        run: |
+          microsmith run build.microsmith.kts --out generated
+          test -f generated/proto/NodeUserCreated.proto

--- a/examples/non-gradle/node/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/node/.github/workflows/microsmith.yml
@@ -15,7 +15,7 @@ jobs:
           echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
       - name: Bootstrap Microsmith
         working-directory: examples/non-gradle/node
-        run: microsmith init --non-interactive --yes
+        run: microsmith init
       - name: Generate protobuf
         working-directory: examples/non-gradle/node
         run: |

--- a/examples/non-gradle/node/package.json
+++ b/examples/non-gradle/node/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "microsmith-node-fixture",
+  "private": true
+}


### PR DESCRIPTION
## Summary
- add a repo-aware `microsmith init` flow for Node, Go, .NET, and generic repositories
- add explicit `--force` and `--skip-ide-helper` handling, richer init summaries, and bootstrap-state doctor validation
- add fixture repo markers plus CI/workflow coverage for plain and non-interactive onboarding paths
- update `README.md` to document the init-first onboarding contract and real output layout behavior

## Problem
Non-JVM repositories still needed too much manual setup to reach a first successful Microsmith run, and the existing bootstrap path did not fully define repo-aware defaults, overwrite semantics, IDE readiness, or fixture-backed onboarding coverage.

## Solution
- detect repository shape from `package.json`, `go.mod`, and `.csproj`/`.sln` markers
- generate repo-aware bootstrap scripts with deterministic preserve vs overwrite behavior
- default `init` to generating `.microsmith/ide`, while keeping an explicit opt-out flag
- surface configured assets and exact next commands directly in normal CLI output
- extend `doctor` to report incomplete bootstrap or stale helper state
- validate the onboarding contract through non-JVM fixtures in repository CI and example workflows

## Validation
- `./gradlew :cli:check :cli:jvmKotest`
- built launcher smoke over temp copies of the Node, Go, and .NET fixtures using both `microsmith init` and `microsmith init --non-interactive --yes`
- verified `./cli/build/microsmith-cli-dist/bin/microsmith --help` matches the README command reference

## Notes
- `.NET` repo detection now searches common nested layouts instead of only shallow roots
- repository-native output guidance now points at the real output root passed to `--out`; the protobuf provider still writes under `proto/` beneath that root

Closes #52
