### PR TITLE
feat(quality-detekt): rebalance guard-clause policy and refactor control flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Microsmith provides:
 - Use infix functions only for DSL-facing APIs when readability is clearly better than the non-infix equivalent.
 - Use `object` and `companion object` only when singleton semantics, namespaced factories, or constants are genuinely clearer than top-level declarations or regular types.
 - Avoid Java-style static utility patterns, unnecessary mutable state, and scope-function chains that hide control flow.
-- Do not contort control flow to appease return-count tooling. Guard clauses are allowed; once a function needs more than a small handful of exits, simplify or decompose it instead.
+- Do not contort control flow to appease return-count tooling. Guard clauses are allowed; excessive non-guard branching should still be simplified or decomposed.
 
 ### Interfaces and ports
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,14 @@ Microsmith provides:
 ### Kotlin idioms
 
 - Prefer immutable data, `val`, and expression-oriented control flow by default.
+- Prefer guard clauses and early returns for preconditions, invalid state handling, and fast exits when they reduce nesting and make the main path easier to read.
 - Default to the narrowest visibility that keeps the API honest. Widen visibility only when a real caller or extension point requires it.
 - Use `sealed interface`, `data object`, `value class`, exhaustive `when`, and null-safety where they make state and invariants clearer.
 - Use extension functions when they improve discoverability for a well-scoped domain operation and avoid creating utility dumping grounds.
 - Use infix functions only for DSL-facing APIs when readability is clearly better than the non-infix equivalent.
 - Use `object` and `companion object` only when singleton semantics, namespaced factories, or constants are genuinely clearer than top-level declarations or regular types.
 - Avoid Java-style static utility patterns, unnecessary mutable state, and scope-function chains that hide control flow.
+- Do not contort control flow to appease return-count tooling. Guard clauses are allowed; once a function needs more than a small handful of exits, simplify or decompose it instead.
 
 ### Interfaces and ports
 

--- a/build-logic/src/test/kotlin/me/liam/microsmith/build/quality/RepositoryQualityTaskFunctionalTests.kt
+++ b/build-logic/src/test/kotlin/me/liam/microsmith/build/quality/RepositoryQualityTaskFunctionalTests.kt
@@ -39,8 +39,8 @@ class RepositoryQualityTaskFunctionalTests : StringSpec() {
             val result = project.buildAndFail("verifyRepositoryStandards")
 
             result.output shouldContain "[multiple-production-types] src/main/kotlin/example/MixedDeclarations.kt"
-            result.output shouldContain multipleProductionTypesRemediation
-            result.output shouldContain policyExceptionRemediationPrefix
+            result.output shouldContain MULTIPLE_PRODUCTION_TYPES_REMEDIATION
+            result.output shouldContain POLICY_EXCEPTION_REMEDIATION_PREFIX
         }
 
         "verifyRepositoryStandards fails for production file line limit violations" {
@@ -53,7 +53,7 @@ class RepositoryQualityTaskFunctionalTests : StringSpec() {
             val result = project.buildAndFail("verifyRepositoryStandards")
 
             result.output shouldContain "[production-file-lines] src/main/kotlin/example/TooLong.kt"
-            result.output shouldContain lineLimitRemediation
+            result.output shouldContain LINE_LIMIT_REMEDIATION
         }
 
         "verifyRepositoryStandards fails for forbidden package segments" {
@@ -85,7 +85,7 @@ class RepositoryQualityTaskFunctionalTests : StringSpec() {
             val result = project.buildAndFail("verifyRepositoryStandards")
 
             result.output shouldContain "[missing-package-declaration] src/main/kotlin/example/NoPackage.kt"
-            result.output shouldContain missingPackageDeclarationRemediation
+            result.output shouldContain MISSING_PACKAGE_DECLARATION_REMEDIATION
         }
 
         "verifyRepositoryStandards accepts package declarations with trailing comments" {
@@ -136,7 +136,7 @@ class RepositoryQualityTaskFunctionalTests : StringSpec() {
             val result = project.buildAndFail("verifyRepositoryStandards")
 
             result.output shouldContain "[primary-type-file-name] src/main/kotlin/example/TypeAliasFile.kt"
-            result.output shouldContain primaryTypeFileNamePrefix
+            result.output shouldContain PRIMARY_TYPE_FILE_NAME_PREFIX
         }
 
         "verifyRepositoryStandards fails for file name mismatches on inline annotated declarations" {
@@ -174,7 +174,7 @@ class RepositoryQualityTaskFunctionalTests : StringSpec() {
             val result = project.buildAndFail("verifyRepositoryStandards")
 
             result.output shouldContain "[multiple-production-types] src/main/kotlin/example/IndentedDeclarations.kt"
-            result.output shouldContain multipleProductionTypesRemediation
+            result.output shouldContain MULTIPLE_PRODUCTION_TYPES_REMEDIATION
         }
 
         "verifyRepositoryStandards scans build-logic production sources" {
@@ -187,7 +187,7 @@ class RepositoryQualityTaskFunctionalTests : StringSpec() {
             val result = project.buildAndFail("verifyRepositoryStandards")
 
             result.output shouldContain "[production-file-lines] build-logic/src/main/kotlin/example/TooLong.kt"
-            result.output shouldContain lineLimitRemediation
+            result.output shouldContain LINE_LIMIT_REMEDIATION
         }
 
         "verifyRepositoryStandards ignores files under build directories" {
@@ -228,17 +228,17 @@ class RepositoryQualityTaskFunctionalTests : StringSpec() {
     }
 
     private companion object {
-        private const val multipleProductionTypesRemediation =
+        private const val MULTIPLE_PRODUCTION_TYPES_REMEDIATION =
             "Split extra production types into their own files or make tightly coupled helpers private."
-        private const val lineLimitRemediation =
+        private const val LINE_LIMIT_REMEDIATION =
             "Split parsing, validation, rendering, diagnostics, policy, or I/O responsibilities " +
                 "before extending the file further."
-        private const val missingPackageDeclarationRemediation =
+        private const val MISSING_PACKAGE_DECLARATION_REMEDIATION =
             "Production Kotlin files must declare an explicit package."
-        private const val policyExceptionRemediationPrefix =
+        private const val POLICY_EXCEPTION_REMEDIATION_PREFIX =
             "Fix the structural issue, or if the exception is truly justified, " +
                 "update RepositoryQualityPolicy"
-        private const val primaryTypeFileNamePrefix =
+        private const val PRIMARY_TYPE_FILE_NAME_PREFIX =
             "File 'TypeAliasFile.kt' does not match the single top-level production declaration"
     }
 }

--- a/build-logic/src/test/kotlin/me/liam/microsmith/build/quality/RepositoryQualityValidatorTests.kt
+++ b/build-logic/src/test/kotlin/me/liam/microsmith/build/quality/RepositoryQualityValidatorTests.kt
@@ -255,7 +255,7 @@ class RepositoryQualityValidatorTests : StringSpec() {
                 RepositoryQualityViolation(
                     rule = "missing-package-declaration",
                     path = "module/src/main/kotlin/example/NoPackage.kt",
-                    message = missingPackageDeclarationMessage,
+                    message = MISSING_PACKAGE_DECLARATION_MESSAGE,
                 ),
             )
         }
@@ -395,7 +395,7 @@ class RepositoryQualityValidatorTests : StringSpec() {
             "Package '$packageName' contains forbidden segment '$forbiddenSegment'. " +
                 "Use a domain-led package name instead of util/utils/misc."
 
-        private const val missingPackageDeclarationMessage =
+        private const val MISSING_PACKAGE_DECLARATION_MESSAGE =
             "Production Kotlin files must declare an explicit package. " +
                 "Use a domain-led package that matches the src/main/kotlin directory."
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -127,12 +127,12 @@ style:
     excludeImportStatements: true
   ReturnCount:
     active: true
-    max: 3
+    max: 4
     excludedFunctions:
       - 'equals'
     excludeLabeled: false
     excludeReturnFromLambda: true
-    excludeGuardClauses: false
+    excludeGuardClauses: true
     excludes:
       - '**/test/**'
   ThrowsCount:

--- a/detekt.yml
+++ b/detekt.yml
@@ -127,7 +127,7 @@ style:
     excludeImportStatements: true
   ReturnCount:
     active: true
-    max: 4
+    max: 3
     excludedFunctions:
       - 'equals'
     excludeLabeled: false

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorBootstrapStateCheck.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorBootstrapStateCheck.kt
@@ -11,12 +11,14 @@ internal object DoctorBootstrapStateCheck {
         val buildScript = projectRoot.resolve(INIT_BUILD_FILE_NAME)
         val settingsScript = projectRoot.resolve(INIT_SETTINGS_FILE_NAME)
         val helperRoot = projectRoot.resolve(IDE_HELPER_DIRECTORY)
+
         validateBootstrapSurface(
             projectRoot = projectRoot,
             buildScript = buildScript,
             settingsScript = settingsScript,
             helperRoot = helperRoot,
         )?.let { return it }
+
         val invalidHelperFiles = invalidIdeHelperFiles(projectRoot = projectRoot, helperRoot = helperRoot)
         val missingHelperFiles = missingIdeHelperFiles(projectRoot = projectRoot, helperRoot = helperRoot)
 
@@ -81,6 +83,7 @@ internal object DoctorBootstrapStateCheck {
         val bootstrapFiles = listOf(buildScript, settingsScript)
         val invalidBootstrapFiles = invalidManagedFiles(projectRoot = projectRoot, managedFiles = bootstrapFiles)
         val missingBootstrapFiles = missingManagedFiles(projectRoot = projectRoot, managedFiles = bootstrapFiles)
+
         return when {
             invalidBootstrapFiles.isNotEmpty() ->
                 DoctorCheckResult(

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorBootstrapStateCheck.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorBootstrapStateCheck.kt
@@ -24,9 +24,7 @@ internal object DoctorBootstrapStateCheck {
 
         return when {
             invalidHelperFiles.isNotEmpty() ->
-                DoctorCheckResult(
-                    id = CHECK_ID,
-                    status = DoctorCheckStatus.FAIL,
+                failure(
                     message =
                     "JetBrains IDE helper contains conflicting managed paths. " +
                         "Remove them and run 'microsmith ide refresh' to repair it.",
@@ -34,25 +32,19 @@ internal object DoctorBootstrapStateCheck {
                 )
 
             missingHelperFiles.isNotEmpty() ->
-                DoctorCheckResult(
-                    id = CHECK_ID,
-                    status = DoctorCheckStatus.FAIL,
+                failure(
                     message = "JetBrains IDE helper is incomplete. Run 'microsmith ide refresh' to repair it.",
                     details = mapOf("missingIdeHelperFiles" to missingHelperFiles.joinToString(separator = ",")),
                 )
 
             Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) ->
-                DoctorCheckResult(
-                    id = CHECK_ID,
-                    status = DoctorCheckStatus.PASS,
+                pass(
                     message = "Bootstrap files and JetBrains IDE helper are present.",
                     details = mapOf("projectRoot" to projectRoot.toString()),
                 )
 
             else ->
-                DoctorCheckResult(
-                    id = CHECK_ID,
-                    status = DoctorCheckStatus.FAIL,
+                failure(
                     message =
                     "Bootstrap files are present, but the JetBrains IDE helper is missing. " +
                         "Run 'microsmith ide refresh' to restore the default onboarding surface.",
@@ -72,9 +64,7 @@ internal object DoctorBootstrapStateCheck {
                 Files.exists(settingsScript, LinkOption.NOFOLLOW_LINKS) ||
                 Files.exists(helperRoot, LinkOption.NOFOLLOW_LINKS)
         if (!hasManagedSurface) {
-            return DoctorCheckResult(
-                id = CHECK_ID,
-                status = DoctorCheckStatus.PASS,
+            return pass(
                 message = "Bootstrap files were not detected in the current working directory.",
                 details = mapOf("projectRoot" to projectRoot.toString()),
             )
@@ -86,9 +76,7 @@ internal object DoctorBootstrapStateCheck {
 
         return when {
             invalidBootstrapFiles.isNotEmpty() ->
-                DoctorCheckResult(
-                    id = CHECK_ID,
-                    status = DoctorCheckStatus.FAIL,
+                failure(
                     message =
                     "Bootstrap paths are invalid. Remove the conflicting paths. " +
                         "Run 'microsmith init' to repair them.",
@@ -99,9 +87,7 @@ internal object DoctorBootstrapStateCheck {
                 )
 
             missingBootstrapFiles.isNotEmpty() ->
-                DoctorCheckResult(
-                    id = CHECK_ID,
-                    status = DoctorCheckStatus.FAIL,
+                failure(
                     message = "Bootstrap state is incomplete. Run 'microsmith init' to repair it.",
                     details =
                     mapOf(
@@ -110,9 +96,7 @@ internal object DoctorBootstrapStateCheck {
                 )
 
             managedPathExists(helperRoot) && !Files.isDirectory(helperRoot, LinkOption.NOFOLLOW_LINKS) ->
-                DoctorCheckResult(
-                    id = CHECK_ID,
-                    status = DoctorCheckStatus.FAIL,
+                failure(
                     message =
                     "JetBrains IDE helper path is invalid. " +
                         "Run 'microsmith ide refresh' after removing the conflicting path.",
@@ -155,6 +139,21 @@ internal object DoctorBootstrapStateCheck {
     private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
 
     private fun isManagedRegularFile(path: Path): Boolean = Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
+
+    private fun pass(message: String, details: Map<String, String> = emptyMap()): DoctorCheckResult = DoctorCheckResult(
+        id = CHECK_ID,
+        status = DoctorCheckStatus.PASS,
+        message = message,
+        details = details,
+    )
+
+    private fun failure(message: String, details: Map<String, String> = emptyMap()): DoctorCheckResult =
+        DoctorCheckResult(
+            id = CHECK_ID,
+            status = DoctorCheckStatus.FAIL,
+            message = message,
+            details = details,
+        )
 }
 
 private const val CHECK_ID = "bootstrap-state"

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorEnvironmentChecks.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorEnvironmentChecks.kt
@@ -30,19 +30,20 @@ internal object DoctorEnvironmentChecks {
     fun checkProviderDiscovery(providerValidator: () -> List<String>): DoctorCheckResult {
         return try {
             val errors = providerValidator()
-            if (errors.isNotEmpty()) {
-                return DoctorCheckResult(
+            if (errors.isEmpty()) {
+                DoctorCheckResult(
+                    id = "provider-discovery",
+                    status = DoctorCheckStatus.PASS,
+                    message = "Required built-in service providers are available.",
+                )
+            } else {
+                DoctorCheckResult(
                     id = "provider-discovery",
                     status = DoctorCheckStatus.FAIL,
                     message = "Required built-in service providers are missing.",
                     details = mapOf("errors" to errors.joinToString(" | ")),
                 )
             }
-            DoctorCheckResult(
-                id = "provider-discovery",
-                status = DoctorCheckStatus.PASS,
-                message = "Required built-in service providers are available.",
-            )
         } catch (error: ServiceConfigurationError) {
             DoctorCheckResult(
                 id = "provider-discovery",

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorEnvironmentChecks.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorEnvironmentChecks.kt
@@ -9,15 +9,8 @@ import kotlin.io.path.deleteIfExists
 internal object DoctorEnvironmentChecks {
     fun checkJavaRuntime(minSupportedJavaFeature: Int = MIN_SUPPORTED_JAVA_FEATURE): DoctorCheckResult {
         val feature = Runtime.version().feature()
-        return if (feature >= minSupportedJavaFeature) {
-            DoctorCheckResult(
-                id = "java-runtime",
-                status = DoctorCheckStatus.PASS,
-                message = "Detected Java runtime feature $feature (minimum is $minSupportedJavaFeature).",
-                details = mapOf("feature" to feature.toString()),
-            )
-        } else {
-            DoctorCheckResult(
+        if (feature < minSupportedJavaFeature) {
+            return DoctorCheckResult(
                 id = "java-runtime",
                 status = DoctorCheckStatus.FAIL,
                 message =
@@ -26,31 +19,38 @@ internal object DoctorEnvironmentChecks {
                 details = mapOf("feature" to feature.toString()),
             )
         }
+        return DoctorCheckResult(
+            id = "java-runtime",
+            status = DoctorCheckStatus.PASS,
+            message = "Detected Java runtime feature $feature (minimum is $minSupportedJavaFeature).",
+            details = mapOf("feature" to feature.toString()),
+        )
     }
 
-    fun checkProviderDiscovery(providerValidator: () -> List<String>): DoctorCheckResult = try {
-        val errors = providerValidator()
-        if (errors.isEmpty()) {
+    fun checkProviderDiscovery(providerValidator: () -> List<String>): DoctorCheckResult {
+        return try {
+            val errors = providerValidator()
+            if (errors.isNotEmpty()) {
+                return DoctorCheckResult(
+                    id = "provider-discovery",
+                    status = DoctorCheckStatus.FAIL,
+                    message = "Required built-in service providers are missing.",
+                    details = mapOf("errors" to errors.joinToString(" | ")),
+                )
+            }
             DoctorCheckResult(
                 id = "provider-discovery",
                 status = DoctorCheckStatus.PASS,
                 message = "Required built-in service providers are available.",
             )
-        } else {
+        } catch (error: ServiceConfigurationError) {
             DoctorCheckResult(
                 id = "provider-discovery",
                 status = DoctorCheckStatus.FAIL,
-                message = "Required built-in service providers are missing.",
-                details = mapOf("errors" to errors.joinToString(" | ")),
+                message = "Service provider loading failed.",
+                details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
             )
         }
-    } catch (error: ServiceConfigurationError) {
-        DoctorCheckResult(
-            id = "provider-discovery",
-            status = DoctorCheckStatus.FAIL,
-            message = "Service provider loading failed.",
-            details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
-        )
     }
 
     fun checkDirectoryWritable(id: String, directory: Path): DoctorCheckResult = runCatching {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorPaths.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/doctor/DoctorPaths.kt
@@ -4,9 +4,8 @@ import java.nio.file.Path
 
 internal fun defaultScriptCacheDirectory(): Path {
     val envPath = System.getenv("MICROSMITH_SCRIPT_CACHE_DIR")?.trim()?.takeIf { it.isNotEmpty() }
-    return if (envPath != null) {
-        Path.of(envPath)
-    } else {
-        Path.of(System.getProperty("user.home"), ".microsmith", "cache", "scripts")
+    if (envPath == null) {
+        return Path.of(System.getProperty("user.home"), ".microsmith", "cache", "scripts")
     }
+    return Path.of(envPath)
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/DoctorCommandHandler.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/DoctorCommandHandler.kt
@@ -16,9 +16,9 @@ internal class DoctorCommandHandler(
             val details = mapOf("check" to check.id) + check.details
             if (check.status == DoctorCheckStatus.PASS) {
                 emitter.info("doctor/${check.id}: ${check.message}", details)
-                return@forEach
+            } else {
+                emitter.error(CliFailureCode.DOCTOR_FAILED, "doctor/${check.id}: ${check.message}", details)
             }
-            emitter.error(CliFailureCode.DOCTOR_FAILED, "doctor/${check.id}: ${check.message}", details)
         }
 
         if (!result.hasFailures) {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/DoctorCommandHandler.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/DoctorCommandHandler.kt
@@ -16,17 +16,16 @@ internal class DoctorCommandHandler(
             val details = mapOf("check" to check.id) + check.details
             if (check.status == DoctorCheckStatus.PASS) {
                 emitter.info("doctor/${check.id}: ${check.message}", details)
-            } else {
-                emitter.error(CliFailureCode.DOCTOR_FAILED, "doctor/${check.id}: ${check.message}", details)
+                return@forEach
             }
+            emitter.error(CliFailureCode.DOCTOR_FAILED, "doctor/${check.id}: ${check.message}", details)
         }
 
-        return if (result.hasFailures) {
-            emitter.error(CliFailureCode.DOCTOR_FAILED, "Doctor detected environment issues.")
-            CliFailureCode.DOCTOR_FAILED.exitCode
-        } else {
+        if (!result.hasFailures) {
             emitter.info("Doctor checks passed.")
-            0
+            return 0
         }
+        emitter.error(CliFailureCode.DOCTOR_FAILED, "Doctor detected environment issues.")
+        return CliFailureCode.DOCTOR_FAILED.exitCode
     }
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/IdeDoctorCommandHandler.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/IdeDoctorCommandHandler.kt
@@ -24,13 +24,13 @@ internal class IdeDoctorCommandHandler(
         result.checks.forEach { check ->
             if (check.passed) {
                 emitter.info("ide-doctor/${check.id}: ${check.message}", check.details)
-                return@forEach
+            } else {
+                emitter.error(
+                    CliFailureCode.IDE_DOCTOR_FAILED,
+                    "ide-doctor/${check.id}: ${check.message}",
+                    check.details,
+                )
             }
-            emitter.error(
-                CliFailureCode.IDE_DOCTOR_FAILED,
-                "ide-doctor/${check.id}: ${check.message}",
-                check.details,
-            )
         }
 
         if (!result.hasFailures) {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/IdeDoctorCommandHandler.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/IdeDoctorCommandHandler.kt
@@ -24,21 +24,20 @@ internal class IdeDoctorCommandHandler(
         result.checks.forEach { check ->
             if (check.passed) {
                 emitter.info("ide-doctor/${check.id}: ${check.message}", check.details)
-            } else {
-                emitter.error(
-                    CliFailureCode.IDE_DOCTOR_FAILED,
-                    "ide-doctor/${check.id}: ${check.message}",
-                    check.details,
-                )
+                return@forEach
             }
+            emitter.error(
+                CliFailureCode.IDE_DOCTOR_FAILED,
+                "ide-doctor/${check.id}: ${check.message}",
+                check.details,
+            )
         }
 
-        return if (result.hasFailures) {
-            emitter.error(CliFailureCode.IDE_DOCTOR_FAILED, "JetBrains IDE helper doctor detected issues.")
-            CliFailureCode.IDE_DOCTOR_FAILED.exitCode
-        } else {
+        if (!result.hasFailures) {
             emitter.info("JetBrains IDE helper doctor checks passed.")
-            0
+            return 0
         }
+        emitter.error(CliFailureCode.IDE_DOCTOR_FAILED, "JetBrains IDE helper doctor detected issues.")
+        return CliFailureCode.IDE_DOCTOR_FAILED.exitCode
     }
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorChecks.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/ide/IdeHelperDoctorChecks.kt
@@ -96,29 +96,28 @@ internal object IdeHelperDoctorChecks {
         val buildFile = IdeHelperManagedSurface.buildFile(helperRoot)
         val buildFileContent = readManagedUtf8TextOrNull(buildFile)
         val missingClasspathEntries =
-            if (buildFileContent == null) {
-                classpathEntries
-            } else {
-                classpathEntries.filterNot { entry -> buildFileContent.contains(entry.toKotlinPathLiteral()) }
-            }
-        return if (missingClasspathEntries.isEmpty()) {
-            IdeDoctorCheckResult(
+            buildFileContent
+                ?.let { content ->
+                    classpathEntries.filterNot { entry -> content.contains(entry.toKotlinPathLiteral()) }
+                }
+                ?: classpathEntries
+        if (missingClasspathEntries.isEmpty()) {
+            return IdeDoctorCheckResult(
                 id = "classpath-sync",
                 passed = true,
                 message = "IDE helper build file is synchronized with runtime classpath.",
             )
-        } else {
-            IdeDoctorCheckResult(
-                id = "classpath-sync",
-                passed = false,
-                message = "IDE helper build file is stale. Run 'microsmith ide refresh'.",
-                details =
-                mapOf(
-                    "missingClasspathEntries" to missingClasspathEntries.size.toString(),
-                    "firstMissingClasspathEntry" to missingClasspathEntries.first().toString(),
-                ),
-            )
         }
+        return IdeDoctorCheckResult(
+            id = "classpath-sync",
+            passed = false,
+            message = "IDE helper build file is stale. Run 'microsmith ide refresh'.",
+            details =
+            mapOf(
+                "missingClasspathEntries" to missingClasspathEntries.size.toString(),
+                "firstMissingClasspathEntry" to missingClasspathEntries.first().toString(),
+            ),
+        )
     }
 
     private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
@@ -128,10 +127,9 @@ internal object IdeHelperDoctorChecks {
     private fun readManagedUtf8TextOrNull(path: Path): String? {
         return try {
             if (!isManagedRegularFile(path)) {
-                null
-            } else {
-                Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n")
+                return null
             }
+            Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n")
         } catch (_: IOException) {
             null
         } catch (_: SecurityException) {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
@@ -31,9 +31,10 @@ internal object JavaOnboardingMarkerFinder {
 
             val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot)
             if (matchedModuleSourceMarkers.isEmpty()) {
-                return emptyList()
+                emptyList()
+            } else {
+                (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
             }
-            (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
         } catch (_: IOException) {
             emptyList()
         } catch (_: UncheckedIOException) {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
@@ -23,17 +23,17 @@ internal object JavaOnboardingMarkerFinder {
                 }
 
             if (matchedSourceMarkers.isNotEmpty()) {
-                (matchedBuildMarkers + matchedSourceMarkers).sorted()
-            } else if (matchedBuildMarkers.isEmpty()) {
-                emptyList()
-            } else {
-                val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot)
-                if (matchedModuleSourceMarkers.isEmpty()) {
-                    emptyList()
-                } else {
-                    (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
-                }
+                return (matchedBuildMarkers + matchedSourceMarkers).sorted()
             }
+            if (matchedBuildMarkers.isEmpty()) {
+                return emptyList()
+            }
+
+            val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot)
+            if (matchedModuleSourceMarkers.isEmpty()) {
+                return emptyList()
+            }
+            (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
         } catch (_: IOException) {
             emptyList()
         } catch (_: UncheckedIOException) {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetector.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetector.kt
@@ -26,24 +26,21 @@ internal class OnboardingProfileDetector(
 
         val matchedProfiles = matches.map(OnboardingProfileMatch::profile).distinctBy(OnboardingProfile::id)
         val matchedMarkers = matches.flatMap(OnboardingProfileMatch::matchedMarkers).distinct().sorted()
-        if (matchedProfiles.isEmpty()) {
-            return OnboardingProfileDetection(
-                profile = fallbackProfile,
-                selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
-                matchedMarkers = matchedMarkers,
-            )
-        }
-        if (matchedProfiles.size == 1) {
-            return OnboardingProfileDetection(
-                profile = matchedProfiles.single(),
-                selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
-                matchedMarkers = matchedMarkers,
-            )
-        }
+        val (profile, selectionReason) =
+            when {
+                matchedProfiles.isEmpty() ->
+                    fallbackProfile to OnboardingProfileSelectionReason.NO_MARKERS_MATCHED
+
+                matchedProfiles.size == 1 ->
+                    matchedProfiles.single() to OnboardingProfileSelectionReason.MATCHED_PROFILE
+
+                else ->
+                    fallbackProfile to OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS
+            }
 
         return OnboardingProfileDetection(
-            profile = fallbackProfile,
-            selectionReason = OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
+            profile = profile,
+            selectionReason = selectionReason,
             matchedMarkers = matchedMarkers,
         )
     }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetector.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetector.kt
@@ -14,35 +14,37 @@ internal class OnboardingProfileDetector(
         val matches =
             matchers.mapNotNull { matcher ->
                 val matchedMarkers = matcher.detect(projectRoot).sorted()
-                if (matchedMarkers.isEmpty()) {
-                    null
-                } else {
-                    OnboardingProfileMatch(
-                        profile = matcher.profile,
-                        matchedMarkers = matchedMarkers,
-                    )
-                }
+                matchedMarkers
+                    .takeIf(List<String>::isNotEmpty)
+                    ?.let {
+                        OnboardingProfileMatch(
+                            profile = matcher.profile,
+                            matchedMarkers = it,
+                        )
+                    }
             }
 
         val matchedProfiles = matches.map(OnboardingProfileMatch::profile).distinctBy(OnboardingProfile::id)
-        val selectionReason =
-            when (matchedProfiles.size) {
-                0 -> OnboardingProfileSelectionReason.NO_MARKERS_MATCHED
-                1 -> OnboardingProfileSelectionReason.MATCHED_PROFILE
-                else -> OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS
-            }
-        val resolvedProfile =
-            when (selectionReason) {
-                OnboardingProfileSelectionReason.MATCHED_PROFILE -> matchedProfiles.single()
-                OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
-                OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
-                -> fallbackProfile
-            }
+        val matchedMarkers = matches.flatMap(OnboardingProfileMatch::matchedMarkers).distinct().sorted()
+        if (matchedProfiles.isEmpty()) {
+            return OnboardingProfileDetection(
+                profile = fallbackProfile,
+                selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                matchedMarkers = matchedMarkers,
+            )
+        }
+        if (matchedProfiles.size == 1) {
+            return OnboardingProfileDetection(
+                profile = matchedProfiles.single(),
+                selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                matchedMarkers = matchedMarkers,
+            )
+        }
 
         return OnboardingProfileDetection(
-            profile = resolvedProfile,
-            selectionReason = selectionReason,
-            matchedMarkers = matches.flatMap(OnboardingProfileMatch::matchedMarkers).distinct().sorted(),
+            profile = fallbackProfile,
+            selectionReason = OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
+            matchedMarkers = matchedMarkers,
         )
     }
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliOptionValueParsers.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/CliOptionValueParsers.kt
@@ -8,24 +8,7 @@ private const val PLUGIN_COORDINATE_PART_COUNT = 3
 
 internal fun parseVariableValue(value: String?): ParsedVariable = when {
     value == null || value.startsWith("--") -> ParsedVariable(error = "Missing value for --var option.")
-
-    else -> {
-        val separatorIndex = value.indexOf('=')
-        val key =
-            if (separatorIndex > 0) {
-                value.take(separatorIndex).trim()
-            } else {
-                ""
-            }
-        if (separatorIndex <= 0 || key.isBlank()) {
-            ParsedVariable(error = "Invalid --var value '$value'. Expected key=value.")
-        } else {
-            ParsedVariable(
-                key = key,
-                value = value.substring(separatorIndex + 1),
-            )
-        }
-    }
+    else -> parseVariableAssignment(value)
 }
 
 internal fun parseFlagValue(value: String?): String? = value
@@ -93,16 +76,30 @@ internal inline fun parseRepoRootOption(
     onSuccess: (Path) -> Unit,
 ): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val error =
-        when {
-            value == null || value.startsWith("--") -> "Missing value for --repo-root option."
-            alreadySpecified -> "--repo-root may only be specified once."
-            else -> null
-        }
-    if (error != null) {
-        return ParsedToken(nextIndex = index, error = error)
+    if (value == null || value.startsWith("--")) {
+        return ParsedToken(nextIndex = index, error = "Missing value for --repo-root option.")
+    }
+    if (alreadySpecified) {
+        return ParsedToken(nextIndex = index, error = "--repo-root may only be specified once.")
     }
 
     onSuccess(Path.of(value))
     return ParsedToken(nextIndex = index + 2)
+}
+
+private fun parseVariableAssignment(value: String): ParsedVariable {
+    val separatorIndex = value.indexOf('=')
+    if (separatorIndex <= 0) {
+        return ParsedVariable(error = "Invalid --var value '$value'. Expected key=value.")
+    }
+
+    val key = value.take(separatorIndex).trim()
+    if (key.isBlank()) {
+        return ParsedVariable(error = "Invalid --var value '$value'. Expected key=value.")
+    }
+
+    return ParsedVariable(
+        key = key,
+        value = value.substring(separatorIndex + 1),
+    )
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/DiagnosticOptionsState.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/DiagnosticOptionsState.kt
@@ -15,21 +15,22 @@ internal class DiagnosticOptionsState {
 
     fun consumeDiagnostics(args: List<String>, index: Int): Int {
         val value = args.getOrNull(index + 1)
-        val parsedFormat = parseDiagnosticFormat(value)
         if (value == null || value.startsWith("--")) {
             error = "Missing value for --diagnostics option."
             return 0
         }
-        if (diagnosticsSpecified) {
-            error = "--diagnostics may only be specified once."
-            return 0
-        }
-        if (parsedFormat == null) {
-            error = "Invalid --diagnostics value '$value'. Expected 'text' or 'json'."
+        val parsedFormat = parseDiagnosticFormat(value)
+        error =
+            when {
+                diagnosticsSpecified -> "--diagnostics may only be specified once."
+                parsedFormat == null -> "Invalid --diagnostics value '$value'. Expected 'text' or 'json'."
+                else -> null
+            }
+        if (error != null) {
             return 0
         }
 
-        diagnosticsFormat = parsedFormat
+        diagnosticsFormat = requireNotNull(parsedFormat)
         diagnosticsSpecified = true
         return 2
     }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/DiagnosticOptionsState.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/DiagnosticOptionsState.kt
@@ -16,19 +16,20 @@ internal class DiagnosticOptionsState {
     fun consumeDiagnostics(args: List<String>, index: Int): Int {
         val value = args.getOrNull(index + 1)
         val parsedFormat = parseDiagnosticFormat(value)
-        error =
-            when {
-                value == null || value.startsWith("--") -> "Missing value for --diagnostics option."
-                diagnosticsSpecified -> "--diagnostics may only be specified once."
-                parsedFormat == null -> "Invalid --diagnostics value '$value'. Expected 'text' or 'json'."
-                else -> null
-            }
-
-        if (error != null) {
+        if (value == null || value.startsWith("--")) {
+            error = "Missing value for --diagnostics option."
+            return 0
+        }
+        if (diagnosticsSpecified) {
+            error = "--diagnostics may only be specified once."
+            return 0
+        }
+        if (parsedFormat == null) {
+            error = "Invalid --diagnostics value '$value'. Expected 'text' or 'json'."
             return 0
         }
 
-        diagnosticsFormat = requireNotNull(parsedFormat)
+        diagnosticsFormat = parsedFormat
         diagnosticsSpecified = true
         return 2
     }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/DoctorCommandParser.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/DoctorCommandParser.kt
@@ -6,14 +6,11 @@ import me.liam.microsmith.cli.command.ErrorCommand
 
 internal fun parseDoctorCommand(args: List<String>): CliCommand {
     val parsed = parseDoctorOptions(args = args, startIndex = 1)
-    return if (parsed.error != null) {
-        ErrorCommand(parsed.error)
-    } else {
-        DoctorCommand(
-            diagnosticsFormat = parsed.diagnosticsFormat,
-            verbose = parsed.verbose,
-        )
-    }
+    parsed.error?.let { return ErrorCommand(it) }
+    return DoctorCommand(
+        diagnosticsFormat = parsed.diagnosticsFormat,
+        verbose = parsed.verbose,
+    )
 }
 
 private fun parseDoctorOptions(args: List<String>, startIndex: Int): ParsedDoctorOptions {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/IdeCommandParser.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/IdeCommandParser.kt
@@ -15,28 +15,22 @@ internal fun parseIdeCommand(args: List<String>): CliCommand = when (val subcomm
 
 private fun parseIdeRefreshCommand(args: List<String>, startIndex: Int): CliCommand {
     val parsed = parseIdeOptions(args = args, startIndex = startIndex)
-    return if (parsed.error != null) {
-        ErrorCommand(parsed.error)
-    } else {
-        IdeRefreshCommand(
-            projectRoot = parsed.projectRoot,
-            diagnosticsFormat = parsed.diagnosticsFormat,
-            verbose = parsed.verbose,
-        )
-    }
+    parsed.error?.let { return ErrorCommand(it) }
+    return IdeRefreshCommand(
+        projectRoot = parsed.projectRoot,
+        diagnosticsFormat = parsed.diagnosticsFormat,
+        verbose = parsed.verbose,
+    )
 }
 
 private fun parseIdeDoctorCommand(args: List<String>, startIndex: Int): CliCommand {
     val parsed = parseIdeOptions(args = args, startIndex = startIndex)
-    return if (parsed.error != null) {
-        ErrorCommand(parsed.error)
-    } else {
-        IdeDoctorCommand(
-            projectRoot = parsed.projectRoot,
-            diagnosticsFormat = parsed.diagnosticsFormat,
-            verbose = parsed.verbose,
-        )
-    }
+    parsed.error?.let { return ErrorCommand(it) }
+    return IdeDoctorCommand(
+        projectRoot = parsed.projectRoot,
+        diagnosticsFormat = parsed.diagnosticsFormat,
+        verbose = parsed.verbose,
+    )
 }
 
 private fun parseIdeOptions(args: List<String>, startIndex: Int): ParsedIdeOptions {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/InitCommandParser.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/InitCommandParser.kt
@@ -7,17 +7,14 @@ import java.nio.file.Path
 
 internal fun parseInitCommand(args: List<String>): CliCommand {
     val parsed = parseInitOptions(args = args, startIndex = 1)
-    return if (parsed.error != null) {
-        ErrorCommand(parsed.error)
-    } else {
-        InitCommand(
-            projectRoot = parsed.projectRoot,
-            diagnosticsFormat = parsed.diagnosticsFormat,
-            verbose = parsed.verbose,
-            force = parsed.force,
-            skipIdeHelper = parsed.skipIdeHelper,
-        )
-    }
+    parsed.error?.let { return ErrorCommand(it) }
+    return InitCommand(
+        projectRoot = parsed.projectRoot,
+        diagnosticsFormat = parsed.diagnosticsFormat,
+        verbose = parsed.verbose,
+        force = parsed.force,
+        skipIdeHelper = parsed.skipIdeHelper,
+    )
 }
 
 private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOptions {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunCommandParser.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunCommandParser.kt
@@ -26,23 +26,22 @@ private fun parseScriptArg(scriptArg: String?): Pair<Path?, String?> = when {
 
 private fun parseRunOptionsCommand(script: Path, args: List<String>, startIndex: Int): CliCommand {
     val parsedOptions = parseRunOptions(args, startIndex)
-    return when {
-        parsedOptions.error != null -> ErrorCommand(parsedOptions.error)
-        parsedOptions.outputDir == null -> ErrorCommand("Missing required --out <output-dir> option.")
-        else ->
-            RunCommand(
-                script = script,
-                outputDir = parsedOptions.outputDir,
-                variables = parsedOptions.variables,
-                flags = parsedOptions.flags,
-                plugins = parsedOptions.plugins,
-                pluginJars = parsedOptions.pluginJars,
-                offline = parsedOptions.offline,
-                repositoryOverride = parsedOptions.repositoryOverride,
-                isolationMode = parsedOptions.isolationMode,
-                diagnosticsFormat = parsedOptions.diagnosticsFormat,
-                verbose = parsedOptions.verbose,
-                eventLog = parsedOptions.eventLog,
-            )
-    }
+    parsedOptions.error?.let { return ErrorCommand(it) }
+    val outputDir =
+        parsedOptions.outputDir
+            ?: return ErrorCommand("Missing required --out <output-dir> option.")
+    return RunCommand(
+        script = script,
+        outputDir = outputDir,
+        variables = parsedOptions.variables,
+        flags = parsedOptions.flags,
+        plugins = parsedOptions.plugins,
+        pluginJars = parsedOptions.pluginJars,
+        offline = parsedOptions.offline,
+        repositoryOverride = parsedOptions.repositoryOverride,
+        isolationMode = parsedOptions.isolationMode,
+        diagnosticsFormat = parsedOptions.diagnosticsFormat,
+        verbose = parsedOptions.verbose,
+        eventLog = parsedOptions.eventLog,
+    )
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
@@ -135,17 +135,18 @@ private fun parseIsolationOption(args: List<String>, index: Int, state: RunOptio
     if (value == null || value.startsWith("--")) {
         return ParsedToken(nextIndex = index, error = "Missing value for --isolation option.")
     }
-    if (state.isolationModeSpecified) {
-        return ParsedToken(nextIndex = index, error = "--isolation may only be specified once.")
+    val parsedMode = parseIsolationMode(value)
+    val error =
+        when {
+            state.isolationModeSpecified -> "--isolation may only be specified once."
+            parsedMode == null -> "Invalid --isolation value '$value'. Expected 'classloader' or 'process'."
+            else -> null
+        }
+    if (error != null) {
+        return ParsedToken(nextIndex = index, error = error)
     }
-    val parsedMode =
-        parseIsolationMode(value)
-            ?: return ParsedToken(
-                nextIndex = index,
-                error = "Invalid --isolation value '$value'. Expected 'classloader' or 'process'.",
-            )
 
-    state.isolationMode = parsedMode
+    state.isolationMode = requireNotNull(parsedMode)
     state.isolationModeSpecified = true
     return ParsedToken(nextIndex = index + 2)
 }
@@ -155,17 +156,18 @@ private fun parseDiagnosticsOption(args: List<String>, index: Int, state: RunOpt
     if (value == null || value.startsWith("--")) {
         return ParsedToken(nextIndex = index, error = "Missing value for --diagnostics option.")
     }
-    if (state.diagnosticsFormatSpecified) {
-        return ParsedToken(nextIndex = index, error = "--diagnostics may only be specified once.")
+    val parsedFormat = parseDiagnosticFormat(value)
+    val error =
+        when {
+            state.diagnosticsFormatSpecified -> "--diagnostics may only be specified once."
+            parsedFormat == null -> "Invalid --diagnostics value '$value'. Expected 'text' or 'json'."
+            else -> null
+        }
+    if (error != null) {
+        return ParsedToken(nextIndex = index, error = error)
     }
-    val parsedFormat =
-        parseDiagnosticFormat(value)
-            ?: return ParsedToken(
-                nextIndex = index,
-                error = "Invalid --diagnostics value '$value'. Expected 'text' or 'json'.",
-            )
 
-    state.diagnosticsFormat = parsedFormat
+    state.diagnosticsFormat = requireNotNull(parsedFormat)
     state.diagnosticsFormatSpecified = true
     return ParsedToken(nextIndex = index + 2)
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
@@ -33,13 +33,12 @@ private fun parseRunOptionToken(args: List<String>, index: Int, state: RunOption
 
 private fun parseOutputOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val error = validateOutputValue(value, state.outputDir != null)
-    return if (error != null) {
-        ParsedToken(nextIndex = index, error = error)
-    } else {
-        state.outputDir = Path.of(requireNotNull(value))
-        ParsedToken(nextIndex = index + 2)
+    validateOutputValue(value, state.outputDir != null)?.let { error ->
+        return ParsedToken(nextIndex = index, error = error)
     }
+
+    state.outputDir = Path.of(requireNotNull(value))
+    return ParsedToken(nextIndex = index + 2)
 }
 
 private fun validateOutputValue(value: String?, outputDirAlreadySet: Boolean): String? = when {
@@ -51,158 +50,143 @@ private fun validateOutputValue(value: String?, outputDirAlreadySet: Boolean): S
 private fun parseVariableOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
     val parsedVariable = parseVariableValue(value)
-    val duplicate = parsedVariable.error == null && state.variables.containsKey(parsedVariable.key)
-
-    return when {
-        parsedVariable.error != null -> ParsedToken(nextIndex = index, error = parsedVariable.error)
-        duplicate -> ParsedToken(nextIndex = index, error = "--var '${parsedVariable.key}' may only be specified once.")
-        else -> {
-            state.variables[parsedVariable.key] = parsedVariable.value
-            ParsedToken(nextIndex = index + 2)
-        }
+    parsedVariable.error?.let { error ->
+        return ParsedToken(nextIndex = index, error = error)
     }
+    if (state.variables.containsKey(parsedVariable.key)) {
+        return ParsedToken(nextIndex = index, error = "--var '${parsedVariable.key}' may only be specified once.")
+    }
+
+    state.variables[parsedVariable.key] = parsedVariable.value
+    return ParsedToken(nextIndex = index + 2)
 }
 
 private fun parseFlagOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
     val flag = parseFlagValue(value)
-    val duplicate = flag != null && state.flags.contains(flag)
-
-    return when {
-        flag == null -> ParsedToken(nextIndex = index, error = "Missing value for --flag option.")
-        duplicate -> ParsedToken(nextIndex = index, error = "--flag '$flag' may only be specified once.")
-        else -> {
-            state.flags.add(flag)
-            ParsedToken(nextIndex = index + 2)
-        }
+    if (flag == null) {
+        return ParsedToken(nextIndex = index, error = "Missing value for --flag option.")
     }
+    if (state.flags.contains(flag)) {
+        return ParsedToken(nextIndex = index, error = "--flag '$flag' may only be specified once.")
+    }
+
+    state.flags.add(flag)
+    return ParsedToken(nextIndex = index + 2)
 }
 
 private fun parsePluginOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
     val pluginCoordinate = parsePluginCoordinate(value)
-    val duplicate = pluginCoordinate != null && state.plugins.contains(pluginCoordinate)
-
-    return when {
-        pluginCoordinate == null ->
-            ParsedToken(
-                nextIndex = index,
-                error = "Invalid --plugin value '$value'. Expected group:artifact:version.",
-            )
-
-        duplicate ->
-            ParsedToken(
-                nextIndex = index,
-                error = "--plugin '$pluginCoordinate' may only be specified once.",
-            )
-
-        else -> {
-            state.plugins.add(pluginCoordinate)
-            ParsedToken(nextIndex = index + 2)
-        }
+    if (pluginCoordinate == null) {
+        return ParsedToken(
+            nextIndex = index,
+            error = "Invalid --plugin value '$value'. Expected group:artifact:version.",
+        )
     }
+    if (state.plugins.contains(pluginCoordinate)) {
+        return ParsedToken(
+            nextIndex = index,
+            error = "--plugin '$pluginCoordinate' may only be specified once.",
+        )
+    }
+
+    state.plugins.add(pluginCoordinate)
+    return ParsedToken(nextIndex = index + 2)
 }
 
 private fun parsePluginJarOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
     val pluginJar = value?.takeUnless { it.startsWith("--") }?.let(Path::of)
-    val duplicate = pluginJar != null && state.pluginJars.contains(pluginJar)
-
-    return when {
-        pluginJar == null -> ParsedToken(nextIndex = index, error = "Missing value for --plugin-jar option.")
-        duplicate -> ParsedToken(nextIndex = index, error = "--plugin-jar '$pluginJar' may only be specified once.")
-        else -> {
-            state.pluginJars.add(pluginJar)
-            ParsedToken(nextIndex = index + 2)
-        }
+    if (pluginJar == null) {
+        return ParsedToken(nextIndex = index, error = "Missing value for --plugin-jar option.")
     }
+    if (state.pluginJars.contains(pluginJar)) {
+        return ParsedToken(nextIndex = index, error = "--plugin-jar '$pluginJar' may only be specified once.")
+    }
+
+    state.pluginJars.add(pluginJar)
+    return ParsedToken(nextIndex = index + 2)
 }
 
-private fun parseOfflineOption(index: Int, state: RunOptionsState): ParsedToken = if (state.offline) {
-    ParsedToken(nextIndex = index, error = "--offline may only be specified once.")
-} else {
+private fun parseOfflineOption(index: Int, state: RunOptionsState): ParsedToken = parseSingleOccurrenceFlag(
+    index = index,
+    alreadySpecified = state.offline,
+    optionName = "--offline",
+) {
     state.offline = true
-    ParsedToken(nextIndex = index + 1)
 }
 
 private fun parseRepositoryOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val missingValue = value == null || value.startsWith("--")
-    val duplicate = state.repositoryOverride != null
-
-    return when {
-        missingValue -> ParsedToken(nextIndex = index, error = "Missing value for --repository option.")
-        duplicate -> ParsedToken(nextIndex = index, error = "--repository may only be specified once.")
-        else -> {
-            state.repositoryOverride = value
-            ParsedToken(nextIndex = index + 2)
-        }
+    if (value == null || value.startsWith("--")) {
+        return ParsedToken(nextIndex = index, error = "Missing value for --repository option.")
     }
+    if (state.repositoryOverride != null) {
+        return ParsedToken(nextIndex = index, error = "--repository may only be specified once.")
+    }
+
+    state.repositoryOverride = value
+    return ParsedToken(nextIndex = index + 2)
 }
 
 private fun parseIsolationOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val parsedMode = parseIsolationMode(value)
-    val duplicate = state.isolationModeSpecified
-
-    return when {
-        value == null || value.startsWith("--") ->
-            ParsedToken(nextIndex = index, error = "Missing value for --isolation option.")
-
-        duplicate -> ParsedToken(nextIndex = index, error = "--isolation may only be specified once.")
-        parsedMode == null ->
-            ParsedToken(
+    if (value == null || value.startsWith("--")) {
+        return ParsedToken(nextIndex = index, error = "Missing value for --isolation option.")
+    }
+    if (state.isolationModeSpecified) {
+        return ParsedToken(nextIndex = index, error = "--isolation may only be specified once.")
+    }
+    val parsedMode =
+        parseIsolationMode(value)
+            ?: return ParsedToken(
                 nextIndex = index,
                 error = "Invalid --isolation value '$value'. Expected 'classloader' or 'process'.",
             )
 
-        else -> {
-            state.isolationMode = parsedMode
-            state.isolationModeSpecified = true
-            ParsedToken(nextIndex = index + 2)
-        }
-    }
+    state.isolationMode = parsedMode
+    state.isolationModeSpecified = true
+    return ParsedToken(nextIndex = index + 2)
 }
 
 private fun parseDiagnosticsOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val parsedFormat = parseDiagnosticFormat(value)
-    val duplicate = state.diagnosticsFormatSpecified
-
-    return when {
-        value == null || value.startsWith("--") ->
-            ParsedToken(nextIndex = index, error = "Missing value for --diagnostics option.")
-
-        duplicate -> ParsedToken(nextIndex = index, error = "--diagnostics may only be specified once.")
-        parsedFormat == null ->
-            ParsedToken(nextIndex = index, error = "Invalid --diagnostics value '$value'. Expected 'text' or 'json'.")
-
-        else -> {
-            state.diagnosticsFormat = parsedFormat
-            state.diagnosticsFormatSpecified = true
-            ParsedToken(nextIndex = index + 2)
-        }
+    if (value == null || value.startsWith("--")) {
+        return ParsedToken(nextIndex = index, error = "Missing value for --diagnostics option.")
     }
+    if (state.diagnosticsFormatSpecified) {
+        return ParsedToken(nextIndex = index, error = "--diagnostics may only be specified once.")
+    }
+    val parsedFormat =
+        parseDiagnosticFormat(value)
+            ?: return ParsedToken(
+                nextIndex = index,
+                error = "Invalid --diagnostics value '$value'. Expected 'text' or 'json'.",
+            )
+
+    state.diagnosticsFormat = parsedFormat
+    state.diagnosticsFormatSpecified = true
+    return ParsedToken(nextIndex = index + 2)
 }
 
-private fun parseVerboseOption(index: Int, state: RunOptionsState): ParsedToken = if (state.verbose) {
-    ParsedToken(nextIndex = index, error = "--verbose may only be specified once.")
-} else {
+private fun parseVerboseOption(index: Int, state: RunOptionsState): ParsedToken = parseSingleOccurrenceFlag(
+    index = index,
+    alreadySpecified = state.verbose,
+    optionName = "--verbose",
+) {
     state.verbose = true
-    ParsedToken(nextIndex = index + 1)
 }
 
 private fun parseEventLogOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val missingValue = value == null || value.startsWith("--")
-    val duplicate = state.eventLog != null
-
-    return when {
-        missingValue -> ParsedToken(nextIndex = index, error = "Missing value for --event-log option.")
-        duplicate -> ParsedToken(nextIndex = index, error = "--event-log may only be specified once.")
-        else -> {
-            state.eventLog = Path.of(value)
-            ParsedToken(nextIndex = index + 2)
-        }
+    if (value == null || value.startsWith("--")) {
+        return ParsedToken(nextIndex = index, error = "Missing value for --event-log option.")
     }
+    if (state.eventLog != null) {
+        return ParsedToken(nextIndex = index, error = "--event-log may only be specified once.")
+    }
+
+    state.eventLog = Path.of(value)
+    return ParsedToken(nextIndex = index + 2)
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/parsing/RunOptionsParser.kt
@@ -63,10 +63,8 @@ private fun parseVariableOption(args: List<String>, index: Int, state: RunOption
 
 private fun parseFlagOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val flag = parseFlagValue(value)
-    if (flag == null) {
-        return ParsedToken(nextIndex = index, error = "Missing value for --flag option.")
-    }
+    val flag =
+        parseFlagValue(value) ?: return ParsedToken(nextIndex = index, error = "Missing value for --flag option.")
     if (state.flags.contains(flag)) {
         return ParsedToken(nextIndex = index, error = "--flag '$flag' may only be specified once.")
     }
@@ -77,13 +75,10 @@ private fun parseFlagOption(args: List<String>, index: Int, state: RunOptionsSta
 
 private fun parsePluginOption(args: List<String>, index: Int, state: RunOptionsState): ParsedToken {
     val value = args.getOrNull(index + 1)
-    val pluginCoordinate = parsePluginCoordinate(value)
-    if (pluginCoordinate == null) {
-        return ParsedToken(
-            nextIndex = index,
-            error = "Invalid --plugin value '$value'. Expected group:artifact:version.",
-        )
-    }
+    val pluginCoordinate = parsePluginCoordinate(value) ?: return ParsedToken(
+        nextIndex = index,
+        error = "Invalid --plugin value '$value'. Expected group:artifact:version.",
+    )
     if (state.plugins.contains(pluginCoordinate)) {
         return ParsedToken(
             nextIndex = index,

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/DefaultRepositoryCredentialsResolver.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/DefaultRepositoryCredentialsResolver.kt
@@ -36,10 +36,7 @@ internal class DefaultRepositoryCredentialsResolver(
 
     private fun githubPackagesCredentialsFor(repositoryUri: String): RepositoryCredentials? {
         val host = URI.create(repositoryUri).host?.lowercase()
-        if (host != GITHUB_PACKAGES_HOST) {
-            return null
-        }
-        return githubPackagesCredentials
+        return githubPackagesCredentials.takeIf { host == GITHUB_PACKAGES_HOST }
     }
 }
 
@@ -60,12 +57,9 @@ internal fun defaultRepositoryCredentialsResolver(
     require(repositoryUsername.isNotEmpty() == repositoryPassword.isNotEmpty()) {
         "Set both $REPOSITORY_USERNAME_ENV and $REPOSITORY_PASSWORD_ENV, or leave both unset."
     }
-    val defaultCredentials =
-        if (repositoryUsername.isNotEmpty()) {
-            RepositoryCredentials(username = repositoryUsername, password = repositoryPassword)
-        } else {
-            null
-        }
+    val defaultCredentials = repositoryUsername.takeIf(String::isNotEmpty)?.let { username ->
+        RepositoryCredentials(username = username, password = repositoryPassword)
+    }
 
     val githubPackagesToken =
         githubPackagesTokenEnv
@@ -74,18 +68,15 @@ internal fun defaultRepositoryCredentialsResolver(
             ?: githubTokenEnv
                 ?.trim()
                 ?.takeIf(String::isNotEmpty)
-    val githubPackagesCredentials =
-        if (githubPackagesToken != null) {
-            val githubPackagesUsername = githubPackagesUsernameEnv?.trim()?.takeIf(String::isNotEmpty)
-            val githubActorUsername = githubActorEnv?.trim()?.takeIf(String::isNotEmpty)
-            val username =
-                githubPackagesUsername
-                    ?: githubActorUsername
-                    ?: DEFAULT_GITHUB_PACKAGES_USERNAME
-            RepositoryCredentials(username = username, password = githubPackagesToken)
-        } else {
-            null
-        }
+    val githubPackagesCredentials = githubPackagesToken?.let { token ->
+        val githubPackagesUsername = githubPackagesUsernameEnv?.trim()?.takeIf(String::isNotEmpty)
+        val githubActorUsername = githubActorEnv?.trim()?.takeIf(String::isNotEmpty)
+        val username =
+            githubPackagesUsername
+                ?: githubActorUsername
+                ?: DEFAULT_GITHUB_PACKAGES_USERNAME
+        RepositoryCredentials(username = username, password = token)
+    }
 
     return DefaultRepositoryCredentialsResolver(
         fileCredentialsByRepository = fileCredentials,

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/OfflinePluginCacheReadinessChecker.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/OfflinePluginCacheReadinessChecker.kt
@@ -6,40 +6,8 @@ import java.nio.file.Path
 /** Offline resolution requires a complete graph lock and matching cached jars and descriptors. */
 internal class OfflinePluginCacheReadinessChecker {
     fun assertReady(lockfile: ParsedLockfile?, lockfilePath: Path, cacheRoot: Path) {
-        val errorMessage =
-            when {
-                lockfile == null ->
-                    "Offline mode requires a plugin lockfile. " +
-                        "Generate '$lockfilePath' by running once without --offline."
-
-                else -> {
-                    val remoteArtifactEntries = lockfile.entries.filter { entry -> entry.kind == REMOTE_ARTIFACT_KIND }
-                    when {
-                        remoteArtifactEntries.isEmpty() ->
-                            "Offline mode requires locked remote dependency graph entries in '$lockfilePath'. " +
-                                "Regenerate the lockfile by running once without --offline."
-
-                        else -> {
-                            val missingArtifacts = findMissingArtifacts(remoteArtifactEntries, cacheRoot)
-                            if (missingArtifacts.isNotEmpty()) {
-                                "Offline mode is enabled but plugin cache is missing " +
-                                    "locked dependency graph artifacts: " +
-                                    missingArtifacts.sorted().joinToString(", ") +
-                                    ". Run once without --offline to restore the cache."
-                            } else {
-                                null
-                            }
-                        }
-                    }
-                }
-            }
-
-        if (errorMessage != null) {
-            throw PluginResolutionDiagnosticException(
-                category = PluginResolverErrorCategory.OFFLINE_CACHE_MISS,
-                message = errorMessage,
-            )
-        }
+        val failure = offlineCacheFailure(lockfile, lockfilePath, cacheRoot) ?: return
+        throw failure
     }
 
     private fun findMissingArtifacts(entries: List<LockEntry>, cacheRoot: Path): List<String> = entries
@@ -51,4 +19,42 @@ internal class OfflinePluginCacheReadinessChecker {
                 else -> null
             }
         }
+
+    private fun offlineCacheFailure(
+        lockfile: ParsedLockfile?,
+        lockfilePath: Path,
+        cacheRoot: Path,
+    ): PluginResolutionDiagnosticException? {
+        if (lockfile == null) {
+            return offlineCacheMiss(
+                "Offline mode requires a plugin lockfile. " +
+                    "Generate '$lockfilePath' by running once without --offline.",
+            )
+        }
+
+        val remoteArtifactEntries = lockfile.entries.filter { entry -> entry.kind == REMOTE_ARTIFACT_KIND }
+        if (remoteArtifactEntries.isEmpty()) {
+            return offlineCacheMiss(
+                "Offline mode requires locked remote dependency graph entries in '$lockfilePath'. " +
+                    "Regenerate the lockfile by running once without --offline.",
+            )
+        }
+
+        val missingArtifacts = findMissingArtifacts(remoteArtifactEntries, cacheRoot)
+        if (missingArtifacts.isEmpty()) {
+            return null
+        }
+
+        return offlineCacheMiss(
+            "Offline mode is enabled but plugin cache is missing locked dependency graph artifacts: " +
+                missingArtifacts.sorted().joinToString(", ") +
+                ". Run once without --offline to restore the cache.",
+        )
+    }
+
+    private fun offlineCacheMiss(message: String): PluginResolutionDiagnosticException =
+        PluginResolutionDiagnosticException(
+            category = PluginResolverErrorCategory.OFFLINE_CACHE_MISS,
+            message = message,
+        )
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginDependencyResolutionDiagnostics.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginDependencyResolutionDiagnostics.kt
@@ -22,40 +22,18 @@ internal class PluginDependencyResolutionDiagnostics {
                 else -> cause?.message ?: error.message ?: "Unknown resolver failure."
             }
 
-        val remediation =
-            if (authenticationFailure) {
-                "Verify repository credentials. Configure per-endpoint credentials via " +
-                    "$REPOSITORY_CREDENTIALS_FILE_ENV, global credentials via " +
-                    "$REPOSITORY_USERNAME_ENV/$REPOSITORY_PASSWORD_ENV, or GitHub Packages via " +
-                    "$GITHUB_PACKAGES_USERNAME_ENV/$GITHUB_PACKAGES_TOKEN_ENV."
-            } else if (offline) {
-                "Offline mode is enabled. Ensure the full dependency graph is cached under " +
-                    "'$localRepositoryRoot' by running once without --offline."
-            } else {
-                "Verify plugin coordinates and repository availability."
-            }
-
-        val category =
-            if (authenticationFailure) {
-                PluginResolverErrorCategory.AUTHENTICATION
-            } else {
-                PluginResolverErrorCategory.DEPENDENCY_RESOLUTION
-            }
-
         return PluginResolutionDiagnosticException(
-            category = category,
+            category = errorCategory(authenticationFailure),
             message =
             "Could not resolve plugin '${coordinate.value}' with transitive dependencies. " +
-                "Repositories: $repositoryList. $reason $remediation",
+                "Repositories: $repositoryList. $reason " +
+                remediation(authenticationFailure, offline, localRepositoryRoot),
             cause = error,
         )
     }
 
     private fun isAuthenticationFailure(cause: Throwable?): Boolean {
-        if (cause == null) {
-            return false
-        }
-
+        cause ?: return false
         return generateSequence(cause) { throwable -> throwable.cause }
             .mapNotNull(Throwable::message)
             .map(String::lowercase)
@@ -67,6 +45,31 @@ internal class PluginDependencyResolutionDiagnostics {
                     message.contains("authentication failed") ||
                     message.contains("not authorized")
             }
+    }
+
+    private fun errorCategory(authenticationFailure: Boolean): PluginResolverErrorCategory =
+        if (authenticationFailure) {
+            PluginResolverErrorCategory.AUTHENTICATION
+        } else {
+            PluginResolverErrorCategory.DEPENDENCY_RESOLUTION
+        }
+
+    private fun remediation(
+        authenticationFailure: Boolean,
+        offline: Boolean,
+        localRepositoryRoot: java.nio.file.Path,
+    ): String {
+        if (authenticationFailure) {
+            return "Verify repository credentials. Configure per-endpoint credentials via " +
+                "$REPOSITORY_CREDENTIALS_FILE_ENV, global credentials via " +
+                "$REPOSITORY_USERNAME_ENV/$REPOSITORY_PASSWORD_ENV, or GitHub Packages via " +
+                "$GITHUB_PACKAGES_USERNAME_ENV/$GITHUB_PACKAGES_TOKEN_ENV."
+        }
+        if (offline) {
+            return "Offline mode is enabled. Ensure the full dependency graph is cached under " +
+                "'$localRepositoryRoot' by running once without --offline."
+        }
+        return "Verify plugin coordinates and repository availability."
     }
 
     private fun primaryResolutionCause(error: DependencyResolutionException): Throwable? =

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionPaths.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolutionPaths.kt
@@ -19,9 +19,8 @@ internal fun defaultLockfilePath(scriptPath: Path): Path {
     val lockfileBaseName = normalizedScriptPath.fileName.toString().removeSuffix(".kts")
     val lockfileName = "$lockfileBaseName.plugins.lock"
     val parent = normalizedScriptPath.parent
-    return if (parent != null) {
-        parent.resolve(lockfileName)
-    } else {
-        Path.of(lockfileName)
+    if (parent == null) {
+        return Path.of(lockfileName)
     }
+    return parent.resolve(lockfileName)
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/plugins/PluginResolver.kt
@@ -24,19 +24,32 @@ internal fun resolvePlugins(command: RunCommand, settings: PluginResolverSetting
     }
 
     val diagnostics = PluginResolutionDiagnostics()
-    var sensitiveValues: Set<String> = emptySet()
+    if (command.plugins.isEmpty()) {
+        return resolveWithDiagnostics(command, settings, diagnostics, sensitiveValues = emptySet())
+    }
 
-    return runCatching {
-        if (command.plugins.isNotEmpty()) {
-            sensitiveValues = settings.repositoryCredentialsResolver.sensitiveValuesWithDiagnostics()
+    val sensitiveValues =
+        runCatching {
+            settings.repositoryCredentialsResolver.sensitiveValuesWithDiagnostics()
+        }.getOrElse { error ->
+            return PluginResolutionResult.Failure(listOf(diagnostics.format(error, sensitiveValues = emptySet())))
         }
-        PluginResolutionService(settings = settings).resolve(command)
-    }.fold(
-        onSuccess = { success -> success },
-        onFailure = { error ->
-            PluginResolutionResult.Failure(listOf(diagnostics.format(error, sensitiveValues)))
-        },
-    )
+
+    return resolveWithDiagnostics(command, settings, diagnostics, sensitiveValues)
 }
 
 private fun RunCommand.requiresPluginResolution(): Boolean = plugins.isNotEmpty() || pluginJars.isNotEmpty()
+
+private fun resolveWithDiagnostics(
+    command: RunCommand,
+    settings: PluginResolverSettings,
+    diagnostics: PluginResolutionDiagnostics,
+    sensitiveValues: Set<String>,
+): PluginResolutionResult = runCatching {
+    PluginResolutionService(settings = settings).resolve(command)
+}.fold(
+    onSuccess = { success -> success },
+    onFailure = { error ->
+        PluginResolutionResult.Failure(listOf(diagnostics.format(error, sensitiveValues)))
+    },
+)

--- a/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/IndexAllocator.kt
+++ b/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/IndexAllocator.kt
@@ -11,21 +11,22 @@ internal class IndexAllocator(private val min: Int, private val protoReserved: I
     private val used = mutableSetOf<Int>()
     private var next = min
 
-    fun allocate(requested: Int? = null): Int = when (requested) {
-        null ->
-            generateSequence(next) { it + 1 }
-                .first { c ->
-                    c !in used && reserved.none { c in it } && protoReserved?.contains(c) != true
-                }.also { candidate ->
-                    validate(candidate)
-                    used += candidate
-                    next = candidate + 1
-                }
+    fun allocate(requested: Int? = null): Int {
+        if (requested != null) {
+            validate(requested)
+            used += requested
+            return requested
+        }
 
-        else ->
-            requested.also {
-                validate(it)
-                used += it
+        return generateSequence(next) { it + 1 }
+            .first { candidate ->
+                candidate !in used &&
+                    reserved.none { candidate in it } &&
+                    protoReserved?.contains(candidate) != true
+            }.also { candidate ->
+                validate(candidate)
+                used += candidate
+                next = candidate + 1
             }
     }
 

--- a/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferencePath.kt
+++ b/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferencePath.kt
@@ -3,23 +3,19 @@ package me.liam.microsmith.dsl.schemas.protobuf.support
 internal fun getReferencePath(currentSegments: List<String>, target: String): List<String> {
     require(target.isNotBlank()) { "Reference target cannot be blank." }
 
-    return when {
-        !target.startsWith(".") ->
-            if ('.' in target) {
-                target.validateReferencePathSegments("Reference target")
-            } else {
-                currentSegments + target
-            }
+    if (target.startsWith(".")) {
+        val upCount = target.takeWhile { it == '.' }.length
+        val remaining = target.drop(upCount)
+        require(remaining.isNotBlank()) { "Reference target cannot end with only dots: '$target'" }
 
-        else -> {
-            val upCount = target.takeWhile { it == '.' }.length
-            val remaining = target.drop(upCount)
-            require(remaining.isNotBlank()) { "Reference target cannot end with only dots: '$target'" }
-
-            currentSegments.dropLast(upCount.coerceAtMost(currentSegments.size)) +
-                remaining.validateReferencePathSegments("Reference target")
-        }
+        return currentSegments.dropLast(upCount.coerceAtMost(currentSegments.size)) +
+            remaining.validateReferencePathSegments("Reference target")
     }
+    if ('.' !in target) {
+        return currentSegments + target
+    }
+
+    return target.validateReferencePathSegments("Reference target")
 }
 
 private fun String.validateReferencePathSegments(label: String): List<String> {

--- a/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferenceResolutionContext.kt
+++ b/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferenceResolutionContext.kt
@@ -7,6 +7,7 @@ import me.liam.microsmith.dsl.schemas.protobuf.field.MapType
 import me.liam.microsmith.dsl.schemas.protobuf.field.OneofField
 import me.liam.microsmith.dsl.schemas.protobuf.field.Reference
 import me.liam.microsmith.dsl.schemas.protobuf.field.ReferenceField
+import me.liam.microsmith.dsl.schemas.protobuf.field.ScalarField
 import me.liam.microsmith.dsl.schemas.protobuf.oneof.Oneof
 import me.liam.microsmith.dsl.schemas.protobuf.types.Message
 
@@ -46,17 +47,18 @@ internal class ReferenceResolutionContext(schemas: Set<ProtobufSchema>) {
         return copy(type = target)
     }
 
-    private fun Field.resolve(messageName: String): Field {
-        if (this is ReferenceField) {
-            return copy(reference = reference.resolve("message $messageName field '$name'"))
-        }
-        if (this !is MapField) {
-            return this
+    private fun Field.resolve(messageName: String): Field = when (this) {
+        is ReferenceField -> copy(reference = reference.resolve("message $messageName field '$name'"))
+
+        is MapField -> {
+            val resolvedValue =
+                (type.value as? Reference)?.resolve("message $messageName map field '$name' value") ?: type.value
+            copy(type = MapType(type.key, resolvedValue))
         }
 
-        val resolvedValue =
-            (type.value as? Reference)?.resolve("message $messageName map field '$name' value") ?: type.value
-        return copy(type = MapType(type.key, resolvedValue))
+        is ScalarField -> this
+
+        is OneofField -> this
     }
 
     private fun OneofField.resolve(messageName: String, oneofName: String): OneofField {

--- a/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferenceResolutionContext.kt
+++ b/modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/ReferenceResolutionContext.kt
@@ -7,7 +7,6 @@ import me.liam.microsmith.dsl.schemas.protobuf.field.MapType
 import me.liam.microsmith.dsl.schemas.protobuf.field.OneofField
 import me.liam.microsmith.dsl.schemas.protobuf.field.Reference
 import me.liam.microsmith.dsl.schemas.protobuf.field.ReferenceField
-import me.liam.microsmith.dsl.schemas.protobuf.field.ScalarField
 import me.liam.microsmith.dsl.schemas.protobuf.oneof.Oneof
 import me.liam.microsmith.dsl.schemas.protobuf.types.Message
 
@@ -16,12 +15,12 @@ internal class ReferenceResolutionContext(schemas: Set<ProtobufSchema>) {
     private val errors = mutableListOf<String>()
 
     fun resolve(schema: ProtobufSchema): ProtobufSchema {
-        val resolvedType =
-            when (val current = schema.schema) {
-                is Message -> current.resolveMessage()
-                else -> current
-            }
-        return schema.copy(schema = resolvedType)
+        val schemaType = schema.schema
+        if (schemaType !is Message) {
+            return schema
+        }
+
+        return schema.copy(schema = schemaType.resolveMessage())
     }
 
     fun failOnUnresolvedReferences() {
@@ -43,26 +42,27 @@ internal class ReferenceResolutionContext(schemas: Set<ProtobufSchema>) {
             errors += "Unresolved reference '$name' in $context"
             return this
         }
+
         return copy(type = target)
     }
 
-    private fun Field.resolve(messageName: String): Field = when (this) {
-        is ReferenceField -> copy(reference = reference.resolve("message $messageName field '$name'"))
-
-        is MapField -> {
-            val resolvedValue =
-                (type.value as? Reference)?.resolve("message $messageName map field '$name' value") ?: type.value
-            copy(type = MapType(type.key, resolvedValue))
+    private fun Field.resolve(messageName: String): Field {
+        if (this is ReferenceField) {
+            return copy(reference = reference.resolve("message $messageName field '$name'"))
+        }
+        if (this !is MapField) {
+            return this
         }
 
-        is ScalarField -> this
-
-        is OneofField -> this
+        val resolvedValue =
+            (type.value as? Reference)?.resolve("message $messageName map field '$name' value") ?: type.value
+        return copy(type = MapType(type.key, resolvedValue))
     }
 
     private fun OneofField.resolve(messageName: String, oneofName: String): OneofField {
         val resolvedFieldType =
-            (fieldType as? Reference)?.resolve("message $messageName oneof '$oneofName' field '$name'") ?: fieldType
+            (fieldType as? Reference)?.resolve("message $messageName oneof '$oneofName' field '$name'")
+                ?: fieldType
         return copy(fieldType = resolvedFieldType)
     }
 

--- a/modules/gen/src/main/kotlin/me/liam/microsmith/gen/helpers/GeneratedOutputPathResolver.kt
+++ b/modules/gen/src/main/kotlin/me/liam/microsmith/gen/helpers/GeneratedOutputPathResolver.kt
@@ -42,11 +42,11 @@ internal object GeneratedOutputPathResolver {
     private fun requireNoSymlinkTraversal(root: Path, relativePath: Path) {
         var current = root
         val segments = relativePath.toList()
-        segments.forEachIndexed { index, segment ->
+        for ((index, segment) in segments.withIndex()) {
             current = current.resolve(segment.toString())
 
             if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
-                return@forEachIndexed
+                continue
             }
 
             require(!Files.isSymbolicLink(current)) {

--- a/modules/gen/src/main/kotlin/me/liam/microsmith/gen/helpers/GeneratorExecutionService.kt
+++ b/modules/gen/src/main/kotlin/me/liam/microsmith/gen/helpers/GeneratorExecutionService.kt
@@ -24,11 +24,11 @@ internal class GeneratorExecutionService(
     }
 
     private suspend fun generate(extension: MicrosmithExtension, space: FileSpace): List<GeneratedFile> {
-        val generator =
-            extension.getGenerator() ?: run {
-                progressReporter.reportMissingGenerator(extension)
-                return emptyList()
-            }
+        val generator = extension.getGenerator()
+        if (generator == null) {
+            progressReporter.reportMissingGenerator(extension)
+            return emptyList()
+        }
 
         return generator.run { extension.generate(space) }.also { generatedFiles ->
             progressReporter.reportGeneratedFiles(extension, generatedFiles.size, space)

--- a/modules/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptDirectivePolicy.kt
+++ b/modules/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptDirectivePolicy.kt
@@ -19,18 +19,16 @@ private val GROUP_FORBIDDEN_DIRECTIVE =
 internal object ScriptDirectivePolicy {
     fun validate(scriptPath: Path): ScriptRunFailure? {
         val violations = collectViolations(Files.readAllLines(scriptPath))
-
-        return if (violations.isEmpty()) {
-            null
-        } else {
-            ScriptRunFailure(
-                diagnostics =
-                listOf(
-                    "Script dependency directives are blocked by default for security hardening.",
-                ) + violations,
-                type = ScriptFailureType.VALIDATION,
-            )
+        if (violations.isEmpty()) {
+            return null
         }
+        return ScriptRunFailure(
+            diagnostics =
+            listOf(
+                "Script dependency directives are blocked by default for security hardening.",
+            ) + violations,
+            type = ScriptFailureType.VALIDATION,
+        )
     }
 
     private fun collectViolations(lines: List<String>): List<String> {
@@ -46,31 +44,42 @@ internal object ScriptDirectivePolicy {
                 violations += violationMessage(index + 1, directive)
             }
 
-            when {
-                groupStartLine == null && GROUP_FILE_DIRECTIVE_START.containsMatchIn(line) -> {
-                    groupStartLine = index + 1
-                    groupBuffer += line
-                    if (GROUP_FILE_DIRECTIVE_END.containsMatchIn(line)) {
-                        val start = groupStartLine
-                        violations += collectGroupedViolations(groupBuffer.joinToString("\n"), start)
-                        groupStartLine = null
-                        groupBuffer.clear()
-                    }
+            if (groupStartLine == null && GROUP_FILE_DIRECTIVE_START.containsMatchIn(line)) {
+                groupStartLine = index + 1
+                groupBuffer += line
+                flushGroupedViolationsIfComplete(groupStartLine, groupBuffer)?.let { groupViolations ->
+                    violations += groupViolations
+                    groupStartLine = null
                 }
+                return@forEachIndexed
+            }
 
-                groupStartLine != null -> {
-                    groupBuffer += line
-                    if (GROUP_FILE_DIRECTIVE_END.containsMatchIn(line)) {
-                        val start = groupStartLine
-                        violations += collectGroupedViolations(groupBuffer.joinToString("\n"), start)
-                        groupStartLine = null
-                        groupBuffer.clear()
-                    }
-                }
+            if (groupStartLine == null) {
+                return@forEachIndexed
+            }
+
+            groupBuffer += line
+            flushGroupedViolationsIfComplete(groupStartLine, groupBuffer)?.let { groupViolations ->
+                violations += groupViolations
+                groupStartLine = null
             }
         }
 
         return violations
+    }
+
+    private fun flushGroupedViolationsIfComplete(
+        groupStartLine: Int?,
+        groupBuffer: MutableList<String>,
+    ): List<String>? {
+        if (!GROUP_FILE_DIRECTIVE_END.containsMatchIn(groupBuffer.last())) {
+            return null
+        }
+
+        val start = requireNotNull(groupStartLine)
+        val groupViolations = collectGroupedViolations(groupBuffer.joinToString("\n"), start)
+        groupBuffer.clear()
+        return groupViolations
     }
 
     private fun collectGroupedViolations(groupText: String, startLine: Int): List<String> {

--- a/modules/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunResultMapper.kt
+++ b/modules/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunResultMapper.kt
@@ -19,28 +19,27 @@ internal object ScriptRunResultMapper {
         val formattedReports = ScriptDiagnosticsFormatter.format(result.reports)
         val hasErrors = ScriptDiagnosticsFormatter.containsErrors(formattedReports)
 
-        return when (result) {
-            is ResultWithDiagnostics.Failure ->
-                ScriptRunFailure(
-                    diagnostics = formattedReports.ifEmpty { listOf("Script compilation failed.") },
-                    type = ScriptFailureType.COMPILATION,
-                )
-
-            is ResultWithDiagnostics.Success ->
-                if (hasErrors) {
-                    ScriptRunFailure(
-                        diagnostics = formattedReports,
-                        type = ScriptFailureType.COMPILATION,
-                    )
-                } else {
-                    successFinalizer.complete(
-                        evaluationResult = result.value,
-                        scriptContext = scriptContext,
-                        warnings = formattedReports,
-                        cacheHit = cacheHit,
-                        elapsedMillis = elapsedMillis,
-                    )
-                }
+        if (result is ResultWithDiagnostics.Failure) {
+            return ScriptRunFailure(
+                diagnostics = formattedReports.ifEmpty { listOf("Script compilation failed.") },
+                type = ScriptFailureType.COMPILATION,
+            )
         }
+
+        if (hasErrors) {
+            return ScriptRunFailure(
+                diagnostics = formattedReports,
+                type = ScriptFailureType.COMPILATION,
+            )
+        }
+
+        val successResult = result as ResultWithDiagnostics.Success
+        return successFinalizer.complete(
+            evaluationResult = successResult.value,
+            scriptContext = scriptContext,
+            warnings = formattedReports,
+            cacheHit = cacheHit,
+            elapsedMillis = elapsedMillis,
+        )
     }
 }

--- a/modules/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunResultMapper.kt
+++ b/modules/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/ScriptRunResultMapper.kt
@@ -19,27 +19,28 @@ internal object ScriptRunResultMapper {
         val formattedReports = ScriptDiagnosticsFormatter.format(result.reports)
         val hasErrors = ScriptDiagnosticsFormatter.containsErrors(formattedReports)
 
-        if (result is ResultWithDiagnostics.Failure) {
-            return ScriptRunFailure(
-                diagnostics = formattedReports.ifEmpty { listOf("Script compilation failed.") },
-                type = ScriptFailureType.COMPILATION,
-            )
-        }
+        return when (result) {
+            is ResultWithDiagnostics.Failure ->
+                ScriptRunFailure(
+                    diagnostics = formattedReports.ifEmpty { listOf("Script compilation failed.") },
+                    type = ScriptFailureType.COMPILATION,
+                )
 
-        if (hasErrors) {
-            return ScriptRunFailure(
-                diagnostics = formattedReports,
-                type = ScriptFailureType.COMPILATION,
-            )
+            is ResultWithDiagnostics.Success ->
+                if (hasErrors) {
+                    ScriptRunFailure(
+                        diagnostics = formattedReports,
+                        type = ScriptFailureType.COMPILATION,
+                    )
+                } else {
+                    successFinalizer.complete(
+                        evaluationResult = result.value,
+                        scriptContext = scriptContext,
+                        warnings = formattedReports,
+                        cacheHit = cacheHit,
+                        elapsedMillis = elapsedMillis,
+                    )
+                }
         }
-
-        val successResult = result as ResultWithDiagnostics.Success
-        return successFinalizer.complete(
-            evaluationResult = successResult.value,
-            scriptContext = scriptContext,
-            warnings = formattedReports,
-            cacheHit = cacheHit,
-            elapsedMillis = elapsedMillis,
-        )
     }
 }


### PR DESCRIPTION
## Why
The existing Detekt `ReturnCount` policy was too blunt for Kotlin-first control flow. It was pushing clear precondition checks and invalid-state exits into extra nesting or awkward rewrites in exactly the command parsing, onboarding, doctor, and scripting paths where guard clauses improve readability.

This change fixes that at the policy level and then applies a focused cleanup pass across production code so the repository actually benefits from the standard instead of only changing the rule.

## What Changed
- rebalanced Detekt return-count enforcement by keeping the rule active, enabling guard-clause exclusion, and keeping the non-guard return limit tight at `3`
- updated contributor guidance in `README.md` so reviewers expect guard clauses where they improve readability, while still requiring decomposition when branching becomes hard to follow
- refactored selected CLI, doctor, onboarding, scripting, protobuf, and generator paths to use clearer guard clauses and straighter happy paths where that improved maintainability
- preserved exhaustive sealed handling in the places where the initial cleanup had gone too far, rather than weakening type safety for the sake of early returns

## Scope
- `detekt.yml`
- `README.md`
- `modules/cli/src/main/kotlin/me/liam/microsmith/cli/**`
- `modules/runtime-scripting/src/main/kotlin/me/liam/microsmith/runtime/scripting/host/**`
- `modules/dsl-schemas-protobuf/src/main/kotlin/me/liam/microsmith/dsl/schemas/protobuf/support/**`
- `modules/gen/src/main/kotlin/me/liam/microsmith/gen/helpers/**`

## Validation
- `./gradlew :cli:ktlintFormat :runtime-scripting:ktlintFormat :dsl-schemas-protobuf:ktlintFormat :gen:ktlintFormat`
- `./gradlew :cli:detekt :cli:check :runtime-scripting:check :dsl-schemas-protobuf:check :gen:check --rerun-tasks --no-build-cache`
- `./gradlew build --rerun-tasks --no-build-cache`
- `git diff --check`

## Notes
- The rule remains enforced. This does not relax the repository into unbounded returns; it allows guard clauses while still keeping larger branching functions under pressure to be simplified or decomposed.
- The cleanup intentionally avoids blanket style churn. It focuses on production paths where guard clauses improve readability without obscuring behavior.
- Review follow-up tightened the original refactor by restoring exhaustive `when` handling where unchecked-cast or open-ended branching would have reduced maintainability.

Closes #103
