### PR TITLE
feat(ide-workflow): add helper lifecycle commands and repo hygiene guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,34 @@ JetBrains workflow:
 3. Refresh Gradle indexing.
 4. Rerun `microsmith ide refresh` after upgrading the Microsmith CLI or changing plugin dependencies.
 
+### When to use each command
+
+- First-time setup in a non-Gradle repository: `microsmith init`
+- Helper was skipped, removed, or needs regeneration after CLI or plugin changes: `microsmith ide refresh`
+- Symbols are still unresolved or the helper appears stale: `microsmith ide doctor --diagnostics json --verbose`
+
+### Repository hygiene
+
+Treat `.microsmith/ide/` as local generated IDE state.
+
+Why:
+- the generated helper build uses local file dependencies that resolve against the current Microsmith runtime installation
+- `microsmith ide refresh` owns the helper files and will rewrite them when the managed content changes
+- runtime generation does not depend on the IDE helper being present
+
+Recommended policy for consumer repositories:
+
+```gitignore
+.microsmith/ide/
+```
+
+Ownership and overwrite rules:
+
+- Microsmith manages only `.microsmith/ide/settings.gradle.kts`, `.microsmith/ide/build.gradle.kts`, and `.microsmith/ide/README.md`
+- do not hand-edit those managed files; rerun `microsmith ide refresh` instead
+- rerun `microsmith ide refresh` after upgrading the Microsmith CLI or changing plugin dependencies
+- if `microsmith ide doctor` reports missing or stale helper state, repair it with `microsmith ide refresh`
+
 Important constraints:
 
 - runtime generation does not depend on the IDE helper

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperProjectTemplates.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperProjectTemplates.kt
@@ -37,10 +37,23 @@ internal object IdeHelperProjectTemplates {
         - provide a minimal Gradle model that exposes Microsmith script-definition/runtime types
         - improve `.microsmith.kts` indexing and type resolution in JetBrains IDEs
 
+        Default first-run path:
+        - run `microsmith init` from the repository root unless helper generation was skipped intentionally
+
+        Lifecycle commands:
+        - run `microsmith ide refresh` to generate or resynchronize the helper
+        - run `microsmith ide doctor --diagnostics json --verbose` when the helper appears stale or symbols remain unresolved
+
         Usage:
-        1. run `microsmith ide refresh` from repository root
+        1. run `microsmith init`, or `microsmith ide refresh` if helper generation was skipped earlier
         2. in your JetBrains IDE, link/import `.microsmith/ide/build.gradle.kts` as a Gradle project
         3. refresh Gradle after upgrading Microsmith CLI or plugin dependencies
+
+        Repository hygiene:
+        - treat `.microsmith/ide/` as local generated IDE state
+        - add `.microsmith/ide/` to your repository `.gitignore`
+        - Microsmith manages only `settings.gradle.kts`, `build.gradle.kts`, and `README.md` in this directory
+        - do not hand-edit those managed files; rerun `microsmith ide refresh` instead
 
         Regeneration:
         - command is idempotent and safe to rerun

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
@@ -52,7 +52,11 @@ class IdeHelperGeneratorTests :
                 buildContent.shouldContain("id(\"java-library\")")
                 buildContent.shouldContain("files(\n            \"")
                 buildContent.shouldContain(runtimeJarLiteral)
-                readmeFile.readText().shouldContain("microsmith ide refresh")
+                val helperReadme = readmeFile.readText()
+                helperReadme.shouldContain("microsmith ide refresh")
+                helperReadme.shouldContain("microsmith ide doctor --diagnostics json --verbose")
+                helperReadme.shouldContain(".microsmith/ide/` to your repository `.gitignore`")
+                helperReadme.shouldContain("do not hand-edit")
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
             }


### PR DESCRIPTION
## Summary
- document the JetBrains IDE helper lifecycle and command decision points in `README.md`
- add explicit repository hygiene guidance for `.microsmith/ide/`, including ignore-by-default guidance and managed-file ownership rules
- strengthen the generated helper `README.md` contract and lock that guidance in with a generator test

## Why
The helper command surface already existed, but the operational contract was still underspecified. The remaining gap in `#51` was not new command behavior; it was making the lifecycle and hygiene model explicit enough that teams know:
- when to use `microsmith init` versus `microsmith ide refresh` versus `microsmith ide doctor`
- that `.microsmith/ide` should be treated as local generated IDE state by default
- which helper files Microsmith owns and may overwrite

## What Changed
- expanded the `JetBrains IDE helper` section in `README.md` with:
  - a small lifecycle decision guide
  - ignore-by-default guidance for `.microsmith/ide/`
  - explicit ownership and overwrite rules for managed helper files
- updated `cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperProjectTemplates.kt` so generated helper projects carry the same lifecycle and hygiene guidance locally
- added regression assertions in `cli/src/test/kotlin/me/liam/microsmith/cli/ide/IdeHelperGeneratorTests.kt`

## Validation
- `./gradlew :cli:check :cli:jvmKotest`
- `git diff --check`

Closes #51
