### PR TITLE
feat(onboarding-python): add first-class bootstrap support for Python repositories

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -204,32 +204,34 @@ jobs:
           test -f install-smoke-repo/settings.microsmith.kts
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
           test -f install-smoke-repo/generated/proto/UserCreated.proto
-      - name: Smoke test Node and Go onboarding fixtures (Linux)
+      - name: Smoke test Node, Go, and Python onboarding fixtures (Linux)
         if: ${{ always() && matrix.os == 'ubuntu-latest' && steps.install-unix.outcome == 'success' }}
         run: |
-          set -eu
-          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node
-          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/node
-          test -f examples/non-gradle/node/build.microsmith.kts
-          test -f examples/non-gradle/node/settings.microsmith.kts
-          test -f examples/non-gradle/node/.microsmith/ide/build.gradle.kts
-          test -f examples/non-gradle/node/.microsmith/ide/README.md
-          ./.microsmith-bin/microsmith ide refresh --repo-root examples/non-gradle/node
-          ./.microsmith-bin/microsmith ide doctor --repo-root examples/non-gradle/node --diagnostics json > node-ide-doctor.json
-          grep -q "JetBrains IDE helper doctor checks passed." node-ide-doctor.json
-          ./.microsmith-bin/microsmith run examples/non-gradle/node/build.microsmith.kts --out examples/non-gradle/node/generated
-          test -f examples/non-gradle/node/generated/proto/NodeUserCreated.proto
-          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go
-          ./.microsmith-bin/microsmith init --repo-root examples/non-gradle/go
-          test -f examples/non-gradle/go/build.microsmith.kts
-          test -f examples/non-gradle/go/settings.microsmith.kts
-          test -f examples/non-gradle/go/.microsmith/ide/build.gradle.kts
-          test -f examples/non-gradle/go/.microsmith/ide/README.md
-          ./.microsmith-bin/microsmith ide refresh --repo-root examples/non-gradle/go
-          ./.microsmith-bin/microsmith ide doctor --repo-root examples/non-gradle/go --diagnostics json > go-ide-doctor.json
-          grep -q "JetBrains IDE helper doctor checks passed." go-ide-doctor.json
-          ./.microsmith-bin/microsmith run examples/non-gradle/go/build.microsmith.kts --out examples/non-gradle/go/internal/gen
-          test -f examples/non-gradle/go/internal/gen/proto/GoUserCreated.proto
+          set -euo pipefail
+          smoke_unix_fixture() {
+            local repo_name="$1"
+            local repo_root="$2"
+            local output_root="$3"
+            local expected_proto="$4"
+            local doctor_output="$5"
+
+            ./.microsmith-bin/microsmith init --repo-root "$repo_root"
+            ./.microsmith-bin/microsmith init --repo-root "$repo_root"
+            test -f "$repo_root/build.microsmith.kts"
+            test -f "$repo_root/settings.microsmith.kts"
+            test -f "$repo_root/.microsmith/ide/build.gradle.kts"
+            test -f "$repo_root/.microsmith/ide/README.md"
+            ./.microsmith-bin/microsmith ide refresh --repo-root "$repo_root"
+            ./.microsmith-bin/microsmith ide doctor --repo-root "$repo_root" --diagnostics json > "$doctor_output"
+            grep -q "JetBrains IDE helper doctor checks passed." "$doctor_output"
+            ./.microsmith-bin/microsmith run "$repo_root/build.microsmith.kts" --out "$repo_root/$output_root"
+            test -f "$repo_root/$output_root/proto/$expected_proto"
+            echo "Validated $repo_name fixture."
+          }
+
+          smoke_unix_fixture node examples/non-gradle/node generated NodeUserCreated.proto node-ide-doctor.json
+          smoke_unix_fixture go examples/non-gradle/go internal/gen GoUserCreated.proto go-ide-doctor.json
+          smoke_unix_fixture python examples/non-gradle/python generated PythonUserCreated.proto python-ide-doctor.json
       - name: Install and verify from installer (Windows)
         id: install-windows
         if: ${{ always() && runner.os == 'Windows' && steps.build-release-windows.outcome == 'success' }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Microsmith
 
 Microsmith is a Kotlin DSL and standalone CLI for declaring domain-specific models and generating artifacts from `.microsmith.kts` scripts.
-It is designed to work both inside this Gradle repository and from consumer repositories that do not use Gradle, including Go, .NET, and Node projects.
+It is designed to work both inside this Gradle repository and from consumer repositories that do not use Gradle, including Go, .NET, Node, and Python projects.
 
 This README is the canonical repository documentation.
 
@@ -210,7 +210,7 @@ Inside `.microsmith.kts` scripts:
 
 ## Standalone CLI for non-Gradle repositories
 
-The CLI is the recommended entrypoint for Go, .NET, Node, and other repositories that do not use Gradle.
+The CLI is the recommended entrypoint for Go, .NET, Node, Python, and other repositories that do not use Gradle.
 The official installer scripts are self-contained and provision a Java 24 runtime automatically when the machine does not already provide one.
 
 Manual channels remain available, but they require Java 24 or newer.
@@ -226,7 +226,7 @@ microsmith run build.microsmith.kts --out ./generated
 
 `microsmith init` is deterministic and non-destructive by default:
 
-- it detects Node, Go, and .NET repositories from `package.json`, `go.mod`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
+- it detects Node, Go, Python, and .NET repositories from `package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
 - it creates `settings.microsmith.kts` when missing
 - it creates `build.microsmith.kts` when missing
 - it preserves existing regular bootstrap files instead of overwriting them
@@ -245,6 +245,7 @@ After the canonical first run succeeds, you can switch to a repository-native ou
 
 - Node: `microsmith run build.microsmith.kts --out ./generated`
 - Go: `microsmith run build.microsmith.kts --out ./internal/gen`
+- Python: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - .NET: `microsmith run build.microsmith.kts --out ./Generated`
 
 ### Direct script execution
@@ -432,7 +433,7 @@ microsmith ide refresh
 `microsmith init`
 
 - bootstraps `settings.microsmith.kts` and `build.microsmith.kts`
-- detects Node, Go, .NET, or generic repository shape and emits a matching starter script
+- detects Node, Go, Python, .NET, or generic repository shape and emits a matching starter script
 - refreshes `.microsmith/ide` by default
 - preserves existing regular bootstrap files unless `--force` is provided
 - supports `--repo-root`, `--force`, `--skip-ide-helper`, `--diagnostics`, and `--verbose`
@@ -488,7 +489,7 @@ When `--diagnostics json` is used, each event is emitted as one JSON line with:
 
 ## JetBrains IDE helper
 
-Use the helper project when your repository is not Gradle-based and you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, and Rider.
+Use the helper project when your repository is not Gradle-based and you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, Rider, and PyCharm.
 
 `microsmith init` already refreshes the helper by default. Use `microsmith ide refresh` when you skipped helper generation during init or need to repair or resynchronize the helper later.
 
@@ -575,7 +576,7 @@ Fallback artifact sources:
 Manual JetBrains setup:
 
 1. Download the fallback jar that matches your Microsmith version, or build it locally.
-2. In IntelliJ IDEA, GoLand, or Rider, add the jar as a project library from the IDE project settings.
+2. In IntelliJ IDEA, GoLand, Rider, or PyCharm, add the jar as a project library from the IDE project settings.
 3. Reopen or reindex `.microsmith.kts` files.
 4. Replace the jar after upgrading Microsmith.
 
@@ -758,6 +759,7 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 |---------|------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
 | Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
 | Go      | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts --out ./internal/gen` | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
+| Python  | `examples/non-gradle/python` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/python/.github/workflows/microsmith.yml` |
 | .NET    | `examples/non-gradle/dotnet` | `microsmith init` then `microsmith run build.microsmith.kts --out .\Generated`    | `examples/non-gradle/dotnet/.github/workflows/microsmith.yml` |
 
 ## Validation matrix and release checklist
@@ -769,8 +771,8 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | CLI help and README contract   | `build-and-qodana` on Ubuntu                         | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.   |
 | CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
 | Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
-| Non-JVM fixture onboarding     | `cli-smoke` on Ubuntu and Windows                    | Node, Go, and .NET fixtures run the canonical `microsmith init` then `microsmith run`.    |
-| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Fixture coverage runs `microsmith ide refresh` and `microsmith ide doctor`.               |
+| Non-JVM fixture onboarding     | `cli-smoke` on Ubuntu and Windows                    | Node, Go, Python, and .NET fixtures run the canonical `microsmith init` then `microsmith run`. |
+| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Fixture coverage runs `microsmith ide refresh` and `microsmith ide doctor` for Node, Go, Python, and .NET fixtures. |
 | Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
 | Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
 
@@ -787,7 +789,7 @@ JetBrains IDE indexing and import behavior is partly host-driven, so final sign-
 
 Support policy:
 
-- supported products are IntelliJ IDEA, GoLand, and Rider
+- supported products are IntelliJ IDEA, GoLand, Rider, and PyCharm
 - supported release band is the current stable major line and the previous stable major line at release cut
 - EAP builds are best-effort only and do not block release
 
@@ -795,6 +797,7 @@ Support policy:
 |-----------------|---------------------------------|---------------------------------------------------------|----------------------------------------------------------|
 | IntelliJ IDEA   | `examples/non-gradle/node`      | Run the helper checklist below against the Node fixture. | Run the fallback checklist below against the Node fixture. |
 | GoLand          | `examples/non-gradle/go`        | Run the helper checklist below against the Go fixture.   | Run the fallback checklist below against the Go fixture.   |
+| PyCharm         | `examples/non-gradle/python`    | Run the helper checklist below against the Python fixture. | Run the fallback checklist below against the Python fixture. |
 | Rider           | `examples/non-gradle/dotnet`    | Run the helper checklist below against the .NET fixture. | Run the fallback checklist below against the .NET fixture. |
 
 ### Manual IDE release checklist

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
@@ -10,6 +10,13 @@ internal object BuiltInOnboardingProfileMatchers {
         return listOf(
             rootMarkerMatcher(NodeOnboardingProfile, "package.json"),
             rootMarkerMatcher(GoOnboardingProfile, "go.mod"),
+            rootMarkerMatcher(
+                PythonOnboardingProfile,
+                "pyproject.toml",
+                "requirements.txt",
+                "setup.py",
+                "setup.cfg",
+            ),
             dotnetMatcher(dotnetMarkerFinder),
         )
     }
@@ -20,12 +27,13 @@ internal object BuiltInOnboardingProfileMatchers {
         }
     }
 
-    private fun rootMarkerMatcher(profile: OnboardingProfile, markerFileName: String): OnboardingProfileMatcher {
+    private fun rootMarkerMatcher(
+        profile: OnboardingProfile,
+        vararg markerFileNames: String,
+    ): OnboardingProfileMatcher {
         return OnboardingProfileMatcher(profile) { projectRoot ->
-            if (projectRoot.resolve(markerFileName).isRegularFile()) {
-                listOf(markerFileName)
-            } else {
-                emptyList()
+            markerFileNames.filter { markerFileName ->
+                projectRoot.resolve(markerFileName).isRegularFile()
             }
         }
     }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/PythonOnboardingProfile.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/PythonOnboardingProfile.kt
@@ -1,0 +1,8 @@
+package me.liam.microsmith.cli.init
+
+internal data object PythonOnboardingProfile : OnboardingProfile {
+    override val id: OnboardingProfileId = OnboardingProfileId("python")
+    override val displayName: String = "Python"
+    override val sampleMessageName: String = "PythonUserCreated"
+    override val recommendedOutputDirectory: String? = null
+}

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -3,6 +3,7 @@ package me.liam.microsmith.cli
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
 import me.liam.microsmith.cli.init.GenericOnboardingProfile
@@ -13,6 +14,7 @@ import me.liam.microsmith.cli.init.InitValidationException
 import me.liam.microsmith.cli.init.NodeOnboardingProfile
 import me.liam.microsmith.cli.init.OnboardingProfileDetection
 import me.liam.microsmith.cli.init.OnboardingProfileSelectionReason
+import me.liam.microsmith.cli.init.PythonOnboardingProfile
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteRecursively
@@ -251,6 +253,51 @@ class MicrosmithCliInitTests :
                 out.joinToString("\n").shouldContain("Preserved existing bootstrap files")
                 out.joinToString("\n").shouldContain("Re-run with --force")
                 out.joinToString("\n").shouldContain("JetBrains IDE helper generation was skipped")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command keeps Python on the canonical generated output path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-python")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingProfileDetection(
+                                    profile = PythonOnboardingProfile,
+                                    selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                                    matchedMarkers = listOf("pyproject.toml"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = emptyList(),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Detected repository profile: Python")
+                out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldNotContain("Optional repository-native output path")
                 err shouldBe emptyList()
             } finally {
                 runCatching { tempDir.deleteRecursively() }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
@@ -68,6 +68,46 @@ class InitBootstrapTests :
             }
         }
 
+        "creates repo-aware bootstrap files for Python repositories without a repository-native output override" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-python")
+            repoRoot.resolve("pyproject.toml").writeText(
+                """
+                [project]
+                name = "fixture-python"
+                version = "0.1.0"
+                """.trimIndent() + "\n",
+            )
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.repositoryDetection.profile shouldBe PythonOnboardingProfile
+                result.repositoryDetection.matchedMarkers shouldBe listOf("pyproject.toml")
+                val buildScript = repoRoot.resolve("build.microsmith.kts").readText()
+                val settingsScript = repoRoot.resolve("settings.microsmith.kts").readText()
+
+                buildScript.shouldContain("PythonUserCreated")
+                buildScript.shouldContain("microsmith run build.microsmith.kts --out ./generated")
+                buildScript.shouldContain("// Bootstrapped Microsmith schema for this Python repository.")
+                buildScript.shouldContain("Canonical first run:")
+                buildScript.contains("Common repository-native output path:") shouldBe false
+                settingsScript.shouldContain("Detected repository profile: Python")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "preserves existing bootstrap files on repeated init runs by default" {
             val repoRoot = createTempDirectory("microsmith-init-bootstrap-idempotent")
             val existingBuild = repoRoot.resolve("build.microsmith.kts")
@@ -270,14 +310,51 @@ class InitBootstrapTests :
             }
         }
 
-        "detects Node, Go, and .NET repositories and falls back to Other for mixed markers" {
+        listOf("pyproject.toml", "requirements.txt", "setup.py", "setup.cfg").forEach { markerFileName ->
+            "detects Python repositories from $markerFileName" {
+                val pythonRoot = createTempDirectory("microsmith-init-detect-python")
+                try {
+                    pythonRoot.resolve(markerFileName).writeText("# marker\n")
+
+                    detectOnboardingProfile(pythonRoot) shouldBe
+                        OnboardingProfileDetection(
+                            profile = PythonOnboardingProfile,
+                            selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                            matchedMarkers = listOf(markerFileName),
+                        )
+                } finally {
+                    runCatching { pythonRoot.deleteRecursively() }
+                }
+            }
+        }
+
+        "keeps the Python profile when multiple Python markers match" {
+            val pythonRoot = createTempDirectory("microsmith-init-detect-python-multi")
+            try {
+                pythonRoot.resolve("pyproject.toml").writeText("[project]\nname = \"fixture-python\"\n")
+                pythonRoot.resolve("requirements.txt").writeText("protobuf==0.0.0\n")
+
+                detectOnboardingProfile(pythonRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = PythonOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pyproject.toml", "requirements.txt"),
+                    )
+            } finally {
+                runCatching { pythonRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Node, Go, Python, and .NET repositories and falls back to Other for mixed markers" {
             val nodeRoot = createTempDirectory("microsmith-init-detect-node")
             val goRoot = createTempDirectory("microsmith-init-detect-go")
+            val pythonRoot = createTempDirectory("microsmith-init-detect-python")
             val dotnetRoot = createTempDirectory("microsmith-init-detect-dotnet")
             val mixedRoot = createTempDirectory("microsmith-init-detect-mixed")
             try {
                 nodeRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
                 goRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
+                pythonRoot.resolve("pyproject.toml").writeText("[project]\nname = \"fixture-python\"\n")
                 dotnetRoot.resolve("src/apps/service").createDirectories()
                 dotnetRoot.resolve("src/apps/service/Fixture.csproj")
                     .writeText("<Project Sdk=\"Microsoft.NET.Sdk\" />\n")
@@ -296,6 +373,12 @@ class InitBootstrapTests :
                         selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
                         matchedMarkers = listOf("go.mod"),
                     )
+                detectOnboardingProfile(pythonRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = PythonOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pyproject.toml"),
+                    )
                 detectOnboardingProfile(dotnetRoot) shouldBe
                     OnboardingProfileDetection(
                         profile = DotnetOnboardingProfile,
@@ -311,6 +394,7 @@ class InitBootstrapTests :
             } finally {
                 runCatching { nodeRoot.deleteRecursively() }
                 runCatching { goRoot.deleteRecursively() }
+                runCatching { pythonRoot.deleteRecursively() }
                 runCatching { dotnetRoot.deleteRecursively() }
                 runCatching { mixedRoot.deleteRecursively() }
             }

--- a/examples/non-gradle/python/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/python/.github/workflows/microsmith.yml
@@ -1,0 +1,23 @@
+name: Microsmith Generate (Python Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Microsmith
+        run: |
+          curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
+          sh microsmith-install.sh --version "$MICROSMITH_VERSION"
+          echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        working-directory: examples/non-gradle/python
+        run: microsmith init
+      - name: Generate protobuf
+        working-directory: examples/non-gradle/python
+        run: |
+          microsmith run build.microsmith.kts --out generated
+          test -f generated/proto/PythonUserCreated.proto

--- a/examples/non-gradle/python/pyproject.toml
+++ b/examples/non-gradle/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "microsmith-python-fixture"
+version = "0.1.0"
+requires-python = ">=3.11"

--- a/examples/non-gradle/python/schema.microsmith.kts
+++ b/examples/non-gradle/python/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("PythonUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #87.

Adds Python as a first-class onboarding profile for `microsmith init`, keeps Python on the canonical `./generated` output layout, and extends the repository fixture/docs/CI surface so Python is covered the same way as the existing Node, Go, and .NET examples.

## Why

`#86` generalized onboarding profile detection, but the built-in profile set was still limited to Node, Go, .NET, and the generic fallback. Python is the next high-value non-JVM ecosystem to support because:

- it is a common consumer-repository shape for generated artifacts
- it needs no Gradle/Maven assumptions for runtime
- PyCharm is the natural JetBrains-side IDE target for the existing helper workflow

The issue explicitly allowed Python to keep the generic output default when the ecosystem does not offer a stronger repo-native convention. This PR takes that path deliberately.

## What Changed

### CLI onboarding

- added `PythonOnboardingProfile` with stable id `python`
- extended `BuiltInOnboardingProfileMatchers` to detect Python repositories from:
  - `pyproject.toml`
  - `requirements.txt`
  - `setup.py`
  - `setup.cfg`
- kept Python on the canonical `./generated` output path by leaving the repository-native override unset

### Tests

- added init-bootstrap coverage for Python bootstrap generation
- added detection coverage for all supported Python markers
- added coverage proving multiple Python markers still resolve to the same Python profile
- added CLI summary coverage proving Python does not emit an optional repository-native output override

### Fixtures and CI

- added `examples/non-gradle/python`
- added the Python fixture GitHub Actions example workflow
- extended the Linux `cli-smoke` fixture pass in `.github/workflows/build_test_qodana.yml`
- refactored the Linux fixture smoke step into a small helper function rather than duplicating a third near-identical block

### Documentation

- documented Python in the top-level non-Gradle onboarding contract in `README.md`
- documented the supported Python markers and the deliberate `./generated` default
- added the Python fixture to the example fixture table
- added PyCharm to the JetBrains helper/fallback guidance and validation bands

## Validation

### Automated

- `./gradlew :cli:check :cli:jvmKotest :cli:releaseArtifacts`
- `./gradlew build`
- `python3 scripts/verify_readme_cli_usage.py README.md <built-help-output>`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_test_qodana.yml")'`
- `git diff --check`

### Manual smoke

- built launcher smoke against a temporary copy of `examples/non-gradle/python`:
  - `microsmith init`
  - `microsmith ide refresh`
  - `microsmith ide doctor --diagnostics json`
  - `microsmith run build.microsmith.kts --out generated`
  - verified `generated/proto/PythonUserCreated.proto`

## Notes

- Python intentionally keeps the generic `./generated` path in this PR. If a stronger Python-specific output convention emerges later, that should be a separate contract change.
- This PR does not add other ecosystems; Rust, Ruby, Java, Kotlin, Scala, and the broader validation expansion remain tracked in their dedicated issues.
