### PR TITLE
feat(validation): add docs, fixtures, and validation matrix for runtime, onboarding, and IDE flows

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -33,6 +33,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Build
         run: ./gradlew build --stacktrace
+      - name: Validate IDE fallback release assets
+        run: |
+          ./gradlew :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums --stacktrace
+          find runtime-scripting/build/release-assets -maxdepth 1 -type f -name 'microsmith-script-definition-*-all.jar' | grep -q .
+          find runtime-scripting/build/release-assets -maxdepth 1 -type f -name 'microsmith-script-definition-*-all.jar.sha256' | grep -q .
       - name: Publish Test Report
         uses: dorny/test-reporter@v2
         if: ${{ always() && hashFiles('**/build/test-results/jvmKotest/*.xml') != '' }}
@@ -91,6 +96,9 @@ jobs:
         run: |
           ./cli/build/microsmith-cli-dist/bin/microsmith --help > cli-help.txt
           grep -q "Usage:" cli-help.txt
+      - name: Verify README CLI usage block (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: python3 scripts/verify_readme_cli_usage.py README.md cli-help.txt
       - name: Smoke test dist generation and provider discovery (Unix)
         if: runner.os != 'Windows'
         run: |
@@ -205,6 +213,10 @@ jobs:
           test -f examples/non-gradle/node/build.microsmith.kts
           test -f examples/non-gradle/node/settings.microsmith.kts
           test -f examples/non-gradle/node/.microsmith/ide/build.gradle.kts
+          test -f examples/non-gradle/node/.microsmith/ide/README.md
+          ./.microsmith-bin/microsmith ide refresh --repo-root examples/non-gradle/node
+          ./.microsmith-bin/microsmith ide doctor --repo-root examples/non-gradle/node --diagnostics json > node-ide-doctor.json
+          grep -q "JetBrains IDE helper doctor checks passed." node-ide-doctor.json
           ./.microsmith-bin/microsmith run examples/non-gradle/node/build.microsmith.kts --out examples/non-gradle/node/generated
           test -f examples/non-gradle/node/generated/proto/NodeUserCreated.proto
           ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go
@@ -212,6 +224,10 @@ jobs:
           test -f examples/non-gradle/go/build.microsmith.kts
           test -f examples/non-gradle/go/settings.microsmith.kts
           test -f examples/non-gradle/go/.microsmith/ide/build.gradle.kts
+          test -f examples/non-gradle/go/.microsmith/ide/README.md
+          ./.microsmith-bin/microsmith ide refresh --repo-root examples/non-gradle/go
+          ./.microsmith-bin/microsmith ide doctor --repo-root examples/non-gradle/go --diagnostics json > go-ide-doctor.json
+          grep -q "JetBrains IDE helper doctor checks passed." go-ide-doctor.json
           ./.microsmith-bin/microsmith run examples/non-gradle/go/build.microsmith.kts --out examples/non-gradle/go/internal/gen
           test -f examples/non-gradle/go/internal/gen/proto/GoUserCreated.proto
       - name: Install and verify from installer (Windows)
@@ -289,6 +305,24 @@ jobs:
           }
           if (-not (Test-Path .\examples\non-gradle\dotnet\.microsmith\ide\build.gradle.kts)) {
             Write-Error "Expected IDE helper build.gradle.kts to exist for the .NET fixture."
+            exit 1
+          }
+          if (-not (Test-Path .\examples\non-gradle\dotnet\.microsmith\ide\README.md)) {
+            Write-Error "Expected IDE helper README.md to exist for the .NET fixture."
+            exit 1
+          }
+          & .\.microsmith-bin\microsmith.cmd ide refresh --repo-root examples/non-gradle/dotnet
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $ideDoctor = & .\.microsmith-bin\microsmith.cmd ide doctor --repo-root examples/non-gradle/dotnet --diagnostics json 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output $ideDoctor
+            exit $LASTEXITCODE
+          }
+          if (($ideDoctor -join "`n") -notmatch "JetBrains IDE helper doctor checks passed.") {
+            Write-Error "IDE helper doctor did not report success for the .NET fixture."
+            Write-Output $ideDoctor
             exit 1
           }
           & .\.microsmith-bin\microsmith.cmd run examples/non-gradle/dotnet/build.microsmith.kts --out examples/non-gradle/dotnet/Generated

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This README is the canonical repository documentation.
 - Plugin resolution and security model
 - CI examples
 - Example fixtures
+- Validation matrix and release checklist
 - Troubleshooting
 - Migration from Gradle
 - Distribution and release artifacts
@@ -388,6 +389,18 @@ Usage:
   microsmith doctor [--diagnostics <text|json>] [--verbose]
   microsmith --version
   microsmith --help
+
+Security policy env vars:
+  MICROSMITH_REPOSITORY_ALLOWLIST   Comma-separated additional allowed repository base URIs.
+  MICROSMITH_ALLOW_FILE_REPOSITORIES Set to true to allow file:// repositories for plugin coordinates.
+  MICROSMITH_REPOSITORY_CREDENTIALS_FILE Path to repository credentials file (<repository-uri>|<username>|<password>).
+  MICROSMITH_REPOSITORY_USERNAME    Default username for authenticated repository access.
+  MICROSMITH_REPOSITORY_PASSWORD    Default password/token for authenticated repository access.
+  MICROSMITH_GITHUB_PACKAGES_USER   Username for https://maven.pkg.github.com access.
+  MICROSMITH_GITHUB_PACKAGES_TOKEN  Token for https://maven.pkg.github.com access.
+  MICROSMITH_PLUGIN_ALLOWLIST_FILE  Path to checksum allowlist file (<kind>|<key>|<sha256>; kind=remote|remote-artifact|local).
+  MICROSMITH_SCRIPT_CACHE_DIR       Override script compilation cache directory.
+  MICROSMITH_PLUGIN_CACHE_DIR       Override plugin resolution cache directory.
 ```
 
 ### Canonical happy paths
@@ -746,6 +759,69 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
 | Go      | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts --out ./internal/gen` | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
 | .NET    | `examples/non-gradle/dotnet` | `microsmith init` then `microsmith run build.microsmith.kts --out .\Generated`    | `examples/non-gradle/dotnet/.github/workflows/microsmith.yml` |
+
+## Validation matrix and release checklist
+
+### Automated validation matrix
+
+| Surface                        | Coverage source                                      | Evidence                                                                                   |
+|--------------------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| CLI help and README contract   | `build-and-qodana` on Ubuntu                         | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.   |
+| CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
+| Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
+| Non-JVM fixture onboarding     | `cli-smoke` on Ubuntu and Windows                    | Node, Go, and .NET fixtures run the canonical `microsmith init` then `microsmith run`.    |
+| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Fixture coverage runs `microsmith ide refresh` and `microsmith ide doctor`.               |
+| Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
+| Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
+
+Automated gates are required on every release candidate commit:
+
+- `Build & Qodana`
+- `cli-smoke` on `ubuntu-latest`
+- `cli-smoke` on `macos-latest`
+- `cli-smoke` on `windows-latest`
+
+### JetBrains IDE validation bands
+
+JetBrains IDE indexing and import behavior is partly host-driven, so final sign-off stays manual even though CI covers helper generation, helper doctor, and fallback artifact packaging.
+
+Support policy:
+
+- supported products are IntelliJ IDEA, GoLand, and Rider
+- supported release band is the current stable major line and the previous stable major line at release cut
+- EAP builds are best-effort only and do not block release
+
+| Product         | Fixture root                    | Required helper smoke path                              | Required fallback smoke path                             |
+|-----------------|---------------------------------|---------------------------------------------------------|----------------------------------------------------------|
+| IntelliJ IDEA   | `examples/non-gradle/node`      | Run the helper checklist below against the Node fixture. | Run the fallback checklist below against the Node fixture. |
+| GoLand          | `examples/non-gradle/go`        | Run the helper checklist below against the Go fixture.   | Run the fallback checklist below against the Go fixture.   |
+| Rider           | `examples/non-gradle/dotnet`    | Run the helper checklist below against the .NET fixture. | Run the fallback checklist below against the .NET fixture. |
+
+### Manual IDE release checklist
+
+Helper path:
+
+1. Install the release-candidate Microsmith CLI.
+2. Run `microsmith init` from the fixture root.
+3. Import `.microsmith/ide/build.gradle.kts` as a Gradle project in the target JetBrains IDE.
+4. Refresh Gradle indexing.
+5. Run `microsmith ide doctor --repo-root <fixture> --diagnostics json --verbose`.
+6. Confirm `microsmith {}`, `schemas {}`, and `protobuf {}` resolve in `build.microsmith.kts` without red squiggles.
+
+Fallback path:
+
+1. Download or build the matching `microsmith-script-definition-<version>-all.jar`.
+2. Attach the jar as a project library in the target JetBrains IDE.
+3. Reindex the project.
+4. Confirm `microsmith {}`, `schemas {}`, and `protobuf {}` resolve in `build.microsmith.kts`.
+5. Confirm plugin-provided types remain a helper-only capability unless the helper project is imported.
+
+Release sign-off artifact:
+
+- record one row per product and IDE version in the release PR or release issue
+- include product, IDE version, fixture root, helper result, fallback result, verifier GitHub handle, and date
+- treat that release record as the required manual sign-off artifact
+- do not cut the release until all required rows for the supported version band are recorded and approved
 
 ## Troubleshooting
 

--- a/scripts/verify_readme_cli_usage.py
+++ b/scripts/verify_readme_cli_usage.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def usage() -> str:
+    return (
+        "Usage: verify_readme_cli_usage.py <README.md> <cli-help.txt>"
+    )
+
+
+def normalize(value: str) -> str:
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    stripped_lines = [line.rstrip() for line in normalized.strip().split("\n")]
+    return "\n".join(stripped_lines)
+
+
+def extract_readme_usage_block(readme_text: str) -> str:
+    pattern = re.compile(
+        r"Current CLI usage:\n\n```text\n(?P<block>.*?)\n```",
+        re.DOTALL,
+    )
+    match = pattern.search(readme_text)
+    if match is None:
+        raise ValueError("Unable to locate the README 'Current CLI usage' block.")
+    return match.group("block")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(usage(), file=sys.stderr)
+        return 2
+
+    readme_path = Path(sys.argv[1])
+    help_output_path = Path(sys.argv[2])
+
+    readme_usage_block = extract_readme_usage_block(readme_path.read_text())
+    help_output = help_output_path.read_text()
+
+    expected = normalize(readme_usage_block)
+    actual = normalize(help_output)
+    if expected == actual:
+        return 0
+
+    print("README CLI usage block does not match built '--help' output.", file=sys.stderr)
+    print("--- README ---", file=sys.stderr)
+    print(expected, file=sys.stderr)
+    print("--- BUILT HELP ---", file=sys.stderr)
+    print(actual, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extend repository CI to validate helper lifecycle flows, fallback release-asset staging, and the README CLI command contract
- publish the canonical validation matrix, JetBrains IDE version-band policy, and release sign-off checklist in `README.md`
- keep the final remaining runtime/IDE rollout issue grounded in real automated and manual verification paths

## Validation
- `./gradlew :cli:releaseArtifacts :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums`
- `./cli/build/microsmith-cli-dist/bin/microsmith --help > cli-help.txt && python3 scripts/verify_readme_cli_usage.py README.md cli-help.txt`
- Unix fixture smoke for Node and Go:
  - `microsmith init`
  - `microsmith ide refresh`
  - `microsmith ide doctor --diagnostics json`
  - `microsmith run build.microsmith.kts --out ...`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_test_qodana.yml")'`
- `git diff --check`

Closes #49
