### PR TITLE
feat(onboarding-scala): define and support Scala repository setup

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -204,7 +204,7 @@ jobs:
           test -f install-smoke-repo/settings.microsmith.kts
           ./.microsmith-bin/microsmith run install-smoke-repo/build.microsmith.kts --out install-smoke-repo/generated
           test -f install-smoke-repo/generated/proto/UserCreated.proto
-      - name: Smoke test Java, Kotlin, Node, Go, Python, Ruby, and Rust onboarding fixtures (Linux)
+      - name: Smoke test Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust onboarding fixtures (Linux)
         if: ${{ always() && matrix.os == 'ubuntu-latest' && steps.install-unix.outcome == 'success' }}
         run: |
           set -euo pipefail
@@ -231,6 +231,7 @@ jobs:
 
           smoke_unix_fixture java examples/jvm/java-maven generated JavaUserCreated.proto java-ide-doctor.json
           smoke_unix_fixture kotlin examples/jvm/kotlin-gradle generated KotlinUserCreated.proto kotlin-ide-doctor.json
+          smoke_unix_fixture scala examples/jvm/scala-sbt generated ScalaUserCreated.proto scala-ide-doctor.json
           smoke_unix_fixture node examples/non-gradle/node generated NodeUserCreated.proto node-ide-doctor.json
           smoke_unix_fixture go examples/non-gradle/go internal/gen GoUserCreated.proto go-ide-doctor.json
           smoke_unix_fixture python examples/non-gradle/python generated PythonUserCreated.proto python-ide-doctor.json

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Inside `.microsmith.kts` scripts:
 
 ## Standalone CLI for consumer repositories
 
-The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, Java, Kotlin, and other repositories when you want self-contained Microsmith execution without depending on a local Gradle or Maven install.
+The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, Java, Kotlin, Scala, and other repositories when you want self-contained Microsmith execution without depending on a local Gradle or Maven install.
 The official installer scripts are self-contained and provision a Java 24 runtime automatically when the machine does not already provide one.
 
 Manual channels remain available, but they require Java 24 or newer.
@@ -239,10 +239,11 @@ microsmith run build.microsmith.kts --out ./generated
 
 `microsmith init` is deterministic and non-destructive by default:
 
-- it detects Node, Go, Java, Kotlin, Python, Ruby, Rust, and .NET repositories from `package.json`, `go.mod`, Java source roots such as `src/main/java` or `src/test/java`, Kotlin source roots such as `src/main/kotlin`, `src/test/kotlin`, or `src/commonMain/kotlin`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `Gemfile`, `gems.rb`, a root `*.gemspec`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
-- repositories that match multiple first-class profiles at once, including mixed Java and Kotlin source roots, fall back to the generic bootstrap instead of guessing the dominant ecosystem
+- it detects Node, Go, Java, Kotlin, Scala, Python, Ruby, Rust, and .NET repositories from `package.json`, `go.mod`, Java source roots such as `src/main/java` or `src/test/java`, Kotlin source roots such as `src/main/kotlin`, `src/test/kotlin`, or `src/commonMain/kotlin`, Scala source roots such as `src/main/scala`, root JVM build markers such as `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle`, `settings.gradle.kts`, `build.sbt`, and `project/build.properties`, `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, `Gemfile`, `gems.rb`, a root `*.gemspec`, a root `Cargo.toml`, `*.csproj`, and `*.sln`, and otherwise falls back to a generic bootstrap
+- repositories that match multiple first-class profiles at once, including mixed Java, Kotlin, and Scala source roots, fall back to the generic bootstrap instead of guessing the dominant ecosystem
 - Java detection is intentionally conservative: it requires a Java source root either at the repository root or inside a nested Maven or Gradle module, then adds root Maven or Gradle markers when present; build-file-only JVM roots stay on the generic path so Microsmith does not guess between Java, Kotlin, and Scala from build files alone
 - Kotlin detection is source-root driven: it recognizes root or nested Kotlin source roots for Maven, Gradle Kotlin DSL, Gradle Groovy, multiplatform-style source-set layouts, and build-tool-light repositories; build-file-only JVM roots still stay on the generic path
+- Scala detection is intentionally conservative: it requires a Scala main source root either at the repository root or inside a nested `sbt`, Maven, or Gradle module, then adds matching root build markers when present; `src/test/scala` alone stays on the generic path so Microsmith does not guess Scala from test-only roots
 - Ruby detection covers Bundler-first app roots and gem-style repositories through a root `Gemfile`, root `gems.rb`, or root `*.gemspec`; nested gems without a root Ruby marker stay on the generic path
 - Rust detection covers both package manifests and workspace roots through a root `Cargo.toml`; nested crates without a root manifest stay on the generic path
 - it creates `settings.microsmith.kts` when missing
@@ -265,6 +266,7 @@ After the canonical first run succeeds, you can switch to a repository-native ou
 - Go: `microsmith run build.microsmith.kts --out ./internal/gen`
 - Java: keep the canonical `./generated` output path unless you explicitly wire generated sources into Maven or Gradle later
 - Kotlin: keep the canonical `./generated` output path unless you intentionally adopt deeper native Gradle or Maven integration later
+- Scala: keep the canonical `./generated` output path unless you intentionally adopt deeper native `sbt`, Gradle, or Maven integration later
 - Python: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Ruby: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Rust: keep the canonical `./generated` output path unless your repository already has a stronger convention
@@ -282,6 +284,13 @@ Kotlin-specific guidance:
 - Gradle Groovy repositories that primarily host Kotlin code: use the same CLI-managed `./generated` path and helper workflow
 - Maven Kotlin repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
 - build-tool-light Kotlin repositories: use the same canonical `./generated` output path and helper workflow
+
+Scala-specific guidance:
+
+- `sbt`-based Scala repositories: keep Microsmith CLI-managed during onboarding and do not wire Microsmith into `sbt` automatically as part of onboarding
+- Maven Scala repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
+- Gradle Scala repositories: keep Microsmith CLI-managed by default and only wire generated sources into Gradle intentionally later
+- test-only Scala roots stay on the generic onboarding path until a Scala main source root exists
 
 ### Direct script execution
 
@@ -568,6 +577,11 @@ Kotlin-specific guidance:
 
 - for Kotlin repositories, IntelliJ IDEA is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
 - native Gradle or Maven import resolves Kotlin project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
+
+Scala-specific guidance:
+
+- for Scala repositories, IntelliJ IDEA with the Scala plugin is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
+- native `sbt`, Maven, or Gradle import resolves Scala project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
 
 Ruby-specific guidance:
 
@@ -897,7 +911,7 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
 | Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
 | Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Kotlin, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
-| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Kotlin, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
+| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
 | Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
 | Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
 
@@ -922,6 +936,7 @@ Support policy:
 |-----------------|---------------------------------|---------------------------------------------------------|----------------------------------------------------------|
 | IntelliJ IDEA   | `examples/jvm/java-maven`       | Run the helper checklist below against the Java fixture. | Run the fallback checklist below against the Java fixture. |
 | IntelliJ IDEA   | `examples/jvm/kotlin-gradle`    | Run the helper checklist below against the Kotlin fixture. | Run the fallback checklist below against the Kotlin fixture. |
+| IntelliJ IDEA   | `examples/jvm/scala-sbt`        | Run the helper checklist below against the Scala fixture. | Run the fallback checklist below against the Scala fixture. |
 | GoLand          | `examples/non-gradle/go`        | Run the helper checklist below against the Go fixture.   | Run the fallback checklist below against the Go fixture.   |
 | PyCharm         | `examples/non-gradle/python`    | Run the helper checklist below against the Python fixture. | Run the fallback checklist below against the Python fixture. |
 | RubyMine        | `examples/non-gradle/ruby`      | Run the helper checklist below against the Ruby fixture. | Run the fallback checklist below against the Ruby fixture. |

--- a/examples/jvm/scala-sbt/.github/workflows/microsmith.yml
+++ b/examples/jvm/scala-sbt/.github/workflows/microsmith.yml
@@ -1,0 +1,23 @@
+name: Microsmith Generate (Scala sbt Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Microsmith
+        run: |
+          curl -fsSL -o microsmith-install.sh "$MICROSMITH_INSTALLER_SH_URL"
+          sh microsmith-install.sh --version "$MICROSMITH_VERSION"
+          echo "$HOME/.microsmith/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Microsmith
+        working-directory: examples/jvm/scala-sbt
+        run: microsmith init
+      - name: Generate protobuf
+        working-directory: examples/jvm/scala-sbt
+        run: |
+          microsmith run build.microsmith.kts --out generated
+          test -f generated/proto/ScalaUserCreated.proto

--- a/examples/jvm/scala-sbt/build.sbt
+++ b/examples/jvm/scala-sbt/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "3.7.1"

--- a/examples/jvm/scala-sbt/project/build.properties
+++ b/examples/jvm/scala-sbt/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.7

--- a/examples/jvm/scala-sbt/schema.microsmith.kts
+++ b/examples/jvm/scala-sbt/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("ScalaUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}

--- a/examples/jvm/scala-sbt/src/main/scala/example/App.scala
+++ b/examples/jvm/scala-sbt/src/main/scala/example/App.scala
@@ -1,0 +1,5 @@
+package example
+
+object App {
+  def message: String = "Microsmith Scala fixture"
+}

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
@@ -14,6 +14,7 @@ internal object BuiltInOnboardingProfileMatchers {
             rootMarkerMatcher(GoOnboardingProfile, "go.mod"),
             javaMatcher(),
             kotlinMatcher(),
+            scalaMatcher(),
             rootMarkerMatcher(
                 PythonOnboardingProfile,
                 "pyproject.toml",
@@ -60,6 +61,12 @@ internal object BuiltInOnboardingProfileMatchers {
     private fun kotlinMatcher(): OnboardingProfileMatcher {
         return OnboardingProfileMatcher(KotlinOnboardingProfile) { projectRoot ->
             KotlinOnboardingMarkerFinder.find(projectRoot)
+        }
+    }
+
+    private fun scalaMatcher(): OnboardingProfileMatcher {
+        return OnboardingProfileMatcher(ScalaOnboardingProfile) { projectRoot ->
+            ScalaOnboardingMarkerFinder.find(projectRoot)
         }
     }
 

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JavaOnboardingMarkerFinder.kt
@@ -3,7 +3,8 @@ package me.liam.microsmith.cli.init
 import java.nio.file.Path
 
 internal object JavaOnboardingMarkerFinder {
-    fun find(projectRoot: Path): List<String> = JvmOnboardingMarkerFinder.find(projectRoot, ::isSupportedJavaSourceRoot)
+    fun find(projectRoot: Path): List<String> =
+        JvmOnboardingMarkerFinder.find(projectRoot, JVM_LANGUAGE_BUILD_MARKERS, ::isSupportedJavaSourceRoot)
 
     private fun isSupportedJavaSourceRoot(relativeDirectory: Path): Boolean =
         JAVA_SOURCE_ROOT_MARKERS.any(relativeDirectory::endsWith)

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingBuildMarkers.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingBuildMarkers.kt
@@ -1,0 +1,16 @@
+package me.liam.microsmith.cli.init
+
+import java.nio.file.Path
+
+internal val JVM_LANGUAGE_BUILD_MARKERS = listOf(
+    Path.of("pom.xml"),
+    Path.of("build.gradle"),
+    Path.of("build.gradle.kts"),
+    Path.of("settings.gradle"),
+    Path.of("settings.gradle.kts"),
+)
+
+internal val SCALA_BUILD_MARKERS = listOf(
+    Path.of("build.sbt"),
+    Path.of("project/build.properties"),
+) + JVM_LANGUAGE_BUILD_MARKERS

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
@@ -10,12 +10,13 @@ import java.nio.file.attribute.BasicFileAttributes
 import kotlin.io.path.isRegularFile
 
 internal object JvmOnboardingMarkerFinder {
-    fun find(projectRoot: Path, sourceRootMatcher: (Path) -> Boolean): List<String> {
+    fun find(projectRoot: Path, buildMarkers: List<Path>, sourceRootMatcher: (Path) -> Boolean): List<String> {
         return try {
             val matchedBuildMarkers =
-                JVM_BUILD_MARKERS.filter { markerFileName ->
-                    projectRoot.resolve(markerFileName).isRegularFile()
-                }
+                buildMarkers
+                    .filter { markerPath ->
+                        projectRoot.resolve(markerPath).isRegularFile()
+                    }.map(Path::toString)
             val rootSourceMarkers = findRootSourceMarkers(projectRoot, sourceRootMatcher)
 
             when {
@@ -85,7 +86,9 @@ internal object JvmOnboardingMarkerFinder {
                     }
 
                     val relativeDirectory = projectRoot.relativize(directory)
-                    return if (isRootSourceMarker(relativeDirectory, sourceRootMatcher)) {
+                    return if (isIgnoredInfrastructureDirectory(relativeDirectory)) {
+                        FileVisitResult.SKIP_SUBTREE
+                    } else if (isRootSourceMarker(relativeDirectory, sourceRootMatcher)) {
                         FileVisitResult.SKIP_SUBTREE
                     } else if (sourceRootMatcher(relativeDirectory)) {
                         matchedMarkers += relativeDirectory.toString()
@@ -110,18 +113,26 @@ internal object JvmOnboardingMarkerFinder {
             relativeDirectory.getName(0).toString() == SOURCE_ROOT_DIRECTORY_NAME &&
             sourceRootMatcher(relativeDirectory)
     }
-}
 
-private val JVM_BUILD_MARKERS = listOf(
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "settings.gradle",
-    "settings.gradle.kts",
-)
+    private fun isIgnoredInfrastructureDirectory(relativeDirectory: Path): Boolean {
+        return relativeDirectory.nameCount == INFRASTRUCTURE_DIRECTORY_DEPTH &&
+            relativeDirectory.getName(0).toString() in IGNORED_INFRASTRUCTURE_DIRECTORIES
+    }
+}
 
 private const val MODULE_SOURCE_SEARCH_DEPTH = 6
 
 private const val ROOT_SOURCE_MARKER_DEPTH = 3
 
+private const val INFRASTRUCTURE_DIRECTORY_DEPTH = 1
+
 private const val SOURCE_ROOT_DIRECTORY_NAME = "src"
+
+private val IGNORED_INFRASTRUCTURE_DIRECTORIES = setOf(
+    ".gradle",
+    ".microsmith",
+    "build",
+    "build-logic",
+    "buildSrc",
+    "gradle",
+)

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
@@ -86,7 +86,7 @@ internal object JvmOnboardingMarkerFinder {
                     }
 
                     val relativeDirectory = projectRoot.relativize(directory)
-                    return if (isIgnoredInfrastructureDirectory(relativeDirectory)) {
+                    return if (isIgnoredNestedScanRootDirectory(relativeDirectory)) {
                         FileVisitResult.SKIP_SUBTREE
                     } else if (isRootSourceMarker(relativeDirectory, sourceRootMatcher)) {
                         FileVisitResult.SKIP_SUBTREE
@@ -114,9 +114,9 @@ internal object JvmOnboardingMarkerFinder {
             sourceRootMatcher(relativeDirectory)
     }
 
-    private fun isIgnoredInfrastructureDirectory(relativeDirectory: Path): Boolean {
+    private fun isIgnoredNestedScanRootDirectory(relativeDirectory: Path): Boolean {
         return relativeDirectory.nameCount == INFRASTRUCTURE_DIRECTORY_DEPTH &&
-            relativeDirectory.getName(0).toString() in IGNORED_INFRASTRUCTURE_DIRECTORIES
+            relativeDirectory.getName(0).toString() in IGNORED_NESTED_SCAN_ROOT_DIRECTORIES
     }
 }
 
@@ -128,11 +128,17 @@ private const val INFRASTRUCTURE_DIRECTORY_DEPTH = 1
 
 private const val SOURCE_ROOT_DIRECTORY_NAME = "src"
 
-private val IGNORED_INFRASTRUCTURE_DIRECTORIES = setOf(
+private val IGNORED_NESTED_SCAN_ROOT_DIRECTORIES = setOf(
     ".gradle",
     ".microsmith",
     "build",
     "build-logic",
     "buildSrc",
+    "doc",
+    "docs",
+    "example",
+    "examples",
     "gradle",
+    "sample",
+    "samples",
 )

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/KotlinOnboardingMarkerFinder.kt
@@ -4,7 +4,7 @@ import java.nio.file.Path
 
 internal object KotlinOnboardingMarkerFinder {
     fun find(projectRoot: Path): List<String> =
-        JvmOnboardingMarkerFinder.find(projectRoot, ::isSupportedKotlinSourceRoot)
+        JvmOnboardingMarkerFinder.find(projectRoot, JVM_LANGUAGE_BUILD_MARKERS, ::isSupportedKotlinSourceRoot)
 
     private fun isSupportedKotlinSourceRoot(relativeDirectory: Path): Boolean {
         if (relativeDirectory.nameCount < MINIMUM_KOTLIN_SOURCE_ROOT_DEPTH) {

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/ScalaOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/ScalaOnboardingMarkerFinder.kt
@@ -1,0 +1,13 @@
+package me.liam.microsmith.cli.init
+
+import java.nio.file.Path
+
+internal object ScalaOnboardingMarkerFinder {
+    fun find(projectRoot: Path): List<String> =
+        JvmOnboardingMarkerFinder.find(projectRoot, SCALA_BUILD_MARKERS, ::isSupportedScalaSourceRoot)
+
+    private fun isSupportedScalaSourceRoot(relativeDirectory: Path): Boolean =
+        relativeDirectory.endsWith(SCALA_MAIN_SOURCE_ROOT_MARKER)
+}
+
+private val SCALA_MAIN_SOURCE_ROOT_MARKER = Path.of("src/main/scala")

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/ScalaOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/init/ScalaOnboardingProfile.kt
@@ -1,0 +1,8 @@
+package me.liam.microsmith.cli.init
+
+internal data object ScalaOnboardingProfile : OnboardingProfile {
+    override val id: OnboardingProfileId = OnboardingProfileId("scala")
+    override val displayName: String = "Scala"
+    override val sampleMessageName: String = "ScalaUserCreated"
+    override val recommendedOutputDirectory: String? = null
+}

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -19,6 +19,7 @@ import me.liam.microsmith.cli.init.OnboardingProfileSelectionReason
 import me.liam.microsmith.cli.init.PythonOnboardingProfile
 import me.liam.microsmith.cli.init.RubyOnboardingProfile
 import me.liam.microsmith.cli.init.RustOnboardingProfile
+import me.liam.microsmith.cli.init.ScalaOnboardingProfile
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteRecursively
@@ -390,6 +391,51 @@ class MicrosmithCliInitTests :
 
                 exitCode shouldBe 0
                 out.joinToString("\n").shouldContain("Detected repository profile: Kotlin")
+                out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldNotContain("Optional repository-native output path")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command keeps Scala on the canonical generated output path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-scala")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingProfileDetection(
+                                    profile = ScalaOnboardingProfile,
+                                    selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                                    matchedMarkers = listOf("build.sbt", "src/main/scala"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = emptyList(),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Detected repository profile: Scala")
                 out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
                 out.joinToString("\n").shouldNotContain("Optional repository-native output path")
                 err shouldBe emptyList()

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
@@ -329,6 +329,94 @@ class OnboardingProfileDetectorTests :
             }
         }
 
+        "detects Scala repositories from sbt, Maven, Gradle, and build-tool-light layouts" {
+            val sbtRoot = createTempDirectory("microsmith-init-detect-scala-sbt")
+            val mavenRoot = createTempDirectory("microsmith-init-detect-scala-maven")
+            val gradleRoot = createTempDirectory("microsmith-init-detect-scala-gradle")
+            val lightweightRoot = createTempDirectory("microsmith-init-detect-scala-lightweight")
+            val testOnlyRoot = createTempDirectory("microsmith-init-detect-scala-test-only")
+            try {
+                sbtRoot.resolve("project").createDirectories()
+                sbtRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                sbtRoot.resolve("project/build.properties").writeText("sbt.version=1.11.7\n")
+                sbtRoot.resolve("src/main/scala/example").createDirectories()
+                mavenRoot.resolve("pom.xml").writeText("<project />\n")
+                mavenRoot.resolve("src/main/scala/example").createDirectories()
+                gradleRoot.resolve("build.gradle.kts").writeText("plugins { scala }\n")
+                gradleRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture-scala\"\n")
+                gradleRoot.resolve("src/main/scala/example").createDirectories()
+                lightweightRoot.resolve("src/main/scala/example").createDirectories()
+                testOnlyRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                testOnlyRoot.resolve("src/test/scala/example").createDirectories()
+
+                detectOnboardingProfile(sbtRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.sbt", "project/build.properties", "src/main/scala"),
+                    )
+                detectOnboardingProfile(mavenRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pom.xml", "src/main/scala"),
+                    )
+                detectOnboardingProfile(gradleRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "settings.gradle.kts", "src/main/scala"),
+                    )
+                detectOnboardingProfile(lightweightRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("src/main/scala"),
+                    )
+                detectOnboardingProfile(testOnlyRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+            } finally {
+                runCatching { sbtRoot.deleteRecursively() }
+                runCatching { mavenRoot.deleteRecursively() }
+                runCatching { gradleRoot.deleteRecursively() }
+                runCatching { lightweightRoot.deleteRecursively() }
+                runCatching { testOnlyRoot.deleteRecursively() }
+            }
+        }
+
+        "ignores top-level JVM build infrastructure source roots" {
+            val scalaInfrastructureRoot = createTempDirectory("microsmith-init-detect-scala-build-infra")
+            val kotlinInfrastructureRoot = createTempDirectory("microsmith-init-detect-kotlin-build-infra")
+            try {
+                scalaInfrastructureRoot.resolve("settings.gradle.kts")
+                    .writeText("rootProject.name = \"fixture-build-infra\"\n")
+                scalaInfrastructureRoot.resolve("build-logic/src/main/scala/example").createDirectories()
+                kotlinInfrastructureRoot.resolve("settings.gradle.kts")
+                    .writeText("rootProject.name = \"fixture-build-infra\"\n")
+                kotlinInfrastructureRoot.resolve("buildSrc/src/main/kotlin/example").createDirectories()
+
+                detectOnboardingProfile(scalaInfrastructureRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+                detectOnboardingProfile(kotlinInfrastructureRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+            } finally {
+                runCatching { scalaInfrastructureRoot.deleteRecursively() }
+                runCatching { kotlinInfrastructureRoot.deleteRecursively() }
+            }
+        }
+
         "keeps the Python profile when multiple Python markers match" {
             val pythonRoot = createTempDirectory("microsmith-init-detect-python-multi")
             try {
@@ -444,6 +532,7 @@ class OnboardingProfileDetectorTests :
             val pythonRoot = createTempDirectory("microsmith-init-detect-python")
             val rubyRoot = createTempDirectory("microsmith-init-detect-ruby")
             val rustRoot = createTempDirectory("microsmith-init-detect-rust")
+            val scalaRoot = createTempDirectory("microsmith-init-detect-scala")
             val dotnetRoot = createTempDirectory("microsmith-init-detect-dotnet")
             val mixedRoot = createTempDirectory("microsmith-init-detect-mixed")
             try {
@@ -456,6 +545,8 @@ class OnboardingProfileDetectorTests :
                 pythonRoot.resolve("pyproject.toml").writeText("[project]\nname = \"fixture-python\"\n")
                 rubyRoot.resolve("gems.rb").writeText("source \"https://rubygems.org\"\n")
                 rustRoot.resolve("Cargo.toml").writeText("[package]\nname = \"fixture-rust\"\nversion = \"0.1.0\"\n")
+                scalaRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                scalaRoot.resolve("src/main/scala/example").createDirectories()
                 dotnetRoot.resolve("src/apps/service").createDirectories()
                 dotnetRoot.resolve("src/apps/service/Fixture.csproj")
                     .writeText("<Project Sdk=\"Microsoft.NET.Sdk\" />\n")
@@ -504,6 +595,12 @@ class OnboardingProfileDetectorTests :
                         selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
                         matchedMarkers = listOf("Cargo.toml"),
                     )
+                detectOnboardingProfile(scalaRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.sbt", "src/main/scala"),
+                    )
                 detectOnboardingProfile(dotnetRoot) shouldBe
                     OnboardingProfileDetection(
                         profile = DotnetOnboardingProfile,
@@ -524,6 +621,7 @@ class OnboardingProfileDetectorTests :
                 runCatching { pythonRoot.deleteRecursively() }
                 runCatching { rubyRoot.deleteRecursively() }
                 runCatching { rustRoot.deleteRecursively() }
+                runCatching { scalaRoot.deleteRecursively() }
                 runCatching { dotnetRoot.deleteRecursively() }
                 runCatching { mixedRoot.deleteRecursively() }
             }

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
@@ -391,6 +391,7 @@ class OnboardingProfileDetectorTests :
         "ignores top-level JVM build infrastructure source roots" {
             val scalaInfrastructureRoot = createTempDirectory("microsmith-init-detect-scala-build-infra")
             val kotlinInfrastructureRoot = createTempDirectory("microsmith-init-detect-kotlin-build-infra")
+            val scalaExamplesRoot = createTempDirectory("microsmith-init-detect-scala-examples")
             try {
                 scalaInfrastructureRoot.resolve("settings.gradle.kts")
                     .writeText("rootProject.name = \"fixture-build-infra\"\n")
@@ -398,6 +399,9 @@ class OnboardingProfileDetectorTests :
                 kotlinInfrastructureRoot.resolve("settings.gradle.kts")
                     .writeText("rootProject.name = \"fixture-build-infra\"\n")
                 kotlinInfrastructureRoot.resolve("buildSrc/src/main/kotlin/example").createDirectories()
+                scalaExamplesRoot.resolve("settings.gradle.kts")
+                    .writeText("rootProject.name = \"fixture-examples\"\n")
+                scalaExamplesRoot.resolve("examples/scala/src/main/scala/example").createDirectories()
 
                 detectOnboardingProfile(scalaInfrastructureRoot) shouldBe
                     OnboardingProfileDetection(
@@ -411,9 +415,16 @@ class OnboardingProfileDetectorTests :
                         selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
                         matchedMarkers = emptyList(),
                     )
+                detectOnboardingProfile(scalaExamplesRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
             } finally {
                 runCatching { scalaInfrastructureRoot.deleteRecursively() }
                 runCatching { kotlinInfrastructureRoot.deleteRecursively() }
+                runCatching { scalaExamplesRoot.deleteRecursively() }
             }
         }
 

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/ScalaOnboardingProfileTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/init/ScalaOnboardingProfileTests.kt
@@ -1,0 +1,203 @@
+package me.liam.microsmith.cli.init
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.cli.command.InitCommand
+import me.liam.microsmith.cli.ide.IdeHelperRefreshResult
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+@OptIn(ExperimentalPathApi::class)
+class ScalaOnboardingProfileTests :
+    StringSpec({
+        "creates repo-aware bootstrap files for Scala repositories without a repository-native output override" {
+            val repoRoot = createTempDirectory("microsmith-init-bootstrap-scala")
+            repoRoot.resolve("project").createDirectories()
+            repoRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+            repoRoot.resolve("project/build.properties").writeText("sbt.version=1.11.7\n")
+            repoRoot.resolve("src/main/scala/example").createDirectories()
+            repoRoot.resolve("src/main/scala/example/App.scala").writeText(
+                """
+                package example
+
+                object App {
+                  def message: String = "Microsmith Scala fixture"
+                }
+                """.trimIndent() + "\n",
+            )
+            try {
+                val helperRoot = repoRoot.resolve(".microsmith/ide")
+                val result =
+                    runInitBootstrap(
+                        command = InitCommand(projectRoot = repoRoot),
+                        ideRefreshRunner = { command ->
+                            IdeHelperRefreshResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                helperRoot = helperRoot,
+                                updatedFiles = listOf(helperRoot.resolve("build.gradle.kts")),
+                                classpathEntries = listOf(repoRoot.resolve("runtime/microsmith-cli-all.jar")),
+                            )
+                        },
+                    )
+
+                result.repositoryDetection.profile shouldBe ScalaOnboardingProfile
+                result.repositoryDetection.matchedMarkers shouldBe
+                    listOf("build.sbt", "project/build.properties", "src/main/scala")
+                val buildScript = repoRoot.resolve("build.microsmith.kts").readText()
+                val settingsScript = repoRoot.resolve("settings.microsmith.kts").readText()
+
+                buildScript.shouldContain("ScalaUserCreated")
+                buildScript.shouldContain("microsmith run build.microsmith.kts --out ./generated")
+                buildScript.shouldContain("// Bootstrapped Microsmith schema for this Scala repository.")
+                buildScript.contains("Common repository-native output path:") shouldBe false
+                settingsScript.shouldContain("Detected repository profile: Scala")
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Scala repositories from sbt roots when a Scala main source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-sbt")
+            try {
+                repoRoot.resolve("project").createDirectories()
+                repoRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                repoRoot.resolve("project/build.properties").writeText("sbt.version=1.11.7\n")
+                repoRoot.resolve("src/main/scala/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.sbt", "project/build.properties", "src/main/scala"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Scala repositories from Maven roots when a Scala main source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-maven")
+            try {
+                repoRoot.resolve("pom.xml").writeText("<project />\n")
+                repoRoot.resolve("src/main/scala/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("pom.xml", "src/main/scala"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects Scala repositories from Gradle roots when a Scala main source tree exists" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-gradle")
+            try {
+                repoRoot.resolve("build.gradle.kts").writeText("plugins { scala }\n")
+                repoRoot.resolve("settings.gradle.kts").writeText("rootProject.name = \"fixture-scala\"\n")
+                repoRoot.resolve("src/main/scala/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.gradle.kts", "settings.gradle.kts", "src/main/scala"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects multi-module Scala repositories from nested Scala main source trees" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-multi-module")
+            try {
+                repoRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                repoRoot.resolve("services/app/src/main/scala/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("build.sbt", "services/app/src/main/scala"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "detects build-tool-light Scala repositories from a Scala main source root alone" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-lightweight")
+            try {
+                repoRoot.resolve("src/main/scala/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = ScalaOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                        matchedMarkers = listOf("src/main/scala"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile for Scala build files without a Scala main source tree" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-build-only")
+            try {
+                repoRoot.resolve("project").createDirectories()
+                repoRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                repoRoot.resolve("project/build.properties").writeText("sbt.version=1.11.7\n")
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile for test-only Scala repositories" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-test-only")
+            try {
+                repoRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                repoRoot.resolve("src/test/scala/example").createDirectories()
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.NO_MARKERS_MATCHED,
+                        matchedMarkers = emptyList(),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+
+        "falls back to the generic profile when Scala and another ecosystem marker both match" {
+            val repoRoot = createTempDirectory("microsmith-init-detect-scala-mixed")
+            try {
+                repoRoot.resolve("build.sbt").writeText("""scalaVersion := "3.7.1""" + "\n")
+                repoRoot.resolve("src/main/scala/example").createDirectories()
+                repoRoot.resolve("package.json").writeText("""{"name":"fixture-node"}""")
+
+                detectOnboardingProfile(repoRoot) shouldBe
+                    OnboardingProfileDetection(
+                        profile = GenericOnboardingProfile,
+                        selectionReason = OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS,
+                        matchedMarkers = listOf("build.sbt", "package.json", "src/main/scala"),
+                    )
+            } finally {
+                runCatching { repoRoot.deleteRecursively() }
+            }
+        }
+    })


### PR DESCRIPTION
## Why
Scala repositories are part of the supported JVM onboarding matrix in milestone `Universal Repository Onboarding and Ecosystem Coverage`, but they still had no explicit bootstrap contract, fixture coverage, or JetBrains IDE guidance.

This PR adds the baseline Scala onboarding path without trying to solve native `sbt`, Maven, or Gradle Microsmith integration in the same change. That deeper build-tool-native work remains tracked separately.

## What Changed
- added a first-class Scala onboarding profile and source-root detection
- generalized the shared JVM marker finder so each JVM language can provide its own build markers
- kept Scala onboarding conservative:
  - requires a Scala main source root such as `src/main/scala`
  - recognizes root `sbt`, Maven, and Gradle markers when present
  - keeps test-only Scala roots on the generic onboarding path
  - keeps mixed first-class matches generic rather than guessing
- hardened the shared JVM module scan to ignore top-level build infrastructure directories such as `buildSrc` and `build-logic`
- added Scala-specific CLI and detector coverage
- added a representative `examples/jvm/scala-sbt` fixture and Linux smoke coverage
- documented the Scala onboarding and JetBrains IDE contract in `README.md`

## Contract
- Scala onboarding is CLI-first and keeps the canonical `./generated` output path.
- `microsmith init` recognizes Scala repositories from:
  - `src/main/scala`
  - nested module `src/main/scala` roots when a root `sbt`, Maven, or Gradle marker exists
  - root `build.sbt`
  - root `project/build.properties`
  - root `pom.xml`
  - root `build.gradle` / `build.gradle.kts`
  - root `settings.gradle` / `settings.gradle.kts`
- `src/test/scala` alone is not treated as sufficient evidence for Scala onboarding in this baseline issue.
- IntelliJ IDEA with the Scala plugin is the documented JetBrains IDE path for `.microsmith.kts` authoring until native JVM build-tool integration lands.

## Validation
- `./gradlew :cli:check :cli:jvmKotest :cli:releaseArtifacts --rerun-tasks --no-build-cache`
- built-launcher smoke against a temp copy of `examples/jvm/scala-sbt`:
  - `microsmith init`
  - `microsmith ide refresh`
  - `microsmith ide doctor --diagnostics json`
  - `microsmith run build.microsmith.kts --out generated`
- `./modules/cli/build/microsmith-cli-dist/bin/microsmith --help > /tmp/microsmith-cli-help.txt && python3 scripts/verify_readme_cli_usage.py README.md /tmp/microsmith-cli-help.txt`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_test_qodana.yml")'`
- `git diff --check`
- `./gradlew build --rerun-tasks --no-build-cache`

## Follow-On Work
- Native Gradle integration: #100
- Native Maven integration: #101
- Native `sbt` integration: #102

Closes #90
