### PR TITLE
feat(quality-ci): consolidate duplicated per-OS CLI smoke workflows

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
 
-  cli-dist-smoke:
+  cli-smoke:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -77,19 +77,19 @@ jobs:
           java-version: 24
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
-      - name: Build CLI distribution artifacts (Unix)
+      - name: Build CLI release assets (Unix)
         if: runner.os != 'Windows'
-        run: ./gradlew :cli:distArtifacts --stacktrace
-      - name: Build CLI distribution artifacts (Windows)
+        run: ./gradlew :cli:releaseArtifacts --stacktrace
+      - name: Build CLI release assets (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: .\gradlew.bat :cli:distArtifacts --stacktrace
-      - name: Smoke test launcher (Unix)
+        run: .\gradlew.bat :cli:releaseArtifacts --stacktrace
+      - name: Smoke test dist launcher (Unix)
         if: runner.os != 'Windows'
         run: |
           ./cli/build/microsmith-cli-dist/bin/microsmith --help > cli-help.txt
           grep -q "Usage:" cli-help.txt
-      - name: Smoke test generation and provider discovery (Unix)
+      - name: Smoke test dist generation and provider discovery (Unix)
         if: runner.os != 'Windows'
         run: |
           cat > schema.microsmith.kts <<'EOF'
@@ -107,12 +107,12 @@ jobs:
           test -f generated/proto/CiSmoke.proto
           ./cli/build/microsmith-cli-dist/bin/microsmith run schema.microsmith.kts --out generated-process --isolation process
           test -f generated-process/proto/CiSmoke.proto
-      - name: Smoke test doctor diagnostics mode (Unix)
+      - name: Smoke test dist doctor diagnostics mode (Unix)
         if: runner.os != 'Windows'
         run: |
           ./cli/build/microsmith-cli-dist/bin/microsmith doctor --diagnostics json > cli-doctor.json
           grep -q "Doctor checks passed." cli-doctor.json
-      - name: Smoke test launcher (Windows)
+      - name: Smoke test dist launcher (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -126,7 +126,7 @@ jobs:
             Write-Output $help
             exit 1
           }
-      - name: Smoke test generation and provider discovery (Windows)
+      - name: Smoke test dist generation and provider discovery (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -157,7 +157,7 @@ jobs:
             Write-Error "Expected generated-process\\proto\\CiSmoke.proto to exist."
             exit 1
           }
-      - name: Smoke test doctor diagnostics mode (Windows)
+      - name: Smoke test dist doctor diagnostics mode (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -171,35 +171,6 @@ jobs:
             Write-Output $doctor
             exit 1
           }
-
-  cli-install-smoke:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v5
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 24
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-      - name: Build CLI release assets (Unix)
-        if: runner.os != 'Windows'
-        run: ./gradlew :cli:releaseArtifacts --stacktrace
-      - name: Build CLI release assets (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: .\gradlew.bat :cli:releaseArtifacts --stacktrace
       - name: Install and verify from installer (Unix)
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -172,7 +172,8 @@ jobs:
             exit 1
           }
       - name: Install and verify from installer (Unix)
-        if: runner.os != 'Windows'
+        id: install-unix
+        if: ${{ always() && runner.os != 'Windows' }}
         run: |
           set -eu
           DIST_FILE="$(find cli/build/release-assets -maxdepth 1 -type f -name 'microsmith-cli-*-dist.tar.gz' | head -n 1)"
@@ -194,7 +195,7 @@ jobs:
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
           test -f install-smoke-repo/generated/proto/UserCreated.proto
       - name: Smoke test Node and Go onboarding fixtures (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ always() && matrix.os == 'ubuntu-latest' && steps.install-unix.outcome == 'success' }}
         run: |
           set -eu
           ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node
@@ -212,7 +213,8 @@ jobs:
           ./.microsmith-bin/microsmith run examples/non-gradle/go/build.microsmith.kts --out examples/non-gradle/go/internal/gen
           test -f examples/non-gradle/go/internal/gen/proto/GoUserCreated.proto
       - name: Install and verify from installer (Windows)
-        if: runner.os == 'Windows'
+        id: install-windows
+        if: ${{ always() && runner.os == 'Windows' }}
         shell: pwsh
         run: |
           $distAsset = Get-ChildItem -Path .\cli\build\release-assets\microsmith-cli-*-dist.zip | Select-Object -First 1
@@ -264,7 +266,7 @@ jobs:
             exit 1
           }
       - name: Smoke test .NET onboarding fixture (Windows)
-        if: matrix.os == 'windows-latest'
+        if: ${{ always() && matrix.os == 'windows-latest' && steps.install-windows.outcome == 'success' }}
         shell: pwsh
         run: |
           & .\.microsmith-bin\microsmith.cmd init --repo-root examples/non-gradle/dotnet

--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -78,9 +78,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
       - name: Build CLI release assets (Unix)
+        id: build-release-unix
         if: runner.os != 'Windows'
         run: ./gradlew :cli:releaseArtifacts --stacktrace
       - name: Build CLI release assets (Windows)
+        id: build-release-windows
         if: runner.os == 'Windows'
         shell: pwsh
         run: .\gradlew.bat :cli:releaseArtifacts --stacktrace
@@ -173,7 +175,7 @@ jobs:
           }
       - name: Install and verify from installer (Unix)
         id: install-unix
-        if: ${{ always() && runner.os != 'Windows' }}
+        if: ${{ always() && runner.os != 'Windows' && steps.build-release-unix.outcome == 'success' }}
         run: |
           set -eu
           DIST_FILE="$(find cli/build/release-assets -maxdepth 1 -type f -name 'microsmith-cli-*-dist.tar.gz' | head -n 1)"
@@ -214,7 +216,7 @@ jobs:
           test -f examples/non-gradle/go/internal/gen/proto/GoUserCreated.proto
       - name: Install and verify from installer (Windows)
         id: install-windows
-        if: ${{ always() && runner.os == 'Windows' }}
+        if: ${{ always() && runner.os == 'Windows' && steps.build-release-windows.outcome == 'success' }}
         shell: pwsh
         run: |
           $distAsset = Get-ChildItem -Path .\cli\build\release-assets\microsmith-cli-*-dist.zip | Select-Object -First 1


### PR DESCRIPTION
## Summary
- consolidate `cli-dist-smoke` and `cli-install-smoke` into a single `cli-smoke` matrix job
- build `:cli:releaseArtifacts` once per OS and reuse that output for both dist-path and installer-path smoke coverage
- preserve the existing Linux Node/Go onboarding fixture coverage and Windows .NET onboarding fixture coverage

## Why
`build_test_qodana.yml` was spending two separate runner jobs per OS on closely related CLI smoke coverage. This change reduces the workflow from six CLI smoke jobs to three while keeping the same validation responsibilities.

## What Changed
- renamed the combined matrix job to `cli-smoke`
- switched the job build step to `:cli:releaseArtifacts`, which already includes `:cli:distArtifacts`
- kept distinct step names for:
  - dist launcher/help smoke
  - dist generation/provider smoke
  - dist doctor diagnostics smoke
  - installer verification
  - init/bootstrap smoke
  - Linux Node/Go fixture onboarding
  - Windows .NET fixture onboarding
- increased the combined job timeout to `60` minutes to account for both smoke phases running sequentially in one job

## Validation
- `./gradlew :cli:releaseArtifacts --stacktrace`
- local Unix smoke validation covering:
  - dist launcher/help
  - dist generation/provider discovery
  - dist doctor diagnostics
  - installer verification
  - init/bootstrap smoke
  - Node fixture onboarding
  - Go fixture onboarding
- `git diff --check`

## Notes
- `actionlint` is not installed in the local environment, so workflow linting was limited to static review plus live smoke execution on the Unix path.
- Windows-specific smoke steps were preserved structurally and reviewed, but not executed locally in this environment.

Closes #81
