### PR TITLE
feat(onboarding-rust): add first-class bootstrap support for Rust repositories

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -204,7 +204,7 @@ jobs:
           test -f install-smoke-repo/settings.microsmith.kts
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
           test -f install-smoke-repo/generated/proto/UserCreated.proto
-      - name: Smoke test Node, Go, and Python onboarding fixtures (Linux)
+      - name: Smoke test Node, Go, Python, and Rust onboarding fixtures (Linux)
         if: ${{ always() && matrix.os == 'ubuntu-latest' && steps.install-unix.outcome == 'success' }}
         run: |
           set -euo pipefail
@@ -232,6 +232,7 @@ jobs:
           smoke_unix_fixture node examples/non-gradle/node generated NodeUserCreated.proto node-ide-doctor.json
           smoke_unix_fixture go examples/non-gradle/go internal/gen GoUserCreated.proto go-ide-doctor.json
           smoke_unix_fixture python examples/non-gradle/python generated PythonUserCreated.proto python-ide-doctor.json
+          smoke_unix_fixture rust examples/non-gradle/rust generated RustUserCreated.proto rust-ide-doctor.json
       - name: Install and verify from installer (Windows)
         id: install-windows
         if: ${{ always() && runner.os == 'Windows' && steps.build-release-windows.outcome == 'success' }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Microsmith
 
 Microsmith is a Kotlin DSL and standalone CLI for declaring domain-specific models and generating artifacts from `.microsmith.kts` scripts.
-It is designed to work both inside this Gradle repository and from consumer repositories that do not use Gradle, including Go, .NET, Node, and Python projects.
+It is designed to work both inside this Gradle repository and from consumer repositories that do not use Gradle, including Go, .NET, Node, Python, and Rust projects.
 
 This README is the canonical repository documentation.
 
@@ -210,7 +210,7 @@ Inside `.microsmith.kts` scripts:
 
 ## Standalone CLI for non-Gradle repositories
 
-The CLI is the recommended entrypoint for Go, .NET, Node, Python, and other repositories that do not use Gradle.
+The CLI is the recommended entrypoint for Go, .NET, Node, Python, Rust, and other repositories that do not use Gradle.
 The official installer scripts are self-contained and provision a Java 24 runtime automatically when the machine does not already provide one.
 
 Manual channels remain available, but they require Java 24 or newer.
@@ -226,7 +226,8 @@ microsmith run build.microsmith.kts --out ./generated
 
 `microsmith init` is deterministic and non-destructive by default:
 
-- it detects Node, Go, Python, and .NET repositories from `package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
+- it detects Node, Go, Python, Rust, and .NET repositories from `package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
+- Rust detection covers both package manifests and workspace roots through a root `Cargo.toml`; nested crates without a root manifest stay on the generic path
 - it creates `settings.microsmith.kts` when missing
 - it creates `build.microsmith.kts` when missing
 - it preserves existing regular bootstrap files instead of overwriting them
@@ -246,6 +247,7 @@ After the canonical first run succeeds, you can switch to a repository-native ou
 - Node: `microsmith run build.microsmith.kts --out ./generated`
 - Go: `microsmith run build.microsmith.kts --out ./internal/gen`
 - Python: keep the canonical `./generated` output path unless your repository already has a stronger convention
+- Rust: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - .NET: `microsmith run build.microsmith.kts --out ./Generated`
 
 ### Direct script execution
@@ -433,7 +435,7 @@ microsmith ide refresh
 `microsmith init`
 
 - bootstraps `settings.microsmith.kts` and `build.microsmith.kts`
-- detects Node, Go, Python, .NET, or generic repository shape and emits a matching starter script
+- detects Node, Go, Python, Rust, .NET, or generic repository shape and emits a matching starter script
 - refreshes `.microsmith/ide` by default
 - preserves existing regular bootstrap files unless `--force` is provided
 - supports `--repo-root`, `--force`, `--skip-ide-helper`, `--diagnostics`, and `--verbose`
@@ -489,7 +491,7 @@ When `--diagnostics json` is used, each event is emitted as one JSON line with:
 
 ## JetBrains IDE helper
 
-Use the helper project when your repository is not Gradle-based and you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, Rider, and PyCharm.
+Use the helper project when your repository is not Gradle-based and you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, Rider, PyCharm, and RustRover.
 
 `microsmith init` already refreshes the helper by default. Use `microsmith ide refresh` when you skipped helper generation during init or need to repair or resynchronize the helper later.
 
@@ -523,6 +525,11 @@ JetBrains workflow:
 2. Link or import `.microsmith/ide/build.gradle.kts` as a Gradle project in the IDE.
 3. Refresh Gradle indexing.
 4. Rerun `microsmith ide refresh` after upgrading the Microsmith CLI or changing plugin dependencies.
+
+Rust-specific guidance:
+
+- for Rust repositories, RustRover is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
+- native Cargo indexing does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar when `.microsmith.kts` files need IDE type resolution
 
 ### When to use each command
 
@@ -576,7 +583,7 @@ Fallback artifact sources:
 Manual JetBrains setup:
 
 1. Download the fallback jar that matches your Microsmith version, or build it locally.
-2. In IntelliJ IDEA, GoLand, Rider, or PyCharm, add the jar as a project library from the IDE project settings.
+2. In IntelliJ IDEA, GoLand, Rider, PyCharm, or RustRover, add the jar as a project library from the IDE project settings.
 3. Reopen or reindex `.microsmith.kts` files.
 4. Replace the jar after upgrading Microsmith.
 
@@ -725,6 +732,28 @@ jobs:
         run: microsmith run build.microsmith.kts --out internal/gen
 ```
 
+### Rust repository
+
+```yaml
+name: Microsmith Generate
+on:
+  pull_request:
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Microsmith CLI
+        run: |
+          curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
+          sh microsmith-install.sh --version "$MICROSMITH_VERSION"
+          echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        run: microsmith init
+      - name: Generate protobuf
+        run: microsmith run build.microsmith.kts --out generated
+```
+
 ### .NET repository
 
 ```yaml
@@ -760,6 +789,7 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
 | Go      | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts --out ./internal/gen` | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
 | Python  | `examples/non-gradle/python` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/python/.github/workflows/microsmith.yml` |
+| Rust    | `examples/non-gradle/rust`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/rust/.github/workflows/microsmith.yml`   |
 | .NET    | `examples/non-gradle/dotnet` | `microsmith init` then `microsmith run build.microsmith.kts --out .\Generated`    | `examples/non-gradle/dotnet/.github/workflows/microsmith.yml` |
 
 ## Validation matrix and release checklist
@@ -771,8 +801,8 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | CLI help and README contract   | `build-and-qodana` on Ubuntu                         | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.   |
 | CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
 | Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
-| Non-JVM fixture onboarding     | `cli-smoke` on Ubuntu and Windows                    | Node, Go, Python, and .NET fixtures run the canonical `microsmith init` then `microsmith run`. |
-| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Fixture coverage runs `microsmith ide refresh` and `microsmith ide doctor` for Node, Go, Python, and .NET fixtures. |
+| Non-JVM fixture onboarding     | `cli-smoke` on Ubuntu and Windows                    | Node, Go, Python, Rust, and .NET fixtures run the canonical `microsmith init` then `microsmith run`. |
+| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Fixture coverage runs `microsmith ide refresh` and `microsmith ide doctor` for Node, Go, Python, Rust, and .NET fixtures. |
 | Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
 | Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
 
@@ -789,7 +819,7 @@ JetBrains IDE indexing and import behavior is partly host-driven, so final sign-
 
 Support policy:
 
-- supported products are IntelliJ IDEA, GoLand, Rider, and PyCharm
+- supported products are IntelliJ IDEA, GoLand, Rider, PyCharm, and RustRover
 - supported release band is the current stable major line and the previous stable major line at release cut
 - EAP builds are best-effort only and do not block release
 
@@ -798,6 +828,7 @@ Support policy:
 | IntelliJ IDEA   | `examples/non-gradle/node`      | Run the helper checklist below against the Node fixture. | Run the fallback checklist below against the Node fixture. |
 | GoLand          | `examples/non-gradle/go`        | Run the helper checklist below against the Go fixture.   | Run the fallback checklist below against the Go fixture.   |
 | PyCharm         | `examples/non-gradle/python`    | Run the helper checklist below against the Python fixture. | Run the fallback checklist below against the Python fixture. |
+| RustRover       | `examples/non-gradle/rust`      | Run the helper checklist below against the Rust fixture. | Run the fallback checklist below against the Rust fixture. |
 | Rider           | `examples/non-gradle/dotnet`    | Run the helper checklist below against the .NET fixture. | Run the fallback checklist below against the .NET fixture. |
 
 ### Manual IDE release checklist

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
@@ -17,6 +17,7 @@ internal object BuiltInOnboardingProfileMatchers {
                 "setup.py",
                 "setup.cfg",
             ),
+            rootMarkerMatcher(RustOnboardingProfile, "Cargo.toml"),
             dotnetMatcher(dotnetMarkerFinder),
         )
     }

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/RustOnboardingProfile.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/RustOnboardingProfile.kt
@@ -1,0 +1,8 @@
+package me.liam.microsmith.cli.init
+
+internal data object RustOnboardingProfile : OnboardingProfile {
+    override val id: OnboardingProfileId = OnboardingProfileId("rust")
+    override val displayName: String = "Rust"
+    override val sampleMessageName: String = "RustUserCreated"
+    override val recommendedOutputDirectory: String? = null
+}

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -15,6 +15,7 @@ import me.liam.microsmith.cli.init.NodeOnboardingProfile
 import me.liam.microsmith.cli.init.OnboardingProfileDetection
 import me.liam.microsmith.cli.init.OnboardingProfileSelectionReason
 import me.liam.microsmith.cli.init.PythonOnboardingProfile
+import me.liam.microsmith.cli.init.RustOnboardingProfile
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteRecursively
@@ -296,6 +297,51 @@ class MicrosmithCliInitTests :
 
                 exitCode shouldBe 0
                 out.joinToString("\n").shouldContain("Detected repository profile: Python")
+                out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldNotContain("Optional repository-native output path")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command keeps Rust on the canonical generated output path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-rust")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingProfileDetection(
+                                    profile = RustOnboardingProfile,
+                                    selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                                    matchedMarkers = listOf("Cargo.toml"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = emptyList(),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Detected repository profile: Rust")
                 out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
                 out.joinToString("\n").shouldNotContain("Optional repository-native output path")
                 err shouldBe emptyList()

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/InitBootstrapTests.kt
@@ -108,6 +108,54 @@ class InitBootstrapTests :
             }
         }
 
+        "creates repo-aware bootstrap files for Rust workspace roots without a repository-native output override" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-rust")
+            repoRoot.resolve("crates/app/src").createDirectories()
+            repoRoot.resolve("Cargo.toml").writeText(
+                """
+                [workspace]
+                members = ["crates/app"]
+                """.trimIndent() + "\n",
+            )
+            repoRoot.resolve("crates/app/Cargo.toml").writeText(
+                """
+                [package]
+                name = "fixture-rust-app"
+                version = "0.1.0"
+                edition = "2024"
+                """.trimIndent() + "\n",
+            )
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.repositoryDetection.profile shouldBe RustOnboardingProfile
+                result.repositoryDetection.matchedMarkers shouldBe listOf("Cargo.toml")
+                val buildScript = repoRoot.resolve("build.microsmith.kts").readText()
+                val settingsScript = repoRoot.resolve("settings.microsmith.kts").readText()
+
+                buildScript.shouldContain("RustUserCreated")
+                buildScript.shouldContain("microsmith run build.microsmith.kts --out ./generated")
+                buildScript.shouldContain("// Bootstrapped Microsmith schema for this Rust repository.")
+                buildScript.shouldContain("Canonical first run:")
+                buildScript.contains("Common repository-native output path:") shouldBe false
+                settingsScript.shouldContain("Detected repository profile: Rust")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "preserves existing bootstrap files on repeated init runs by default" {
             val repoRoot = createTempDirectory("microsmith-init-bootstrap-idempotent")
             val existingBuild = repoRoot.resolve("build.microsmith.kts")
@@ -328,6 +376,68 @@ class InitBootstrapTests :
             }
         }
 
+        "detects Rust repositories from Cargo.toml at package or workspace roots" {
+            val packageRoot = createTempDirectory("microsmith-init-detect-rust-package")
+            val workspaceRoot = createTempDirectory("microsmith-init-detect-rust-workspace")
+            try {
+                packageRoot.resolve("Cargo.toml").writeText(
+                    """
+                    [package]
+                    name = "fixture-rust"
+                    version = "0.1.0"
+                    edition = "2024"
+                    """.trimIndent() + "\n",
+                )
+                workspaceRoot.resolve("crates/app").createDirectories()
+                workspaceRoot.resolve("Cargo.toml").writeText(
+                    """
+                    [workspace]
+                    members = ["crates/app"]
+                    """.trimIndent() + "\n",
+                )
+
+                detectOnboardingProfile(packageRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = RustOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("Cargo.toml"),
+                    )
+                detectOnboardingProfile(workspaceRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = RustOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("Cargo.toml"),
+                    )
+            } finally {
+                runCatching { packageRoot.deleteRecursively() }
+                runCatching { workspaceRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile when a nested Rust crate exists without a root Cargo.toml" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-rust-nested-only")
+            try {
+                repoRoot.resolve("crates/app").createDirectories()
+                repoRoot.resolve("crates/app/Cargo.toml").writeText(
+                    """
+                    [package]
+                    name = "fixture-rust-app"
+                    version = "0.1.0"
+                    edition = "2024"
+                    """.trimIndent() + "\n",
+                )
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "keeps the Python profile when multiple Python markers match" {
             val pythonRoot = createTempDirectory("microsmith-init-detect-python-multi")
             try {
@@ -345,21 +455,23 @@ class InitBootstrapTests :
             }
         }
 
-        "detects Node, Go, Python, and .NET repositories and falls back to Other for mixed markers" {
+        "detects Node, Go, Python, Rust, and .NET repositories and falls back to Other for mixed markers" {
             val nodeRoot = createTempDirectory("microsmith-init-detect-node")
             val goRoot = createTempDirectory("microsmith-init-detect-go")
             val pythonRoot = createTempDirectory("microsmith-init-detect-python")
+            val rustRoot = createTempDirectory("microsmith-init-detect-rust")
             val dotnetRoot = createTempDirectory("microsmith-init-detect-dotnet")
             val mixedRoot = createTempDirectory("microsmith-init-detect-mixed")
             try {
                 nodeRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
                 goRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
                 pythonRoot.resolve("pyproject.toml").writeText("[project]\nname = \"fixture-python\"\n")
+                rustRoot.resolve("Cargo.toml").writeText("[package]\nname = \"fixture-rust\"\nversion = \"0.1.0\"\n")
                 dotnetRoot.resolve("src/apps/service").createDirectories()
                 dotnetRoot.resolve("src/apps/service/Fixture.csproj")
                     .writeText("<Project Sdk=\"Microsoft.NET.Sdk\" />\n")
                 mixedRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
-                mixedRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
+                mixedRoot.resolve("Cargo.toml").writeText("[package]\nname = \"fixture-rust\"\nversion = \"0.1.0\"\n")
 
                 detectOnboardingProfile(nodeRoot) shouldBe
                     OnboardingProfileDetection(
@@ -379,6 +491,12 @@ class InitBootstrapTests :
                         selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
                         matchedMarkers = listOf("pyproject.toml"),
                     )
+                detectOnboardingProfile(rustRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = RustOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("Cargo.toml"),
+                    )
                 detectOnboardingProfile(dotnetRoot) shouldBe
                     OnboardingProfileDetection(
                         profile = DotnetOnboardingProfile,
@@ -389,12 +507,13 @@ class InitBootstrapTests :
                     OnboardingProfileDetection(
                         profile = GenericOnboardingProfile,
                         selectionReason = OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
-                        matchedMarkers = listOf("go.mod", "package.json"),
+                        matchedMarkers = listOf("Cargo.toml", "package.json"),
                     )
             } finally {
                 runCatching { nodeRoot.deleteRecursively() }
                 runCatching { goRoot.deleteRecursively() }
                 runCatching { pythonRoot.deleteRecursively() }
+                runCatching { rustRoot.deleteRecursively() }
                 runCatching { dotnetRoot.deleteRecursively() }
                 runCatching { mixedRoot.deleteRecursively() }
             }

--- a/examples/non-gradle/rust/.github/workflows/microsmith.yml
+++ b/examples/non-gradle/rust/.github/workflows/microsmith.yml
@@ -1,0 +1,23 @@
+name: Microsmith Generate (Rust Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Microsmith
+        run: |
+          curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
+          sh microsmith-install.sh --version "$MICROSMITH_VERSION"
+          echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        working-directory: examples/non-gradle/rust
+        run: microsmith init
+      - name: Generate protobuf
+        working-directory: examples/non-gradle/rust
+        run: |
+          microsmith run build.microsmith.kts --out generated
+          test -f generated/proto/RustUserCreated.proto

--- a/examples/non-gradle/rust/Cargo.toml
+++ b/examples/non-gradle/rust/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/app"]
+resolver = "3"

--- a/examples/non-gradle/rust/Cargo.toml
+++ b/examples/non-gradle/rust/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 members = ["crates/app"]
-resolver = "3"
+resolver = "2"

--- a/examples/non-gradle/rust/crates/app/Cargo.toml
+++ b/examples/non-gradle/rust/crates/app/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "microsmith-rust-fixture-app"
+version = "0.1.0"
+edition = "2024"

--- a/examples/non-gradle/rust/crates/app/Cargo.toml
+++ b/examples/non-gradle/rust/crates/app/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "microsmith-rust-fixture-app"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"

--- a/examples/non-gradle/rust/crates/app/src/lib.rs
+++ b/examples/non-gradle/rust/crates/app/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn fixture_name() -> &'static str {
+    "microsmith-rust-fixture-app"
+}

--- a/examples/non-gradle/rust/schema.microsmith.kts
+++ b/examples/non-gradle/rust/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("RustUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why
Rust repositories are part of the universal onboarding goal, but `microsmith init` currently only recognizes Node, Go, Python, and .NET repository markers. That leaves Rust users on the generic path even when a repository has an unambiguous root Cargo manifest.

This PR adds first-class Rust onboarding while keeping the runtime and IDE story aligned with the existing installer-first, Gradle-less flow.

## What Changed
- added a Rust onboarding profile in `cli/src/main/kotlin/me/liam/microsmith/cli/init/RustOnboardingProfile.kt`
- added built-in Rust detection from a root `Cargo.toml` in `cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt`
- kept Rust on the canonical `./generated` output path because the repository convention is weaker than Go or .NET
- added CLI regression coverage for:
  - package and workspace root detection
  - nested-crate-without-root-manifest fallback behavior
  - repo-aware bootstrap messaging and output-path guidance
- added a representative Rust fixture and Linux smoke coverage in:
  - `examples/non-gradle/rust`
  - `.github/workflows/build_test_qodana.yml`
- updated `README.md` to document:
  - root `Cargo.toml` detection semantics
  - Rust output-path guidance
  - RustRover as the recommended JetBrains path for Rust repositories
  - the Rust fixture and validation matrix coverage

## Scope Notes
- Rust detection intentionally requires a root `Cargo.toml`.
- That supports both single-crate repositories and workspace roots.
- Repositories that only contain nested crates without a root manifest remain on the generic onboarding path for now.
- This PR does not add an explicit `--profile` override flag; that remains future work under the broader ecosystem epic if product policy changes.

## Validation
- `./gradlew :cli:check :cli:jvmKotest :cli:releaseArtifacts`
- `./gradlew build`
- built-launcher smoke against a temporary copy of `examples/non-gradle/rust`:
  - `microsmith init`
  - `microsmith ide refresh`
  - `microsmith ide doctor --diagnostics json`
  - `microsmith run build.microsmith.kts --out generated`
- `python3 scripts/verify_readme_cli_usage.py README.md <built-help-output>`
- YAML parse of `.github/workflows/build_test_qodana.yml`
- `git diff --check`

Closes #93
