### PR TITLE
feat(ide-fallback): package script-definition jar fallback and JetBrains IDE setup docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build CLI release assets
-        run: ./gradlew :cli:releaseArtifacts --stacktrace
+      - name: Build release assets
+        run: ./gradlew :cli:releaseArtifacts :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums --stacktrace
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -64,5 +64,7 @@ jobs:
             cli/build/release-assets/microsmith-install.sh
             cli/build/release-assets/microsmith-install.ps1
             cli/build/release-assets/*.sha256
+            runtime-scripting/build/release-assets/microsmith-script-definition-*-all.jar
+            runtime-scripting/build/release-assets/microsmith-script-definition-*-all.jar.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -544,6 +544,35 @@ Important constraints:
 - the helper build uses local file dependencies only
 - repeated refreshes only rewrite files when content changes
 
+### Script-definition fallback
+
+Use the fallback only when you explicitly do not want the generated `.microsmith/ide` helper project.
+
+Choose between the two paths like this:
+
+- prefer the helper when you want the strongest JetBrains IDE experience and automatic synchronization with the local Microsmith runtime classpath
+- use the fallback when you want a smaller repository footprint and are willing to attach a library manually
+
+Fallback artifact sources:
+
+- GitHub Release asset: `microsmith-script-definition-<version>-all.jar`
+- local build: `./gradlew :runtime-scripting:ideFallbackArtifacts`
+- published package: `me.liam.microsmith:runtime-scripting:<version>:all`
+
+Manual JetBrains setup:
+
+1. Download the fallback jar that matches your Microsmith version, or build it locally.
+2. In IntelliJ IDEA, GoLand, or Rider, add the jar as a project library from the IDE project settings.
+3. Reopen or reindex `.microsmith.kts` files.
+4. Replace the jar after upgrading Microsmith.
+
+Limitations versus the helper path:
+
+- fallback setup is manual and more IDE-version-sensitive
+- the fallback jar does not keep project-local plugin classpaths synchronized automatically
+- plugin-provided types from `--plugin` or `--plugin-jar` are not exposed automatically through this fallback
+- if symbols remain unresolved after attaching the jar, prefer the helper workflow instead
+
 ## Plugin resolution and security model
 
 ### Plugin inputs
@@ -828,7 +857,7 @@ The DSL surface and plugin architecture stay the same; the execution model chang
 
 ### Release asset contents
 
-`./gradlew :cli:releaseArtifacts` produces:
+`./gradlew :cli:releaseArtifacts :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums` produces:
 
 - `cli/build/libs/microsmith-cli-<version>-all.jar`
 - `cli/build/distributions/microsmith-cli-<version>-dist.zip`
@@ -837,6 +866,8 @@ The DSL surface and plugin architecture stay the same; the execution model chang
 - `cli/build/release-assets/microsmith-install.ps1`
 - `cli/build/release-assets/*.sha256`
 - `cli/build/generated/microsmith/bundled-plugins.lock`
+- `runtime-scripting/build/release-assets/microsmith-script-definition-<version>-all.jar`
+- `runtime-scripting/build/release-assets/microsmith-script-definition-<version>-all.jar.sha256`
 
 The bundled plugin catalog is packaged into the official artifacts and pinned to the CLI version.
 Published packages are available from:
@@ -856,6 +887,9 @@ https://maven.pkg.github.com/lmliam/microsmith
 - `:cli:distArtifacts` for internal staging into `cli/build/release-assets/`
 - `:cli:generateReleaseChecksums`
 - `:cli:releaseArtifacts`
+- `:runtime-scripting:verifyIdeFallbackShadowJar`
+- `:runtime-scripting:ideFallbackArtifacts`
+- `:runtime-scripting:generateIdeFallbackChecksums`
 
 ### Current packaging model
 

--- a/runtime-scripting/build.gradle
+++ b/runtime-scripting/build.gradle
@@ -1,3 +1,8 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.jar.JarFile
+
 dependencies {
     implementation project(":dsl")
     implementation project(":dsl-schemas")
@@ -9,4 +14,85 @@ dependencies {
     implementation libs.kotlin.scripting.common
     implementation libs.kotlin.scripting.jvm
     implementation libs.kotlin.scripting.jvm.host
+}
+
+def ideFallbackReleaseAssetsDirectory = layout.buildDirectory.dir("release-assets")
+def ideFallbackShadowJarTask = tasks.named("shadowJar", ShadowJar)
+def ideFallbackShadowJarArchive = ideFallbackShadowJarTask.flatMap { it.archiveFile }
+def ideFallbackExpectedEntries = [
+    "me/liam/microsmith/runtime/scripting/definition/MicrosmithScript.class",
+    "me/liam/microsmith/runtime/scripting/definition/MicrosmithScriptCompilationConfiguration.class",
+    "me/liam/microsmith/runtime/scripting/context/MicrosmithScriptContext.class",
+    "kotlin/script/experimental/jvmhost/BasicJvmScriptingHost.class",
+]
+
+tasks.named("shadowJar", ShadowJar) {
+    archiveBaseName.set("microsmith-script-definition")
+    archiveClassifier.set("all")
+    manifest {
+        attributes(
+            "Implementation-Version": project.version.toString(),
+        )
+    }
+}
+
+tasks.register("verifyIdeFallbackShadowJar") {
+    dependsOn(ideFallbackShadowJarTask)
+    inputs.file(ideFallbackShadowJarArchive)
+
+    doLast {
+        File archiveFile = ideFallbackShadowJarArchive.get().asFile
+        if (!archiveFile.isFile()) {
+            throw new GradleException("IDE fallback shadow jar '${archiveFile.path}' was not created.")
+        }
+
+        JarFile jarFile = new JarFile(archiveFile)
+        try {
+            def entryNames = jarFile.entries().collect { entry -> entry.name } as Set
+            def missingEntries = ideFallbackExpectedEntries.findAll { expected -> !entryNames.contains(expected) }
+            if (!missingEntries.isEmpty()) {
+                throw new GradleException(
+                    "IDE fallback shadow jar '${archiveFile.name}' is missing expected entries: ${missingEntries.join(', ')}",
+                )
+            }
+        } finally {
+            jarFile.close()
+        }
+    }
+}
+
+tasks.register("ideFallbackArtifacts", Sync) {
+    dependsOn(tasks.named("verifyIdeFallbackShadowJar"))
+    into(ideFallbackReleaseAssetsDirectory)
+    from(ideFallbackShadowJarArchive)
+}
+
+tasks.register("generateIdeFallbackChecksums") {
+    dependsOn(tasks.named("ideFallbackArtifacts"))
+    inputs.dir(ideFallbackReleaseAssetsDirectory)
+    outputs.dir(ideFallbackReleaseAssetsDirectory)
+
+    doLast {
+        File releaseDir = ideFallbackReleaseAssetsDirectory.get().asFile
+        if (!releaseDir.isDirectory()) {
+            throw new GradleException("IDE fallback release assets directory '${releaseDir.path}' does not exist.")
+        }
+
+        def sourceFiles =
+            releaseDir.listFiles()
+                .findAll { file -> file.isFile() && !file.name.endsWith('.sha256') }
+                .sort { left, right -> left.name <=> right.name }
+        if (sourceFiles.isEmpty()) {
+            throw new GradleException("IDE fallback release assets directory '${releaseDir.path}' did not contain files to checksum.")
+        }
+
+        sourceFiles.each { file ->
+            String checksum = MessageDigest.getInstance("SHA-256").digest(file.bytes).encodeHex().toString()
+            new File(releaseDir, "${file.name}.sha256").setText("${checksum}  ${file.name}\n", StandardCharsets.UTF_8.name())
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("verifyIdeFallbackShadowJar"))
 }


### PR DESCRIPTION
## Summary
- package a shaded `runtime-scripting` script-definition fallback jar for manual JetBrains IDE setup
- stage and checksum the fallback artifact for release publishing and verify the jar contains the expected scripting host classes
- document the helper-vs-fallback decision, manual setup flow, and fallback limitations in `README.md`

## Validation
- `./gradlew :runtime-scripting:check :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums`
- `./gradlew :runtime-scripting:publishGprPublicationToMavenLocal -Dmaven.repo.local="$TMPDIR/microsmith-m2"`
- `git diff --check`
- Ruby YAML parse of `.github/workflows/release.yml`

Closes #50
