### PR TITLE
feat(onboarding-java): define and support Java repository setup

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -204,7 +204,7 @@ jobs:
           test -f install-smoke-repo/settings.microsmith.kts
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
           test -f install-smoke-repo/generated/proto/UserCreated.proto
-      - name: Smoke test Node, Go, Python, Ruby, and Rust onboarding fixtures (Linux)
+      - name: Smoke test Java, Node, Go, Python, Ruby, and Rust onboarding fixtures (Linux)
         if: ${{ always() && matrix.os == 'ubuntu-latest' && steps.install-unix.outcome == 'success' }}
         run: |
           set -euo pipefail
@@ -229,6 +229,7 @@ jobs:
             echo "Validated $repo_name fixture."
           }
 
+          smoke_unix_fixture java examples/jvm/java-maven generated JavaUserCreated.proto java-ide-doctor.json
           smoke_unix_fixture node examples/non-gradle/node generated NodeUserCreated.proto node-ide-doctor.json
           smoke_unix_fixture go examples/non-gradle/go internal/gen GoUserCreated.proto go-ide-doctor.json
           smoke_unix_fixture python examples/non-gradle/python generated PythonUserCreated.proto python-ide-doctor.json

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ microsmith run build.microsmith.kts --out ./generated
 `microsmith init` is deterministic and non-destructive by default:
 
 - it detects Node, Go, Java, Python, Ruby, Rust, and .NET repositories from `package.json`, `go.mod`, Java source roots such as `src/main/java` or `src/test/java`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `Gemfile`, `gems.rb`, a root `*.gemspec`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
-- Java detection is intentionally conservative: it requires a Java source root, then adds Maven or Gradle root markers when present; build-file-only JVM roots stay on the generic path so future Kotlin and Scala support can remain unambiguous
+- Java detection is intentionally conservative: it requires a Java source root either at the repository root or inside a nested Maven or Gradle module, then adds root Maven or Gradle markers when present; build-file-only JVM roots stay on the generic path so future Kotlin and Scala support can remain unambiguous
 - Ruby detection covers Bundler-first app roots and gem-style repositories through a root `Gemfile`, root `gems.rb`, or root `*.gemspec`; nested gems without a root Ruby marker stay on the generic path
 - Rust detection covers both package manifests and workspace roots through a root `Cargo.toml`; nested crates without a root manifest stay on the generic path
 - it creates `settings.microsmith.kts` when missing

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Microsmith
 
 Microsmith is a Kotlin DSL and standalone CLI for declaring domain-specific models and generating artifacts from `.microsmith.kts` scripts.
-It is designed to work both inside this Gradle repository and from consumer repositories that do not use Gradle, including Go, .NET, Node, Python, Ruby, and Rust projects.
+It is designed to work both inside this Gradle repository and from consumer repositories including Go, .NET, Node, Python, Ruby, Rust, and Java projects.
 
 This README is the canonical repository documentation.
 
@@ -12,7 +12,7 @@ This README is the canonical repository documentation.
 - Repository Kotlin standards
 - Build, test, and quality gates
 - DSL usage
-- Standalone CLI for non-Gradle repositories
+- Standalone CLI for consumer repositories
 - Installation and verification
 - Command reference
 - JetBrains IDE helper
@@ -32,7 +32,7 @@ Microsmith provides:
 - extension points for schema and generation dialects
 - a standalone CLI for running `.microsmith.kts` scripts without embedding Gradle in consumer repositories
 - bundled built-in providers for the default schema and protobuf workflows
-- a JetBrains IDE helper workflow for stronger type resolution in non-Gradle repositories
+- a JetBrains IDE helper workflow for stronger type resolution in consumer repositories
 
 ## Repository modules
 
@@ -208,9 +208,9 @@ Inside `.microsmith.kts` scripts:
 - a script can return a `MicrosmithModel`
 - a script can also call `emit(model)` or `generate(model)`
 
-## Standalone CLI for non-Gradle repositories
+## Standalone CLI for consumer repositories
 
-The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, and other repositories that do not use Gradle.
+The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, Java, and other repositories when you want self-contained Microsmith execution without depending on a local Gradle or Maven install.
 The official installer scripts are self-contained and provision a Java 24 runtime automatically when the machine does not already provide one.
 
 Manual channels remain available, but they require Java 24 or newer.
@@ -226,7 +226,8 @@ microsmith run build.microsmith.kts --out ./generated
 
 `microsmith init` is deterministic and non-destructive by default:
 
-- it detects Node, Go, Python, Ruby, Rust, and .NET repositories from `package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `Gemfile`, `gems.rb`, a root `*.gemspec`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
+- it detects Node, Go, Java, Python, Ruby, Rust, and .NET repositories from `package.json`, `go.mod`, Java source roots such as `src/main/java` or `src/test/java`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `Gemfile`, `gems.rb`, a root `*.gemspec`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
+- Java detection is intentionally conservative: it requires a Java source root, then adds Maven or Gradle root markers when present; build-file-only JVM roots stay on the generic path so future Kotlin and Scala support can remain unambiguous
 - Ruby detection covers Bundler-first app roots and gem-style repositories through a root `Gemfile`, root `gems.rb`, or root `*.gemspec`; nested gems without a root Ruby marker stay on the generic path
 - Rust detection covers both package manifests and workspace roots through a root `Cargo.toml`; nested crates without a root manifest stay on the generic path
 - it creates `settings.microsmith.kts` when missing
@@ -247,10 +248,17 @@ After the canonical first run succeeds, you can switch to a repository-native ou
 
 - Node: `microsmith run build.microsmith.kts --out ./generated`
 - Go: `microsmith run build.microsmith.kts --out ./internal/gen`
+- Java: keep the canonical `./generated` output path unless you explicitly wire generated sources into Maven or Gradle later
 - Python: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Ruby: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Rust: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - .NET: `microsmith run build.microsmith.kts --out ./Generated`
+
+Java-specific guidance:
+
+- Maven-based Java repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
+- Gradle-based Java repositories: keep Microsmith CLI-managed by default and do not wire Microsmith into the Gradle build automatically as part of onboarding
+- build-tool-light Java repositories: use the same canonical `./generated` output path and helper workflow
 
 ### Direct script execution
 
@@ -493,7 +501,7 @@ When `--diagnostics json` is used, each event is emitted as one JSON line with:
 
 ## JetBrains IDE helper
 
-Use the helper project when your repository is not Gradle-based and you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, Rider, PyCharm, RubyMine, and RustRover.
+Use the helper project when you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, Rider, PyCharm, RubyMine, and RustRover.
 
 `microsmith init` already refreshes the helper by default. Use `microsmith ide refresh` when you skipped helper generation during init or need to repair or resynchronize the helper later.
 
@@ -528,6 +536,11 @@ JetBrains workflow:
 3. Refresh Gradle indexing.
 4. Rerun `microsmith ide refresh` after upgrading the Microsmith CLI or changing plugin dependencies.
 
+Java-specific guidance:
+
+- for Java repositories, IntelliJ IDEA is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
+- native Maven or Gradle import resolves Java project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
+
 Ruby-specific guidance:
 
 - for Ruby repositories, RubyMine is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
@@ -540,7 +553,7 @@ Rust-specific guidance:
 
 ### When to use each command
 
-- First-time setup in a non-Gradle repository: `microsmith init`
+- First-time setup in a consumer repository: `microsmith init`
 - Helper was skipped, removed, or needs regeneration after CLI or plugin changes: `microsmith ide refresh`
 - Symbols are still unresolved or the helper appears stale: `microsmith ide doctor --diagnostics json --verbose`
 
@@ -717,6 +730,28 @@ jobs:
         run: microsmith run build.microsmith.kts --out generated
 ```
 
+### Java repository
+
+```yaml
+name: Microsmith Generate
+on:
+  pull_request:
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Microsmith CLI
+        run: |
+          curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
+          sh microsmith-install.sh --version "$MICROSMITH_VERSION"
+          echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        run: microsmith init
+      - name: Generate protobuf
+        run: microsmith run build.microsmith.kts --out generated
+```
+
 ### Go repository
 
 ```yaml
@@ -810,11 +845,12 @@ jobs:
 
 ## Example fixtures
 
-The repository includes non-Gradle fixture repositories under `examples/non-gradle/`.
+The repository includes fixture repositories under `examples/non-gradle/` and `examples/jvm/`.
 Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.microsmith.kts` manual example, and a GitHub Actions example that exercises the init-first path.
 
 | Fixture | Directory                    | Local command from fixture root                                                   | CI workflow                                                   |
 |---------|------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
+| Java    | `examples/jvm/java-maven`    | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`   | `examples/jvm/java-maven/.github/workflows/microsmith.yml`    |
 | Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
 | Go      | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts --out ./internal/gen` | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
 | Python  | `examples/non-gradle/python` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/python/.github/workflows/microsmith.yml` |
@@ -831,8 +867,8 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | CLI help and README contract   | `build-and-qodana` on Ubuntu                         | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.   |
 | CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
 | Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
-| Non-JVM fixture onboarding     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
-| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
+| Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
+| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
 | Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
 | Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
 
@@ -855,7 +891,7 @@ Support policy:
 
 | Product         | Fixture root                    | Required helper smoke path                              | Required fallback smoke path                             |
 |-----------------|---------------------------------|---------------------------------------------------------|----------------------------------------------------------|
-| IntelliJ IDEA   | `examples/non-gradle/node`      | Run the helper checklist below against the Node fixture. | Run the fallback checklist below against the Node fixture. |
+| IntelliJ IDEA   | `examples/jvm/java-maven`       | Run the helper checklist below against the Java fixture. | Run the fallback checklist below against the Java fixture. |
 | GoLand          | `examples/non-gradle/go`        | Run the helper checklist below against the Go fixture.   | Run the fallback checklist below against the Go fixture.   |
 | PyCharm         | `examples/non-gradle/python`    | Run the helper checklist below against the Python fixture. | Run the fallback checklist below against the Python fixture. |
 | RubyMine        | `examples/non-gradle/ruby`      | Run the helper checklist below against the Ruby fixture. | Run the fallback checklist below against the Ruby fixture. |

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
@@ -12,6 +12,7 @@ internal object BuiltInOnboardingProfileMatchers {
         return listOf(
             rootMarkerMatcher(NodeOnboardingProfile, "package.json"),
             rootMarkerMatcher(GoOnboardingProfile, "go.mod"),
+            javaMatcher(),
             rootMarkerMatcher(
                 PythonOnboardingProfile,
                 "pyproject.toml",
@@ -46,6 +47,12 @@ internal object BuiltInOnboardingProfileMatchers {
     private fun rubyGemspecMatcher(): OnboardingProfileMatcher {
         return OnboardingProfileMatcher(RubyOnboardingProfile) { projectRoot ->
             RubyOnboardingMarkerFinder.find(projectRoot)
+        }
+    }
+
+    private fun javaMatcher(): OnboardingProfileMatcher {
+        return OnboardingProfileMatcher(JavaOnboardingProfile) { projectRoot ->
+            JavaOnboardingMarkerFinder.find(projectRoot)
         }
     }
 

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
@@ -1,24 +1,79 @@
 package me.liam.microsmith.cli.init
 
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
 
 internal object JavaOnboardingMarkerFinder {
     fun find(projectRoot: Path): List<String> {
-        val matchedSourceMarkers =
-            SOURCE_MARKERS.filter { markerPath ->
-                projectRoot.resolve(markerPath).isDirectory()
-            }
-        if (matchedSourceMarkers.isEmpty()) {
-            return emptyList()
-        }
+        return try {
+            val matchedSourceMarkers =
+                ROOT_SOURCE_MARKERS.filter { markerPath ->
+                    projectRoot.resolve(markerPath).isDirectory()
+                }
+            val matchedBuildMarkers =
+                BUILD_MARKERS.filter { markerFileName ->
+                    projectRoot.resolve(markerFileName).isRegularFile()
+                }
 
-        val matchedBuildMarkers =
-            BUILD_MARKERS.filter { markerFileName ->
-                projectRoot.resolve(markerFileName).isRegularFile()
+            if (matchedSourceMarkers.isNotEmpty()) {
+                (matchedBuildMarkers + matchedSourceMarkers).sorted()
+            } else if (matchedBuildMarkers.isEmpty()) {
+                emptyList()
+            } else {
+                val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot)
+                if (matchedModuleSourceMarkers.isEmpty()) {
+                    emptyList()
+                } else {
+                    (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
+                }
             }
-        return (matchedBuildMarkers + matchedSourceMarkers).sorted()
+        } catch (_: IOException) {
+            emptyList()
+        } catch (_: UncheckedIOException) {
+            emptyList()
+        } catch (_: SecurityException) {
+            emptyList()
+        }
+    }
+
+    private fun findModuleSourceMarkers(projectRoot: Path): List<String> {
+        val matchedMarkers = mutableListOf<String>()
+        Files.walkFileTree(
+            projectRoot,
+            emptySet(),
+            MODULE_SOURCE_SEARCH_DEPTH,
+            object : SimpleFileVisitor<Path>() {
+                override fun preVisitDirectory(directory: Path, attributes: BasicFileAttributes): FileVisitResult {
+                    if (directory == projectRoot) {
+                        return FileVisitResult.CONTINUE
+                    }
+
+                    val relativeDirectory = projectRoot.relativize(directory)
+                    return when {
+                        relativeDirectory in ROOT_SOURCE_MARKER_PATHS -> FileVisitResult.SKIP_SUBTREE
+                        ROOT_SOURCE_MARKER_PATHS.any(relativeDirectory::endsWith) -> {
+                            matchedMarkers += relativeDirectory.toString()
+                            FileVisitResult.SKIP_SUBTREE
+                        }
+                        else -> FileVisitResult.CONTINUE
+                    }
+                }
+
+                override fun visitFileFailed(file: Path, exception: IOException): FileVisitResult =
+                    FileVisitResult.CONTINUE
+
+                override fun postVisitDirectory(directory: Path, exception: IOException?): FileVisitResult =
+                    FileVisitResult.CONTINUE
+            },
+        )
+        return matchedMarkers.sorted()
     }
 }
 
@@ -30,7 +85,11 @@ private val BUILD_MARKERS = listOf(
     "settings.gradle.kts",
 )
 
-private val SOURCE_MARKERS = listOf(
+private val ROOT_SOURCE_MARKERS = listOf(
     "src/main/java",
     "src/test/java",
 )
+
+private val ROOT_SOURCE_MARKER_PATHS = ROOT_SOURCE_MARKERS.map(Path::of)
+
+private const val MODULE_SOURCE_SEARCH_DEPTH = 6

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
@@ -1,0 +1,36 @@
+package me.liam.microsmith.cli.init
+
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+
+internal object JavaOnboardingMarkerFinder {
+    fun find(projectRoot: Path): List<String> {
+        val matchedSourceMarkers =
+            SOURCE_MARKERS.filter { markerPath ->
+                projectRoot.resolve(markerPath).isDirectory()
+            }
+        if (matchedSourceMarkers.isEmpty()) {
+            return emptyList()
+        }
+
+        val matchedBuildMarkers =
+            BUILD_MARKERS.filter { markerFileName ->
+                projectRoot.resolve(markerFileName).isRegularFile()
+            }
+        return (matchedBuildMarkers + matchedSourceMarkers).sorted()
+    }
+}
+
+private val BUILD_MARKERS = listOf(
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "settings.gradle",
+    "settings.gradle.kts",
+)
+
+private val SOURCE_MARKERS = listOf(
+    "src/main/java",
+    "src/test/java",
+)

--- a/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingProfile.kt
+++ b/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingProfile.kt
@@ -1,0 +1,8 @@
+package me.liam.microsmith.cli.init
+
+internal data object JavaOnboardingProfile : OnboardingProfile {
+    override val id: OnboardingProfileId = OnboardingProfileId("java")
+    override val displayName: String = "Java"
+    override val sampleMessageName: String = "JavaUserCreated"
+    override val recommendedOutputDirectory: String? = null
+}

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -11,6 +11,7 @@ import me.liam.microsmith.cli.init.GoOnboardingProfile
 import me.liam.microsmith.cli.init.InitBootstrapResult
 import me.liam.microsmith.cli.init.InitConflictException
 import me.liam.microsmith.cli.init.InitValidationException
+import me.liam.microsmith.cli.init.JavaOnboardingProfile
 import me.liam.microsmith.cli.init.NodeOnboardingProfile
 import me.liam.microsmith.cli.init.OnboardingProfileDetection
 import me.liam.microsmith.cli.init.OnboardingProfileSelectionReason
@@ -298,6 +299,51 @@ class MicrosmithCliInitTests :
 
                 exitCode shouldBe 0
                 out.joinToString("\n").shouldContain("Detected repository profile: Python")
+                out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldNotContain("Optional repository-native output path")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command keeps Java on the canonical generated output path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-java")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingProfileDetection(
+                                    profile = JavaOnboardingProfile,
+                                    selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                                    matchedMarkers = listOf("pom.xml", "src/main/java"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = emptyList(),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Detected repository profile: Java")
                 out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
                 out.joinToString("\n").shouldNotContain("Optional repository-native output path")
                 err shouldBe emptyList()

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/JavaOnboardingProfileTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/JavaOnboardingProfileTests.kt
@@ -1,0 +1,148 @@
+package me.liam.microsmith.cli.init
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class JavaOnboardingProfileTests :
+    StringSpec({
+        "creates repo-aware bootstrap files for Java repositories without a repository-native output override" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-java")
+            repoRoot.resolve("pom.xml").writeText("<project />\n")
+            repoRoot.resolve("src/main/java/example").createDirectories()
+            repoRoot.resolve("src/main/java/example/App.java").writeText(
+                """
+                package example;
+
+                public final class App {
+                    public String message() {
+                        return \"Microsmith Java fixture\";
+                    }
+                }
+                """.trimIndent() + "\n",
+            )
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.repositoryDetection.profile shouldBe JavaOnboardingProfile
+                result.repositoryDetection.matchedMarkers shouldBe listOf("pom.xml", "src/main/java")
+                val buildScript = repoRoot.resolve("build.microsmith.kts").readText()
+                val settingsScript = repoRoot.resolve("settings.microsmith.kts").readText()
+
+                buildScript.shouldContain("JavaUserCreated")
+                buildScript.shouldContain("microsmith run build.microsmith.kts --out ./generated")
+                buildScript.shouldContain("// Bootstrapped Microsmith schema for this Java repository.")
+                buildScript.contains("Common repository-native output path:") shouldBe false
+                settingsScript.shouldContain("Detected repository profile: Java")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Java repositories from Maven roots when a Java source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-java-maven")
+            try {
+                repoRoot.resolve("pom.xml").writeText("<project />\n")
+                repoRoot.resolve("src/main/java/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = JavaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pom.xml", "src/main/java"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Java repositories from Gradle roots when a Java source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-java-gradle")
+            try {
+                repoRoot.resolve("build.gradle.kts").writeText("plugins { java }\n")
+                repoRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture-java\"\n")
+                repoRoot.resolve("src/test/java/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = JavaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "settings.gradle.kts", "src/test/java"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects build-tool-light Java repositories from source roots alone" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-java-lightweight")
+            try {
+                repoRoot.resolve("src/main/java/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = JavaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("src/main/java"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile for Java build files without a Java source tree" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-java-build-only")
+            try {
+                repoRoot.resolve("pom.xml").writeText("<project />\n")
+                repoRoot.resolve("build.gradle.kts").writeText("plugins { java }\n")
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile when Java and another ecosystem marker both match" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-java-mixed")
+            try {
+                repoRoot.resolve("pom.xml").writeText("<project />\n")
+                repoRoot.resolve("src/main/java/example").createDirectories()
+                repoRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
+                        matchedMarkers = listOf("package.json", "pom.xml", "src/main/java"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+    })

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/JavaOnboardingProfileTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/JavaOnboardingProfileTests.kt
@@ -25,7 +25,7 @@ class JavaOnboardingProfileTests :
 
                 public final class App {
                     public String message() {
-                        return \"Microsmith Java fixture\";
+                        return "Microsmith Java fixture";
                     }
                 }
                 """.trimIndent() + "\n",
@@ -77,6 +77,23 @@ class JavaOnboardingProfileTests :
             }
         }
 
+        "detects multi-module Maven Java repositories from nested Java source trees" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-java-maven-multi-module")
+            try {
+                repoRoot.resolve("pom.xml").writeText("<project />\n")
+                repoRoot.resolve("modules/service-a/src/main/java/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = JavaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("modules/service-a/src/main/java", "pom.xml"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
         "detects Java repositories from Gradle roots when a Java source tree exists" {
             val repoRoot = createTempDirectory("microsmith-init-detect-java-gradle")
             try {
@@ -89,6 +106,23 @@ class JavaOnboardingProfileTests :
                         profile = JavaOnboardingProfile,
                         selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
                         matchedMarkers = listOf("build.gradle.kts", "settings.gradle.kts", "src/test/java"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects multi-module Gradle Java repositories from nested Java source trees" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-java-gradle-multi-module")
+            try {
+                repoRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture-java\"\n")
+                repoRoot.resolve("services/app/src/test/java/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = JavaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("services/app/src/test/java", "settings.gradle.kts"),
                     )
             } finally {
                 runCatching { repoRoot.deleteRecursively() }

--- a/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
+++ b/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
@@ -369,6 +369,7 @@ class OnboardingProfileDetectorTests :
         }
 
         "detects built-in repository profiles and falls back to the generic profile for ambiguous markers" {
+            val javaRoot = createTempDirectory("microsmith-init-detect-java")
             val nodeRoot = createTempDirectory("microsmith-init-detect-node")
             val goRoot = createTempDirectory("microsmith-init-detect-go")
             val pythonRoot = createTempDirectory("microsmith-init-detect-python")
@@ -377,6 +378,8 @@ class OnboardingProfileDetectorTests :
             val dotnetRoot = createTempDirectory("microsmith-init-detect-dotnet")
             val mixedRoot = createTempDirectory("microsmith-init-detect-mixed")
             try {
+                javaRoot.resolve("pom.xml").writeText("<project />\n")
+                javaRoot.resolve("src/main/java/example").createDirectories()
                 nodeRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
                 goRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
                 pythonRoot.resolve("pyproject.toml").writeText("[project]\nname = \"fixture-python\"\n")
@@ -388,6 +391,12 @@ class OnboardingProfileDetectorTests :
                 mixedRoot.resolve("gems.rb").writeText("source \"https://rubygems.org\"\n")
                 mixedRoot.resolve("Cargo.toml").writeText("[package]\nname = \"fixture-rust\"\nversion = \"0.1.0\"\n")
 
+                detectOnboardingProfile(javaRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = JavaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pom.xml", "src/main/java"),
+                    )
                 detectOnboardingProfile(nodeRoot) shouldBe
                     OnboardingProfileDetection(
                         profile = NodeOnboardingProfile,
@@ -431,6 +440,7 @@ class OnboardingProfileDetectorTests :
                         matchedMarkers = listOf("Cargo.toml", "gems.rb"),
                     )
             } finally {
+                runCatching { javaRoot.deleteRecursively() }
                 runCatching { nodeRoot.deleteRecursively() }
                 runCatching { goRoot.deleteRecursively() }
                 runCatching { pythonRoot.deleteRecursively() }

--- a/examples/jvm/java-maven/.github/workflows/microsmith.yml
+++ b/examples/jvm/java-maven/.github/workflows/microsmith.yml
@@ -1,0 +1,23 @@
+name: Microsmith Generate (Java Maven Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Microsmith
+        run: |
+          curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
+          sh microsmith-install.sh --version "$MICROSMITH_VERSION"
+          echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        working-directory: examples/jvm/java-maven
+        run: microsmith init
+      - name: Generate protobuf
+        working-directory: examples/jvm/java-maven
+        run: |
+          microsmith run build.microsmith.kts --out generated
+          test -f generated/proto/JavaUserCreated.proto

--- a/examples/jvm/java-maven/pom.xml
+++ b/examples/jvm/java-maven/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>example.microsmith</groupId>
+    <artifactId>java-maven-fixture</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+    </properties>
+</project>

--- a/examples/jvm/java-maven/schema.microsmith.kts
+++ b/examples/jvm/java-maven/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("JavaUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}

--- a/examples/jvm/java-maven/src/main/java/example/App.java
+++ b/examples/jvm/java-maven/src/main/java/example/App.java
@@ -1,0 +1,7 @@
+package example;
+
+public final class App {
+    public String message() {
+        return "Microsmith Java fixture";
+    }
+}


### PR DESCRIPTION
## Why
Java repositories need a first-class Microsmith setup story, but they are not the same as the current non-JVM fixtures. Some Java repositories use Maven, some use Gradle, and some are lighter source-only layouts. The onboarding path needs to improve first-run UX without pretending Microsmith owns those build tools.

This change adds a conservative Java profile that improves `microsmith init` for real Java repositories while avoiding false positives that would make the later Kotlin and Scala issues harder.

## What Changed
- added `JavaOnboardingProfile` and `JavaOnboardingMarkerFinder`
- added conservative Java detection anchored on `src/main/java` or `src/test/java`, with `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle`, and `settings.gradle.kts` enriching the matched marker set when present
- kept Java on the canonical `./generated` output path rather than auto-wiring Maven or Gradle integration during onboarding
- added Java-specific bootstrap and CLI coverage in:
  - `cli/src/test/kotlin/me/liam/microsmith/cli/init/JavaOnboardingProfileTests.kt`
  - `cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt`
  - `cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt`
- added a representative Maven-based Java fixture in `examples/jvm/java-maven`
- extended Linux CLI smoke coverage to exercise the Java fixture
- documented the Java onboarding contract, IntelliJ IDEA guidance, fixture inventory, and validation matrix in `README.md`

## Contract Decisions
- Maven-based Java repositories: supported
- Gradle-based Java repositories: supported for onboarding guidance and profile detection, but Microsmith does not wire itself into the Gradle build automatically
- build-tool-light Java repositories: supported through Java source-root detection
- build-file-only JVM roots: intentionally stay on the generic profile until a language-specific source root exists
- JetBrains IDE path: IntelliJ IDEA plus the existing helper workflow remains the primary `.microsmith.kts` authoring path; fallback jar remains the manual secondary path

## Validation
- `./gradlew :cli:check :cli:jvmKotest :cli:releaseArtifacts --rerun-tasks --no-build-cache`
- built launcher smoke against a temporary copy of `examples/jvm/java-maven`:
  - `microsmith init`
  - `microsmith ide refresh`
  - `microsmith ide doctor --diagnostics json`
  - `microsmith run build.microsmith.kts --out generated`
- `./cli/build/microsmith-cli-dist/bin/microsmith --help > /tmp/microsmith-cli-help.txt && python3 scripts/verify_readme_cli_usage.py README.md /tmp/microsmith-cli-help.txt`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_test_qodana.yml")'`
- `git diff --check`
- `./gradlew build --rerun-tasks --no-build-cache`

Closes #88
