### PR TITLE
feat(onboarding-kotlin): define and support Kotlin repository setup

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -204,7 +204,7 @@ jobs:
           test -f install-smoke-repo/settings.microsmith.kts
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
           test -f install-smoke-repo/generated/proto/UserCreated.proto
-      - name: Smoke test Java, Node, Go, Python, Ruby, and Rust onboarding fixtures (Linux)
+      - name: Smoke test Java, Kotlin, Node, Go, Python, Ruby, and Rust onboarding fixtures (Linux)
         if: ${{ always() && matrix.os == 'ubuntu-latest' && steps.install-unix.outcome == 'success' }}
         run: |
           set -euo pipefail
@@ -230,6 +230,7 @@ jobs:
           }
 
           smoke_unix_fixture java examples/jvm/java-maven generated JavaUserCreated.proto java-ide-doctor.json
+          smoke_unix_fixture kotlin examples/jvm/kotlin-gradle generated KotlinUserCreated.proto kotlin-ide-doctor.json
           smoke_unix_fixture node examples/non-gradle/node generated NodeUserCreated.proto node-ide-doctor.json
           smoke_unix_fixture go examples/non-gradle/go internal/gen GoUserCreated.proto go-ide-doctor.json
           smoke_unix_fixture python examples/non-gradle/python generated PythonUserCreated.proto python-ide-doctor.json

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Inside `.microsmith.kts` scripts:
 
 ## Standalone CLI for consumer repositories
 
-The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, Java, and other repositories when you want self-contained Microsmith execution without depending on a local Gradle or Maven install.
+The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, Java, Kotlin, and other repositories when you want self-contained Microsmith execution without depending on a local Gradle or Maven install.
 The official installer scripts are self-contained and provision a Java 24 runtime automatically when the machine does not already provide one.
 
 Manual channels remain available, but they require Java 24 or newer.
@@ -239,8 +239,10 @@ microsmith run build.microsmith.kts --out ./generated
 
 `microsmith init` is deterministic and non-destructive by default:
 
-- it detects Node, Go, Java, Python, Ruby, Rust, and .NET repositories from `package.json`, `go.mod`, Java source roots such as `src/main/java` or `src/test/java`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `Gemfile`, `gems.rb`, a root `*.gemspec`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
-- Java detection is intentionally conservative: it requires a Java source root either at the repository root or inside a nested Maven or Gradle module, then adds root Maven or Gradle markers when present; build-file-only JVM roots stay on the generic path so future Kotlin and Scala support can remain unambiguous
+- it detects Node, Go, Java, Kotlin, Python, Ruby, Rust, and .NET repositories from `package.json`, `go.mod`, Java source roots such as `src/main/java` or `src/test/java`, Kotlin source roots such as `src/main/kotlin`, `src/test/kotlin`, or `src/commonMain/kotlin`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `Gemfile`, `gems.rb`, a root `*.gemspec`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
+- repositories that match multiple first-class profiles at once, including mixed Java and Kotlin source roots, fall back to the generic bootstrap instead of guessing the dominant ecosystem
+- Java detection is intentionally conservative: it requires a Java source root either at the repository root or inside a nested Maven or Gradle module, then adds root Maven or Gradle markers when present; build-file-only JVM roots stay on the generic path so Microsmith does not guess between Java, Kotlin, and Scala from build files alone
+- Kotlin detection is source-root driven: it recognizes root or nested Kotlin source roots for Maven, Gradle Kotlin DSL, Gradle Groovy, multiplatform-style source-set layouts, and build-tool-light repositories; build-file-only JVM roots still stay on the generic path
 - Ruby detection covers Bundler-first app roots and gem-style repositories through a root `Gemfile`, root `gems.rb`, or root `*.gemspec`; nested gems without a root Ruby marker stay on the generic path
 - Rust detection covers both package manifests and workspace roots through a root `Cargo.toml`; nested crates without a root manifest stay on the generic path
 - it creates `settings.microsmith.kts` when missing
@@ -262,6 +264,7 @@ After the canonical first run succeeds, you can switch to a repository-native ou
 - Node: `microsmith run build.microsmith.kts --out ./generated`
 - Go: `microsmith run build.microsmith.kts --out ./internal/gen`
 - Java: keep the canonical `./generated` output path unless you explicitly wire generated sources into Maven or Gradle later
+- Kotlin: keep the canonical `./generated` output path unless you intentionally adopt deeper native Gradle or Maven integration later
 - Python: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Ruby: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Rust: keep the canonical `./generated` output path unless your repository already has a stronger convention
@@ -272,6 +275,13 @@ Java-specific guidance:
 - Maven-based Java repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
 - Gradle-based Java repositories: keep Microsmith CLI-managed by default and do not wire Microsmith into the Gradle build automatically as part of onboarding
 - build-tool-light Java repositories: use the same canonical `./generated` output path and helper workflow
+
+Kotlin-specific guidance:
+
+- Gradle Kotlin DSL repositories: keep Microsmith CLI-managed during onboarding and do not wire Microsmith into the Gradle build automatically as part of onboarding
+- Gradle Groovy repositories that primarily host Kotlin code: use the same CLI-managed `./generated` path and helper workflow
+- Maven Kotlin repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
+- build-tool-light Kotlin repositories: use the same canonical `./generated` output path and helper workflow
 
 ### Direct script execution
 
@@ -553,6 +563,11 @@ Java-specific guidance:
 
 - for Java repositories, IntelliJ IDEA is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
 - native Maven or Gradle import resolves Java project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
+
+Kotlin-specific guidance:
+
+- for Kotlin repositories, IntelliJ IDEA is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
+- native Gradle or Maven import resolves Kotlin project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
 
 Ruby-specific guidance:
 
@@ -863,7 +878,8 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 
 | Fixture | Directory                    | Local command from fixture root                                                   | CI workflow                                                   |
 |---------|------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
-| Java    | `examples/jvm/java-maven`    | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`   | `examples/jvm/java-maven/.github/workflows/microsmith.yml`    |
+| Java    | `examples/jvm/java-maven`    | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/jvm/java-maven/.github/workflows/microsmith.yml`    |
+| Kotlin  | `examples/jvm/kotlin-gradle` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/jvm/kotlin-gradle/.github/workflows/microsmith.yml` |
 | Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
 | Go      | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts --out ./internal/gen` | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
 | Python  | `examples/non-gradle/python` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/python/.github/workflows/microsmith.yml` |
@@ -880,8 +896,8 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | CLI help and README contract   | `build-and-qodana` on Ubuntu                         | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.   |
 | CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
 | Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
-| Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
-| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
+| Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Kotlin, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
+| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Kotlin, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
 | Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
 | Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
 
@@ -905,6 +921,7 @@ Support policy:
 | Product         | Fixture root                    | Required helper smoke path                              | Required fallback smoke path                             |
 |-----------------|---------------------------------|---------------------------------------------------------|----------------------------------------------------------|
 | IntelliJ IDEA   | `examples/jvm/java-maven`       | Run the helper checklist below against the Java fixture. | Run the fallback checklist below against the Java fixture. |
+| IntelliJ IDEA   | `examples/jvm/kotlin-gradle`    | Run the helper checklist below against the Kotlin fixture. | Run the fallback checklist below against the Kotlin fixture. |
 | GoLand          | `examples/non-gradle/go`        | Run the helper checklist below against the Go fixture.   | Run the fallback checklist below against the Go fixture.   |
 | PyCharm         | `examples/non-gradle/python`    | Run the helper checklist below against the Python fixture. | Run the fallback checklist below against the Python fixture. |
 | RubyMine        | `examples/non-gradle/ruby`      | Run the helper checklist below against the Ruby fixture. | Run the fallback checklist below against the Ruby fixture. |

--- a/examples/jvm/kotlin-gradle/.github/workflows/microsmith.yml
+++ b/examples/jvm/kotlin-gradle/.github/workflows/microsmith.yml
@@ -1,0 +1,23 @@
+name: Microsmith Generate (Kotlin Gradle Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Microsmith
+        run: |
+          curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
+          sh microsmith-install.sh --version "$MICROSMITH_VERSION"
+          echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        working-directory: examples/jvm/kotlin-gradle
+        run: microsmith init
+      - name: Generate protobuf
+        working-directory: examples/jvm/kotlin-gradle
+        run: |
+          microsmith run build.microsmith.kts --out generated
+          test -f generated/proto/KotlinUserCreated.proto

--- a/examples/jvm/kotlin-gradle/build.gradle.kts
+++ b/examples/jvm/kotlin-gradle/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    kotlin("jvm") version "2.2.21"
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvmToolchain(21)
+}

--- a/examples/jvm/kotlin-gradle/schema.microsmith.kts
+++ b/examples/jvm/kotlin-gradle/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("KotlinUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}

--- a/examples/jvm/kotlin-gradle/settings.gradle.kts
+++ b/examples/jvm/kotlin-gradle/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kotlin-gradle-fixture"

--- a/examples/jvm/kotlin-gradle/src/main/kotlin/example/App.kt
+++ b/examples/jvm/kotlin-gradle/src/main/kotlin/example/App.kt
@@ -1,0 +1,5 @@
+package example
+
+class App {
+    fun message(): String = "Microsmith Kotlin fixture"
+}

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
@@ -13,6 +13,7 @@ internal object BuiltInOnboardingProfileMatchers {
             rootMarkerMatcher(NodeOnboardingProfile, "package.json"),
             rootMarkerMatcher(GoOnboardingProfile, "go.mod"),
             javaMatcher(),
+            kotlinMatcher(),
             rootMarkerMatcher(
                 PythonOnboardingProfile,
                 "pyproject.toml",
@@ -53,6 +54,12 @@ internal object BuiltInOnboardingProfileMatchers {
     private fun javaMatcher(): OnboardingProfileMatcher {
         return OnboardingProfileMatcher(JavaOnboardingProfile) { projectRoot ->
             JavaOnboardingMarkerFinder.find(projectRoot)
+        }
+    }
+
+    private fun kotlinMatcher(): OnboardingProfileMatcher {
+        return OnboardingProfileMatcher(KotlinOnboardingProfile) { projectRoot ->
+            KotlinOnboardingMarkerFinder.find(projectRoot)
         }
     }
 

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
@@ -1,96 +1,15 @@
 package me.liam.microsmith.cli.init
 
-import java.io.IOException
-import java.io.UncheckedIOException
-import java.nio.file.FileVisitResult
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.SimpleFileVisitor
-import java.nio.file.attribute.BasicFileAttributes
-import kotlin.io.path.isDirectory
-import kotlin.io.path.isRegularFile
 
 internal object JavaOnboardingMarkerFinder {
-    fun find(projectRoot: Path): List<String> {
-        return try {
-            val matchedSourceMarkers =
-                ROOT_SOURCE_MARKERS.filter { markerPath ->
-                    projectRoot.resolve(markerPath).isDirectory()
-                }
-            val matchedBuildMarkers =
-                BUILD_MARKERS.filter { markerFileName ->
-                    projectRoot.resolve(markerFileName).isRegularFile()
-                }
+    fun find(projectRoot: Path): List<String> = JvmOnboardingMarkerFinder.find(projectRoot, ::isSupportedJavaSourceRoot)
 
-            if (matchedSourceMarkers.isNotEmpty()) {
-                return (matchedBuildMarkers + matchedSourceMarkers).sorted()
-            }
-            if (matchedBuildMarkers.isEmpty()) {
-                return emptyList()
-            }
-
-            val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot)
-            if (matchedModuleSourceMarkers.isEmpty()) {
-                emptyList()
-            } else {
-                (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
-            }
-        } catch (_: IOException) {
-            emptyList()
-        } catch (_: UncheckedIOException) {
-            emptyList()
-        } catch (_: SecurityException) {
-            emptyList()
-        }
-    }
-
-    private fun findModuleSourceMarkers(projectRoot: Path): List<String> {
-        val matchedMarkers = mutableListOf<String>()
-        Files.walkFileTree(
-            projectRoot,
-            emptySet(),
-            MODULE_SOURCE_SEARCH_DEPTH,
-            object : SimpleFileVisitor<Path>() {
-                override fun preVisitDirectory(directory: Path, attributes: BasicFileAttributes): FileVisitResult {
-                    if (directory == projectRoot) {
-                        return FileVisitResult.CONTINUE
-                    }
-
-                    val relativeDirectory = projectRoot.relativize(directory)
-                    return when {
-                        relativeDirectory in ROOT_SOURCE_MARKER_PATHS -> FileVisitResult.SKIP_SUBTREE
-                        ROOT_SOURCE_MARKER_PATHS.any(relativeDirectory::endsWith) -> {
-                            matchedMarkers += relativeDirectory.toString()
-                            FileVisitResult.SKIP_SUBTREE
-                        }
-                        else -> FileVisitResult.CONTINUE
-                    }
-                }
-
-                override fun visitFileFailed(file: Path, exception: IOException): FileVisitResult =
-                    FileVisitResult.CONTINUE
-
-                override fun postVisitDirectory(directory: Path, exception: IOException?): FileVisitResult =
-                    FileVisitResult.CONTINUE
-            },
-        )
-        return matchedMarkers.sorted()
-    }
+    private fun isSupportedJavaSourceRoot(relativeDirectory: Path): Boolean =
+        JAVA_SOURCE_ROOT_MARKERS.any(relativeDirectory::endsWith)
 }
 
-private val BUILD_MARKERS = listOf(
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "settings.gradle",
-    "settings.gradle.kts",
+private val JAVA_SOURCE_ROOT_MARKERS = listOf(
+    Path.of("src/main/java"),
+    Path.of("src/test/java"),
 )
-
-private val ROOT_SOURCE_MARKERS = listOf(
-    "src/main/java",
-    "src/test/java",
-)
-
-private val ROOT_SOURCE_MARKER_PATHS = ROOT_SOURCE_MARKERS.map(Path::of)
-
-private const val MODULE_SOURCE_SEARCH_DEPTH = 6

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
@@ -16,9 +16,7 @@ internal object JvmOnboardingMarkerFinder {
                 JVM_BUILD_MARKERS.filter { markerFileName ->
                     projectRoot.resolve(markerFileName).isRegularFile()
                 }
-            val matchedSourceMarkers = findSourceMarkers(projectRoot, sourceRootMatcher)
-            val rootSourceMarkers =
-                matchedSourceMarkers.filter(::isRootSourceMarker)
+            val rootSourceMarkers = findRootSourceMarkers(projectRoot, sourceRootMatcher)
 
             when {
                 rootSourceMarkers.isNotEmpty() -> {
@@ -29,12 +27,13 @@ internal object JvmOnboardingMarkerFinder {
                     emptyList()
                 }
 
-                matchedSourceMarkers.isEmpty() -> {
-                    emptyList()
-                }
-
                 else -> {
-                    (matchedBuildMarkers + matchedSourceMarkers).sorted()
+                    val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot, sourceRootMatcher)
+                    if (matchedModuleSourceMarkers.isEmpty()) {
+                        emptyList()
+                    } else {
+                        (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
+                    }
                 }
             }
         } catch (_: IOException) {
@@ -46,7 +45,34 @@ internal object JvmOnboardingMarkerFinder {
         }
     }
 
-    private fun findSourceMarkers(projectRoot: Path, sourceRootMatcher: (Path) -> Boolean): List<String> {
+    private fun findRootSourceMarkers(projectRoot: Path, sourceRootMatcher: (Path) -> Boolean): List<String> {
+        val srcDirectory = projectRoot.resolve(SOURCE_ROOT_DIRECTORY_NAME)
+        if (!Files.isDirectory(srcDirectory)) {
+            return emptyList()
+        }
+
+        return Files.newDirectoryStream(srcDirectory).use { sourceSetDirectories ->
+            sourceSetDirectories
+                .asSequence()
+                .filter(Files::isDirectory)
+                .flatMap { sourceSetDirectory ->
+                    Files.newDirectoryStream(sourceSetDirectory).use { sourceTypeDirectories ->
+                        sourceTypeDirectories
+                            .asSequence()
+                            .filter(Files::isDirectory)
+                            .map(projectRoot::relativize)
+                            .filter(sourceRootMatcher)
+                            .map(Path::toString)
+                            .toList()
+                            .asSequence()
+                    }
+                }
+                .sorted()
+                .toList()
+        }
+    }
+
+    private fun findModuleSourceMarkers(projectRoot: Path, sourceRootMatcher: (Path) -> Boolean): List<String> {
         val matchedMarkers = mutableListOf<String>()
         Files.walkFileTree(
             projectRoot,
@@ -59,7 +85,9 @@ internal object JvmOnboardingMarkerFinder {
                     }
 
                     val relativeDirectory = projectRoot.relativize(directory)
-                    return if (sourceRootMatcher(relativeDirectory)) {
+                    return if (isRootSourceMarker(relativeDirectory, sourceRootMatcher)) {
+                        FileVisitResult.SKIP_SUBTREE
+                    } else if (sourceRootMatcher(relativeDirectory)) {
                         matchedMarkers += relativeDirectory.toString()
                         FileVisitResult.SKIP_SUBTREE
                     } else {
@@ -77,8 +105,10 @@ internal object JvmOnboardingMarkerFinder {
         return matchedMarkers.sorted()
     }
 
-    private fun isRootSourceMarker(markerPath: String): Boolean {
-        return Path.of(markerPath).nameCount == ROOT_SOURCE_MARKER_DEPTH
+    private fun isRootSourceMarker(relativeDirectory: Path, sourceRootMatcher: (Path) -> Boolean): Boolean {
+        return relativeDirectory.nameCount == ROOT_SOURCE_MARKER_DEPTH &&
+            relativeDirectory.getName(0).toString() == SOURCE_ROOT_DIRECTORY_NAME &&
+            sourceRootMatcher(relativeDirectory)
     }
 }
 
@@ -93,3 +123,5 @@ private val JVM_BUILD_MARKERS = listOf(
 private const val MODULE_SOURCE_SEARCH_DEPTH = 6
 
 private const val ROOT_SOURCE_MARKER_DEPTH = 3
+
+private const val SOURCE_ROOT_DIRECTORY_NAME = "src"

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
@@ -1,0 +1,95 @@
+package me.liam.microsmith.cli.init
+
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import kotlin.io.path.isRegularFile
+
+internal object JvmOnboardingMarkerFinder {
+    fun find(projectRoot: Path, sourceRootMatcher: (Path) -> Boolean): List<String> {
+        return try {
+            val matchedBuildMarkers =
+                JVM_BUILD_MARKERS.filter { markerFileName ->
+                    projectRoot.resolve(markerFileName).isRegularFile()
+                }
+            val matchedSourceMarkers = findSourceMarkers(projectRoot, sourceRootMatcher)
+            val rootSourceMarkers =
+                matchedSourceMarkers.filter(::isRootSourceMarker)
+
+            when {
+                rootSourceMarkers.isNotEmpty() -> {
+                    (matchedBuildMarkers + rootSourceMarkers).sorted()
+                }
+
+                matchedBuildMarkers.isEmpty() -> {
+                    emptyList()
+                }
+
+                matchedSourceMarkers.isEmpty() -> {
+                    emptyList()
+                }
+
+                else -> {
+                    (matchedBuildMarkers + matchedSourceMarkers).sorted()
+                }
+            }
+        } catch (_: IOException) {
+            emptyList()
+        } catch (_: UncheckedIOException) {
+            emptyList()
+        } catch (_: SecurityException) {
+            emptyList()
+        }
+    }
+
+    private fun findSourceMarkers(projectRoot: Path, sourceRootMatcher: (Path) -> Boolean): List<String> {
+        val matchedMarkers = mutableListOf<String>()
+        Files.walkFileTree(
+            projectRoot,
+            emptySet(),
+            MODULE_SOURCE_SEARCH_DEPTH,
+            object : SimpleFileVisitor<Path>() {
+                override fun preVisitDirectory(directory: Path, attributes: BasicFileAttributes): FileVisitResult {
+                    if (directory == projectRoot) {
+                        return FileVisitResult.CONTINUE
+                    }
+
+                    val relativeDirectory = projectRoot.relativize(directory)
+                    return if (sourceRootMatcher(relativeDirectory)) {
+                        matchedMarkers += relativeDirectory.toString()
+                        FileVisitResult.SKIP_SUBTREE
+                    } else {
+                        FileVisitResult.CONTINUE
+                    }
+                }
+
+                override fun visitFileFailed(file: Path, exception: IOException): FileVisitResult =
+                    FileVisitResult.CONTINUE
+
+                override fun postVisitDirectory(directory: Path, exception: IOException?): FileVisitResult =
+                    FileVisitResult.CONTINUE
+            },
+        )
+        return matchedMarkers.sorted()
+    }
+
+    private fun isRootSourceMarker(markerPath: String): Boolean {
+        return Path.of(markerPath).nameCount == ROOT_SOURCE_MARKER_DEPTH
+    }
+}
+
+private val JVM_BUILD_MARKERS = listOf(
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "settings.gradle",
+    "settings.gradle.kts",
+)
+
+private const val MODULE_SOURCE_SEARCH_DEPTH = 6
+
+private const val ROOT_SOURCE_MARKER_DEPTH = 3

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingMarkerFinder.kt
@@ -1,0 +1,42 @@
+package me.liam.microsmith.cli.init
+
+import java.nio.file.Path
+
+internal object KotlinOnboardingMarkerFinder {
+    fun find(projectRoot: Path): List<String> =
+        JvmOnboardingMarkerFinder.find(projectRoot, ::isSupportedKotlinSourceRoot)
+
+    private fun isSupportedKotlinSourceRoot(relativeDirectory: Path): Boolean {
+        if (relativeDirectory.nameCount < MINIMUM_KOTLIN_SOURCE_ROOT_DEPTH) {
+            return false
+        }
+
+        if (relativeDirectory.fileName.toString() != KOTLIN_SOURCE_DIRECTORY_NAME) {
+            return false
+        }
+
+        val sourceDirectoryName =
+            relativeDirectory.getName(relativeDirectory.nameCount - SOURCE_ROOT_PREFIX_DEPTH).toString()
+        if (sourceDirectoryName != SOURCE_DIRECTORY_NAME) {
+            return false
+        }
+
+        val sourceSetName =
+            relativeDirectory.getName(relativeDirectory.nameCount - SOURCE_SET_NAME_OFFSET).toString()
+        return sourceSetName == MAIN_SOURCE_SET_NAME ||
+            sourceSetName == TEST_SOURCE_SET_NAME ||
+            sourceSetName.endsWith(MAIN_SOURCE_SET_SUFFIX) ||
+            sourceSetName.endsWith(TEST_SOURCE_SET_SUFFIX)
+    }
+}
+
+private const val MINIMUM_KOTLIN_SOURCE_ROOT_DEPTH = 3
+private const val SOURCE_ROOT_PREFIX_DEPTH = 3
+private const val SOURCE_SET_NAME_OFFSET = 2
+
+private const val SOURCE_DIRECTORY_NAME = "src"
+private const val KOTLIN_SOURCE_DIRECTORY_NAME = "kotlin"
+private const val MAIN_SOURCE_SET_NAME = "main"
+private const val TEST_SOURCE_SET_NAME = "test"
+private const val MAIN_SOURCE_SET_SUFFIX = "Main"
+private const val TEST_SOURCE_SET_SUFFIX = "Test"

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingProfile.kt
@@ -1,0 +1,8 @@
+package me.liam.microsmith.cli.init
+
+internal data object KotlinOnboardingProfile : OnboardingProfile {
+    override val id: OnboardingProfileId = OnboardingProfileId("kotlin")
+    override val displayName: String = "Kotlin"
+    override val sampleMessageName: String = "KotlinUserCreated"
+    override val recommendedOutputDirectory: String? = null
+}

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -12,6 +12,7 @@ import me.liam.microsmith.cli.init.InitBootstrapResult
 import me.liam.microsmith.cli.init.InitConflictException
 import me.liam.microsmith.cli.init.InitValidationException
 import me.liam.microsmith.cli.init.JavaOnboardingProfile
+import me.liam.microsmith.cli.init.KotlinOnboardingProfile
 import me.liam.microsmith.cli.init.NodeOnboardingProfile
 import me.liam.microsmith.cli.init.OnboardingProfileDetection
 import me.liam.microsmith.cli.init.OnboardingProfileSelectionReason
@@ -344,6 +345,51 @@ class MicrosmithCliInitTests :
 
                 exitCode shouldBe 0
                 out.joinToString("\n").shouldContain("Detected repository profile: Java")
+                out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldNotContain("Optional repository-native output path")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command keeps Kotlin on the canonical generated output path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-kotlin")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingProfileDetection(
+                                    profile = KotlinOnboardingProfile,
+                                    selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                                    matchedMarkers = listOf("build.gradle.kts", "src/main/kotlin"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = emptyList(),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Detected repository profile: Kotlin")
                 out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
                 out.joinToString("\n").shouldNotContain("Optional repository-native output path")
                 err shouldBe emptyList()

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingProfileTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingProfileTests.kt
@@ -1,0 +1,226 @@
+package me.liam.microsmith.cli.init
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class KotlinOnboardingProfileTests :
+    StringSpec({
+        "creates repo-aware bootstrap files for Kotlin repositories without a repository-native output override" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-kotlin")
+            repoRoot.resolve("build.gradle.kts").writeText("plugins { kotlin(\"jvm\") version \"2.2.21\" }\n")
+            repoRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture-kotlin\"\n")
+            repoRoot.resolve("src/main/kotlin/example").createDirectories()
+            repoRoot.resolve("src/main/kotlin/example/App.kt").writeText(
+                """
+                package example
+
+                class App {
+                    fun message(): String = "Microsmith Kotlin fixture"
+                }
+                """.trimIndent() + "\n",
+            )
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.repositoryDetection.profile shouldBe KotlinOnboardingProfile
+                result.repositoryDetection.matchedMarkers shouldBe
+                    listOf("build.gradle.kts", "settings.gradle.kts", "src/main/kotlin")
+                val buildScript = repoRoot.resolve("build.microsmith.kts").readText()
+                val settingsScript = repoRoot.resolve("settings.microsmith.kts").readText()
+
+                buildScript.shouldContain("KotlinUserCreated")
+                buildScript.shouldContain("microsmith run build.microsmith.kts --out ./generated")
+                buildScript.shouldContain("// Bootstrapped Microsmith schema for this Kotlin repository.")
+                buildScript.contains("Common repository-native output path:") shouldBe false
+                settingsScript.shouldContain("Detected repository profile: Kotlin")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Kotlin repositories from Maven roots when a Kotlin source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-maven")
+            try {
+                repoRoot.resolve("pom.xml").writeText("<project />\n")
+                repoRoot.resolve("src/main/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pom.xml", "src/main/kotlin"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Kotlin repositories from Gradle Kotlin DSL roots when a Kotlin source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-gradle-kts")
+            try {
+                repoRoot.resolve("build.gradle.kts").writeText("plugins { kotlin(\"jvm\") version \"2.2.21\" }\n")
+                repoRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture-kotlin\"\n")
+                repoRoot.resolve("src/test/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "settings.gradle.kts", "src/test/kotlin"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Kotlin repositories from Gradle Groovy roots when a Kotlin source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-gradle-groovy")
+            try {
+                repoRoot.resolve(
+                    "build.gradle",
+                ).writeText("plugins { id 'org.jetbrains.kotlin.jvm' version '2.2.21' }\n")
+                repoRoot.resolve(
+                    "settings.gradle",
+                ).writeText("rootProject.name = 'fixture-kotlin'\n")
+                repoRoot.resolve("src/main/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle", "settings.gradle", "src/main/kotlin"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Kotlin multiplatform repositories from source-set roots" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-multiplatform")
+            try {
+                repoRoot.resolve(
+                    "build.gradle.kts",
+                ).writeText("plugins { kotlin(\"multiplatform\") version \"2.2.21\" }\n")
+                repoRoot.resolve(
+                    "src/commonMain/kotlin/example",
+                ).createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "src/commonMain/kotlin"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects build-tool-light Kotlin repositories from source roots alone" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-lightweight")
+            try {
+                repoRoot.resolve("src/main/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("src/main/kotlin"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects multi-module Kotlin repositories from nested Kotlin source trees" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-multi-module")
+            try {
+                repoRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture-kotlin\"\n")
+                repoRoot.resolve("services/app/src/jvmMain/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("services/app/src/jvmMain/kotlin", "settings.gradle.kts"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile for Kotlin build files without a Kotlin source tree" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-build-only")
+            try {
+                repoRoot.resolve("build.gradle.kts").writeText("plugins { kotlin(\"jvm\") version \"2.2.21\" }\n")
+                repoRoot.resolve("pom.xml").writeText("<project />\n")
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile when Kotlin and another ecosystem marker both match" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-mixed")
+            try {
+                repoRoot.resolve("build.gradle.kts").writeText("plugins { kotlin(\"jvm\") version \"2.2.21\" }\n")
+                repoRoot.resolve("src/main/kotlin/example").createDirectories()
+                repoRoot.resolve("pyproject.toml").writeText("[project]\nname = \"fixture-python\"\n")
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
+                        matchedMarkers = listOf("build.gradle.kts", "pyproject.toml", "src/main/kotlin"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile when Java and Kotlin source roots both match" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-kotlin-java-mixed")
+            try {
+                repoRoot.resolve("build.gradle.kts").writeText("plugins { kotlin(\"jvm\") version \"2.2.21\" }\n")
+                repoRoot.resolve("src/main/java/example").createDirectories()
+                repoRoot.resolve("src/main/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
+                        matchedMarkers = listOf("build.gradle.kts", "src/main/java", "src/main/kotlin"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+    })

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
@@ -261,6 +261,74 @@ class OnboardingProfileDetectorTests :
             }
         }
 
+        "detects Kotlin repositories from source roots across Maven, Gradle, and build-tool-light layouts" {
+            val mavenRoot = createTempDirectory("microsmith-init-detect-kotlin-maven")
+            val gradleKotlinDslRoot = createTempDirectory("microsmith-init-detect-kotlin-gradle-kts")
+            val gradleGroovyRoot = createTempDirectory("microsmith-init-detect-kotlin-gradle-groovy")
+            val multiplatformRoot = createTempDirectory("microsmith-init-detect-kotlin-multiplatform")
+            val lightweightRoot = createTempDirectory("microsmith-init-detect-kotlin-lightweight")
+            try {
+                mavenRoot.resolve("pom.xml").writeText("<project />\n")
+                mavenRoot.resolve("src/main/kotlin/example").createDirectories()
+                gradleKotlinDslRoot.resolve(
+                    "build.gradle.kts",
+                ).writeText("plugins { kotlin(\"jvm\") version \"2.2.21\" }\n")
+                gradleKotlinDslRoot.resolve(
+                    "settings.gradle.kts",
+                ).writeText("rootProject.name = \"fixture-kotlin\"\n")
+                gradleKotlinDslRoot.resolve("src/test/kotlin/example").createDirectories()
+                gradleGroovyRoot.resolve(
+                    "build.gradle",
+                ).writeText("plugins { id 'org.jetbrains.kotlin.jvm' version '2.2.21' }\n")
+                gradleGroovyRoot.resolve(
+                    "settings.gradle",
+                ).writeText("rootProject.name = 'fixture-kotlin'\n")
+                gradleGroovyRoot.resolve("src/main/kotlin/example").createDirectories()
+                multiplatformRoot.resolve(
+                    "build.gradle.kts",
+                ).writeText("plugins { kotlin(\"multiplatform\") version \"2.2.21\" }\n")
+                multiplatformRoot.resolve("src/commonMain/kotlin/example").createDirectories()
+                lightweightRoot.resolve("src/main/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(mavenRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pom.xml", "src/main/kotlin"),
+                    )
+                detectOnboardingProfile(gradleKotlinDslRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "settings.gradle.kts", "src/test/kotlin"),
+                    )
+                detectOnboardingProfile(gradleGroovyRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle", "settings.gradle", "src/main/kotlin"),
+                    )
+                detectOnboardingProfile(multiplatformRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "src/commonMain/kotlin"),
+                    )
+                detectOnboardingProfile(lightweightRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("src/main/kotlin"),
+                    )
+            } finally {
+                runCatching { mavenRoot.deleteRecursively() }
+                runCatching { gradleKotlinDslRoot.deleteRecursively() }
+                runCatching { gradleGroovyRoot.deleteRecursively() }
+                runCatching { multiplatformRoot.deleteRecursively() }
+                runCatching { lightweightRoot.deleteRecursively() }
+            }
+        }
+
         "keeps the Python profile when multiple Python markers match" {
             val pythonRoot = createTempDirectory("microsmith-init-detect-python-multi")
             try {
@@ -370,6 +438,7 @@ class OnboardingProfileDetectorTests :
 
         "detects built-in repository profiles and falls back to the generic profile for ambiguous markers" {
             val javaRoot = createTempDirectory("microsmith-init-detect-java")
+            val kotlinRoot = createTempDirectory("microsmith-init-detect-kotlin")
             val nodeRoot = createTempDirectory("microsmith-init-detect-node")
             val goRoot = createTempDirectory("microsmith-init-detect-go")
             val pythonRoot = createTempDirectory("microsmith-init-detect-python")
@@ -380,6 +449,8 @@ class OnboardingProfileDetectorTests :
             try {
                 javaRoot.resolve("pom.xml").writeText("<project />\n")
                 javaRoot.resolve("src/main/java/example").createDirectories()
+                kotlinRoot.resolve("build.gradle.kts").writeText("plugins { kotlin(\"jvm\") version \"2.2.21\" }\n")
+                kotlinRoot.resolve("src/main/kotlin/example").createDirectories()
                 nodeRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
                 goRoot.resolve("go.mod").writeText("module example.com/microsmith/fixture\n")
                 pythonRoot.resolve("pyproject.toml").writeText("[project]\nname = \"fixture-python\"\n")
@@ -396,6 +467,12 @@ class OnboardingProfileDetectorTests :
                         profile = JavaOnboardingProfile,
                         selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
                         matchedMarkers = listOf("pom.xml", "src/main/java"),
+                    )
+                detectOnboardingProfile(kotlinRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = KotlinOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "src/main/kotlin"),
                     )
                 detectOnboardingProfile(nodeRoot) shouldBe
                     OnboardingProfileDetection(
@@ -441,6 +518,7 @@ class OnboardingProfileDetectorTests :
                     )
             } finally {
                 runCatching { javaRoot.deleteRecursively() }
+                runCatching { kotlinRoot.deleteRecursively() }
                 runCatching { nodeRoot.deleteRecursively() }
                 runCatching { goRoot.deleteRecursively() }
                 runCatching { pythonRoot.deleteRecursively() }


### PR DESCRIPTION
## Summary
Adds first-class Kotlin repository onboarding for the standalone Microsmith CLI.

## Why
Kotlin repositories were still falling back to either the generic bootstrap or the Java-specific path, which left Kotlin consumers without a clear onboarding contract for detection, bootstrap behavior, fixture coverage, and baseline JetBrains IDE guidance.

This PR keeps Kotlin onboarding intentionally CLI-managed for now. Native Gradle and Maven Microsmith integration remain separate follow-on work.

## What Changed
- added a Kotlin onboarding profile and Kotlin source-root detection for:
  - Maven repositories
  - Gradle Kotlin DSL repositories
  - Gradle Groovy repositories that primarily host Kotlin code
  - multiplatform-style source-set layouts such as `src/commonMain/kotlin`
  - build-tool-light Kotlin repositories with root Kotlin source trees
- extracted shared JVM source-root marker handling so Java and Kotlin onboarding stay consistent
- kept build-file-only JVM roots on the generic bootstrap path instead of guessing from `pom.xml` / Gradle files alone
- kept mixed first-class profile matches, including mixed Java/Kotlin source roots, on the generic bootstrap path
- added CLI/init regression coverage for Kotlin profile selection and bootstrap output behavior
- added a representative Kotlin Gradle fixture under `examples/jvm/kotlin-gradle`
- extended Ubuntu CLI smoke coverage to exercise the Kotlin fixture through `init`, `ide refresh`, `ide doctor`, and `run`
- documented the Kotlin onboarding and IntelliJ IDEA guidance in `README.md`

## Validation
- `./gradlew :cli:ktlintFormat :cli:check :cli:jvmKotest :cli:releaseArtifacts --rerun-tasks --no-build-cache`
- `./modules/cli/build/microsmith-cli-dist/bin/microsmith --help > /tmp/microsmith-cli-help.txt && python3 scripts/verify_readme_cli_usage.py README.md /tmp/microsmith-cli-help.txt`
- built-launcher smoke against a temp copy of `examples/jvm/kotlin-gradle`:
  - `microsmith init`
  - `microsmith ide refresh`
  - `microsmith ide doctor --diagnostics json`
  - `microsmith run build.microsmith.kts --out generated`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_test_qodana.yml")'`
- `./gradlew build --rerun-tasks --no-build-cache`
- `git diff --check`

Closes #89
