### PR TITLE
feat(jvm-gradle): support native Microsmith integration in Gradle repositories

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build-and-qodana:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
     permissions:
@@ -33,6 +33,28 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Build
         run: ./gradlew build --stacktrace
+      - name: Publish Gradle-native packages to mavenLocal
+        run: |
+          ./gradlew \
+            :dsl:publishToMavenLocal \
+            :dsl-schemas:publishToMavenLocal \
+            :dsl-schemas-protobuf:publishToMavenLocal \
+            :gen:publishToMavenLocal \
+            :gen-schemas:publishToMavenLocal \
+            :gen-schemas-protobuf:publishToMavenLocal \
+            :runtime-scripting:publishToMavenLocal \
+            :gradle-plugin:publishToMavenLocal \
+            --stacktrace
+      - name: Validate native Gradle fixtures
+        run: |
+          set -euo pipefail
+          VERSION="$(./gradlew -q properties | sed -n 's/^version: //p' | head -n 1)"
+          ./gradlew -p examples/gradle/java microsmithGenerate -PmicrosmithVersion="$VERSION" --stacktrace
+          test -f examples/gradle/java/build/generated/microsmith/proto/JavaGradleUserCreated.proto
+          ./gradlew -p examples/gradle/kotlin microsmithGenerate -PmicrosmithVersion="$VERSION" --stacktrace
+          test -f examples/gradle/kotlin/build/generated/microsmith/proto/KotlinGradleUserCreated.proto
+          ./gradlew -p examples/gradle/scala microsmithGenerate -PmicrosmithVersion="$VERSION" --stacktrace
+          test -f examples/gradle/scala/build/generated/microsmith/proto/ScalaGradleUserCreated.proto
       - name: Validate IDE fallback release assets
         run: |
           ./gradlew :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums --stacktrace
@@ -40,10 +62,10 @@ jobs:
           find modules/runtime-scripting/build/release-assets -maxdepth 1 -type f -name 'microsmith-script-definition-*-all.jar.sha256' | grep -q .
       - name: Publish Test Report
         uses: dorny/test-reporter@v2
-        if: ${{ always() && hashFiles('**/build/test-results/jvmKotest/*.xml') != '' }}
+        if: ${{ always() && hashFiles('**/build/test-results/**/*.xml') != '' }}
         with:
-          name: Kotest Results
-          path: '**/build/test-results/jvmKotest/*.xml'
+          name: JVM Test Results
+          path: '**/build/test-results/**/*.xml'
           reporter: java-junit
       - name: 'Qodana Scan'
         if: ${{ env.QODANA_TOKEN != '' }}

--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -49,12 +49,18 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="$(./gradlew -q properties | sed -n 's/^version: //p' | head -n 1)"
-          ./gradlew -p examples/gradle/java microsmithGenerate -PmicrosmithVersion="$VERSION" --stacktrace
-          test -f examples/gradle/java/build/generated/microsmith/proto/JavaGradleUserCreated.proto
-          ./gradlew -p examples/gradle/kotlin microsmithGenerate -PmicrosmithVersion="$VERSION" --stacktrace
-          test -f examples/gradle/kotlin/build/generated/microsmith/proto/KotlinGradleUserCreated.proto
-          ./gradlew -p examples/gradle/scala microsmithGenerate -PmicrosmithVersion="$VERSION" --stacktrace
-          test -f examples/gradle/scala/build/generated/microsmith/proto/ScalaGradleUserCreated.proto
+          validate_gradle_fixture() {
+            local repo_root="$1"
+            local generated_root="$repo_root/build/generated/microsmith/proto"
+
+            ./gradlew -p "$repo_root" microsmithGenerate -PmicrosmithVersion="$VERSION" --stacktrace
+            test -d "$generated_root"
+            find "$generated_root" -maxdepth 1 -type f -name '*.proto' | grep -q .
+          }
+
+          validate_gradle_fixture examples/gradle/java
+          validate_gradle_fixture examples/gradle/kotlin
+          validate_gradle_fixture examples/gradle/scala
       - name: Validate IDE fallback release assets
         run: |
           ./gradlew :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums --stacktrace

--- a/README.md
+++ b/README.md
@@ -311,13 +311,17 @@ Canonical contract:
 1. Configure plugin resolution in `settings.gradle.kts`.
 2. Configure normal dependency repositories as well, because the plugin resolves `runtime-scripting` and any `microsmithPlugins` entries as standard Gradle dependencies.
 3. Apply plugin id `me.liam.microsmith.gradle`.
-4. Configure `microsmithGradle { ... }`.
+4. Configure `microsmith { ... }`.
 5. Run `./gradlew microsmithGenerate`.
 
 Minimal settings example:
 
 ```kotlin
 pluginManagement {
+    val microsmithVersion = providers.gradleProperty("microsmithVersion").orNull ?: error(
+        "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+    )
+
     repositories {
         gradlePluginPortal()
         mavenCentral()
@@ -332,15 +336,8 @@ pluginManagement {
             }
         }
     }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "me.liam.microsmith.gradle") {
-                val microsmithVersion = providers.gradleProperty("microsmithVersion").orNull ?: error(
-                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
-                )
-                useModule("me.liam.microsmith:gradle-plugin:$microsmithVersion")
-            }
-        }
+    plugins {
+        id("me.liam.microsmith.gradle") version microsmithVersion
     }
 }
 
@@ -369,7 +366,7 @@ plugins {
     id("me.liam.microsmith.gradle")
 }
 
-microsmithGradle {
+microsmith {
     scriptFile.set(layout.projectDirectory.file("build.microsmith.kts"))
 }
 
@@ -378,12 +375,18 @@ tasks.named("check") {
 }
 ```
 
+No extra import is required. The plugin exposes `microsmith { ... }` through Gradle Kotlin DSL accessors once the plugin is applied in the `plugins {}` block.
+
+The plugin version still has to be declared in `settings.gradle.kts` or in the `plugins {}` block. Gradle resolves the plugin before plugin code runs, so the plugin cannot self-select or self-upgrade its own version.
+
 The native Gradle plugin exposes:
 
 - `microsmithGenerate`: runs the configured `.microsmith.kts` script in a dedicated worker JVM so Gradle's embedded Kotlin runtime does not collide with Microsmith's scripting host
-- `microsmithGradle`: extension for `scriptFile`, `outputDirectory`, `variables`, and `flags`
+- `microsmith`: extension for `scriptFile`, `outputDirectory`, `variables`, and `flags`
 - `microsmithPlugins`: resolvable configuration for external Microsmith generator plugins
 - `microsmithIde`: IDE-facing classpath that includes Microsmith runtime types and plugin-provided types and is wired into `compileOnly` for Java-base projects
+
+Gradle does not support a task path like `microsmith:generate` unless Microsmith were modeled as a separate project. The idiomatic expansion path is a `microsmith` task group with prefixed tasks such as `microsmithGenerate`, `microsmithDoctor`, and `microsmithIdeRefresh`.
 
 External plugin example:
 

--- a/README.md
+++ b/README.md
@@ -375,18 +375,12 @@ tasks.named("check") {
 }
 ```
 
-No extra import is required. The plugin exposes `microsmith { ... }` through Gradle Kotlin DSL accessors once the plugin is applied in the `plugins {}` block.
-
-The plugin version still has to be declared in `settings.gradle.kts` or in the `plugins {}` block. Gradle resolves the plugin before plugin code runs, so the plugin cannot self-select or self-upgrade its own version.
-
 The native Gradle plugin exposes:
 
 - `microsmithGenerate`: runs the configured `.microsmith.kts` script in a dedicated worker JVM so Gradle's embedded Kotlin runtime does not collide with Microsmith's scripting host
 - `microsmith`: extension for `scriptFile`, `outputDirectory`, `variables`, and `flags`
 - `microsmithPlugins`: resolvable configuration for external Microsmith generator plugins
 - `microsmithIde`: IDE-facing classpath that includes Microsmith runtime types and plugin-provided types and is wired into `compileOnly` for Java-base projects
-
-Gradle does not support a task path like `microsmith:generate` unless Microsmith were modeled as a separate project. The idiomatic expansion path is a `microsmith` task group with prefixed tasks such as `microsmithGenerate`, `microsmithDoctor`, and `microsmithIdeRefresh`.
 
 External plugin example:
 
@@ -1205,14 +1199,14 @@ The DSL surface stays the same; the execution boundary changes.
 
 | Previous pattern                 | CLI replacement                                          |
 |----------------------------------|----------------------------------------------------------|
-| Gradle task invoking generation  | `microsmith run schema.microsmith.kts --out ./generated` |
+| Gradle task invoking generation  | `microsmith run build.microsmith.kts --out ./generated`  |
 | Gradle-managed plugin dependency | `--plugin group:artifact:version`                        |
 | local classpath jar wiring       | `--plugin-jar ./path/to/plugin.jar`                      |
 | Gradle offline mode              | `--offline`                                              |
 
 ### Recommended migration sequence to the standalone CLI
 
-1. Move the DSL into `*.microsmith.kts` files.
+1. Keep the Microsmith DSL in `*.microsmith.kts` files.
 2. Replace Gradle-based generation commands in CI with `microsmith run`.
 3. Pin plugin coordinates and validate lock or checksum behavior for reproducibility.
 4. Enable the relevant security controls for your environment.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Microsmith
 
 Microsmith is a Kotlin DSL and standalone CLI for declaring domain-specific models and generating artifacts from `.microsmith.kts` scripts.
-It is designed to work both inside this Gradle repository and from consumer repositories including Go, .NET, Node, Python, Ruby, Rust, and Java projects.
+It is designed to work both inside this Gradle repository, inside consumer Gradle builds, and from standalone consumer repositories including Go, .NET, Node, Python, Ruby, Rust, Java, Kotlin, and Scala projects.
 
 This README is the canonical repository documentation.
 
@@ -14,6 +14,7 @@ This README is the canonical repository documentation.
 - Build, test, and quality gates
 - DSL usage
 - Standalone CLI for consumer repositories
+- Native Gradle integration
 - Installation and verification
 - Command reference
 - JetBrains IDE helper
@@ -33,6 +34,7 @@ Microsmith provides:
 - extension points for schema and generation dialects
 - a standalone CLI for running `.microsmith.kts` scripts without embedding Gradle in consumer repositories
 - bundled built-in providers for the default schema and protobuf workflows
+- a native Gradle plugin for Java, Kotlin, and Scala repositories that want imported-project build alignment
 - a JetBrains IDE helper workflow for stronger type resolution in consumer repositories
 
 ## Repository modules
@@ -45,6 +47,7 @@ Microsmith provides:
 - `gen-schemas-protobuf`: protobuf emitters, rendering, and protobuf-specific generation support
 - `runtime-scripting`: Kotlin scripting host for `.microsmith.kts` execution
 - `cli`: command-line entrypoint, diagnostics, installer packaging, and IDE helper support
+- `gradle-plugin`: native Gradle integration for `.microsmith.kts` execution and imported-project IDE alignment
 - `kotest`: shared Kotest configuration used by repository test suites
 
 ### Module boundary map
@@ -56,11 +59,12 @@ Microsmith provides:
 - `gen-schemas` and `gen-schemas-protobuf` own schema-aware emission, rendering, and validation. They should depend downward on model and generator layers, not upward on CLI or installer behavior.
 - `runtime-scripting` is the scripting host and execution boundary. It may depend on DSL and generation layers, but it must not absorb CLI parsing, onboarding, or distribution concerns.
 - `cli` is the application layer for command parsing, diagnostics, repository onboarding, plugin resolution, installation, and JetBrains IDE helper workflows. Lower layers must not depend on `cli`.
+- `gradle-plugin` is the native Gradle integration surface for Gradle-imported JVM repositories. It should stay thin, Gradle-conventional, and explicit about task/configuration wiring rather than absorbing CLI concerns.
 - `kotest` is test support only and should not become a production dependency surface.
 
 ## Repository layout
 
-- `modules/`: production Gradle subprojects, including `cli`, `dsl`, `dsl-schemas`, `dsl-schemas-protobuf`, `gen`, `gen-schemas`, `gen-schemas-protobuf`, `runtime-scripting`, and `kotest`
+- `modules/`: production Gradle subprojects, including `cli`, `dsl`, `dsl-schemas`, `dsl-schemas-protobuf`, `gen`, `gen-schemas`, `gen-schemas-protobuf`, `runtime-scripting`, `gradle-plugin`, and `kotest`
 - `build-logic/`: included Gradle build that owns repository-specific plugins and quality tasks
 - `examples/`: consumer-repository fixtures and onboarding examples
 - `gradle/`: wrapper files, version catalog, and dependency locks
@@ -223,7 +227,7 @@ Inside `.microsmith.kts` scripts:
 
 ## Standalone CLI for consumer repositories
 
-The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, Java, Kotlin, Scala, and other repositories when you want self-contained Microsmith execution without depending on a local Gradle or Maven install.
+The CLI is the recommended entrypoint for Go, .NET, Node, Python, Ruby, Rust, Maven-based JVM repositories, build-tool-light JVM repositories, and any repository where you want self-contained Microsmith execution without depending on a local Gradle or Maven install.
 The official installer scripts are self-contained and provision a Java 24 runtime automatically when the machine does not already provide one.
 
 Manual channels remain available, but they require Java 24 or newer.
@@ -265,8 +269,8 @@ After the canonical first run succeeds, you can switch to a repository-native ou
 - Node: `microsmith run build.microsmith.kts --out ./generated`
 - Go: `microsmith run build.microsmith.kts --out ./internal/gen`
 - Java: keep the canonical `./generated` output path unless you explicitly wire generated sources into Maven or Gradle later
-- Kotlin: keep the canonical `./generated` output path unless you intentionally adopt deeper native Gradle or Maven integration later
-- Scala: keep the canonical `./generated` output path unless you intentionally adopt deeper native `sbt`, Gradle, or Maven integration later
+- Kotlin: keep the canonical `./generated` output path unless you explicitly wire generated sources into Gradle or Maven later
+- Scala: keep the canonical `./generated` output path unless you explicitly wire generated sources into Gradle, `sbt`, or Maven later
 - Python: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Ruby: keep the canonical `./generated` output path unless your repository already has a stronger convention
 - Rust: keep the canonical `./generated` output path unless your repository already has a stronger convention
@@ -275,22 +279,133 @@ After the canonical first run succeeds, you can switch to a repository-native ou
 Java-specific guidance:
 
 - Maven-based Java repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
-- Gradle-based Java repositories: keep Microsmith CLI-managed by default and do not wire Microsmith into the Gradle build automatically as part of onboarding
+- Gradle-based Java repositories: prefer the native Gradle integration path documented below when you want imported-project IDE support and Gradle-task execution
 - build-tool-light Java repositories: use the same canonical `./generated` output path and helper workflow
 
 Kotlin-specific guidance:
 
-- Gradle Kotlin DSL repositories: keep Microsmith CLI-managed during onboarding and do not wire Microsmith into the Gradle build automatically as part of onboarding
-- Gradle Groovy repositories that primarily host Kotlin code: use the same CLI-managed `./generated` path and helper workflow
+- Gradle Kotlin DSL repositories: prefer the native Gradle integration path documented below when you want imported-project IDE support and Gradle-task execution
+- Gradle Groovy repositories that primarily host Kotlin code: the same native Gradle plugin path applies when Kotlin is the primary source language
 - Maven Kotlin repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
 - build-tool-light Kotlin repositories: use the same canonical `./generated` output path and helper workflow
 
 Scala-specific guidance:
 
-- `sbt`-based Scala repositories: keep Microsmith CLI-managed during onboarding and do not wire Microsmith into `sbt` automatically as part of onboarding
+- `sbt`-based Scala repositories: keep Microsmith CLI-managed during onboarding until native `sbt` integration is configured separately
 - Maven Scala repositories: keep Microsmith CLI-managed by default and only add `./generated` into the Maven compile path if you explicitly want generated sources compiled by Maven
-- Gradle Scala repositories: keep Microsmith CLI-managed by default and only wire generated sources into Gradle intentionally later
+- Gradle Scala repositories: prefer the native Gradle integration path documented below when you want imported-project IDE support and Gradle-task execution
 - test-only Scala roots stay on the generic onboarding path until a Scala main source root exists
+
+## Native Gradle integration
+
+Use the Gradle plugin as the primary path for Java, Kotlin, and Scala repositories that already build with Gradle and want imported-project IDE support.
+
+Prefer this path when:
+
+- the repository already has a Gradle wrapper and existing Gradle build conventions
+- generation should run as `./gradlew microsmithGenerate`
+- JetBrains IDEs should resolve `.microsmith.kts` symbols from the imported Gradle project instead of a separate helper project
+
+Canonical contract:
+
+1. Configure plugin resolution in `settings.gradle.kts`.
+2. Configure normal dependency repositories as well, because the plugin resolves `runtime-scripting` and any `microsmithPlugins` entries as standard Gradle dependencies.
+3. Apply plugin id `me.liam.microsmith.gradle`.
+4. Configure `microsmithGradle { ... }`.
+5. Run `./gradlew microsmithGenerate`.
+
+Minimal settings example:
+
+```kotlin
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "me.liam.microsmith.gradle") {
+                val microsmithVersion = providers.gradleProperty("microsmithVersion").orNull ?: error(
+                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+                )
+                useModule("me.liam.microsmith:gradle-plugin:$microsmithVersion")
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+}
+```
+
+Minimal build example:
+
+```kotlin
+plugins {
+    java
+    id("me.liam.microsmith.gradle")
+}
+
+microsmithGradle {
+    scriptFile.set(layout.projectDirectory.file("build.microsmith.kts"))
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("microsmithGenerate"))
+}
+```
+
+The native Gradle plugin exposes:
+
+- `microsmithGenerate`: runs the configured `.microsmith.kts` script in a dedicated worker JVM so Gradle's embedded Kotlin runtime does not collide with Microsmith's scripting host
+- `microsmithGradle`: extension for `scriptFile`, `outputDirectory`, `variables`, and `flags`
+- `microsmithPlugins`: resolvable configuration for external Microsmith generator plugins
+- `microsmithIde`: IDE-facing classpath that includes Microsmith runtime types and plugin-provided types and is wired into `compileOnly` for Java-base projects
+
+External plugin example:
+
+```kotlin
+dependencies {
+    add("microsmithPlugins", "com.acme:microsmith-emitter-ts:1.4.2")
+}
+```
+
+Generated-source guidance:
+
+- Microsmith does not auto-register generated directories as Java, Kotlin, or Scala sources
+- keep the default `build/generated/microsmith` output root unless you have a concrete source-emission contract to wire into your build
+- only add generated directories into source sets when a generator actually emits compilable language sources for that repository
+- use the same explicit Gradle source-set wiring you already use for other generated sources; do not add the entire output root blindly
+
+Coexistence with the CLI, helper, and fallback paths:
+
+- `microsmith init` still works in Gradle repositories and is the fastest way to scaffold `build.microsmith.kts`
+- once native Gradle integration is adopted, use `./gradlew microsmithGenerate` as the primary generation path
+- the JetBrains IDE helper and fallback jar remain useful when you intentionally keep Microsmith outside the Gradle build, or when you are validating CLI-managed flows
+- representative native Gradle fixtures live in `examples/gradle/java`, `examples/gradle/kotlin`, and `examples/gradle/scala`
 
 ### Direct script execution
 
@@ -533,7 +648,9 @@ When `--diagnostics json` is used, each event is emitted as one JSON line with:
 
 ## JetBrains IDE helper
 
-Use the helper project when you want stronger `.microsmith.kts` type resolution in JetBrains IDEs such as IntelliJ IDEA, GoLand, Rider, PyCharm, RubyMine, and RustRover.
+Use the helper project when you want stronger `.microsmith.kts` type resolution in repositories that intentionally keep Microsmith outside the host build, or in non-Gradle repositories such as Go, .NET, Node, Python, Ruby, and Rust.
+
+For Java, Kotlin, and Scala repositories that already use Gradle, prefer the native Gradle integration path above first. Use the helper only when you intentionally keep Microsmith CLI-managed instead of adopting the Gradle plugin.
 
 `microsmith init` already refreshes the helper by default. Use `microsmith ide refresh` when you skipped helper generation during init or need to repair or resynchronize the helper later.
 
@@ -571,17 +688,17 @@ JetBrains workflow:
 Java-specific guidance:
 
 - for Java repositories, IntelliJ IDEA is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
-- native Maven or Gradle import resolves Java project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
+- Gradle-based Java repositories should prefer the native Gradle plugin path; use the helper or fallback for Maven and CLI-managed Java repositories
 
 Kotlin-specific guidance:
 
 - for Kotlin repositories, IntelliJ IDEA is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
-- native Gradle or Maven import resolves Kotlin project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
+- Gradle-based Kotlin repositories should prefer the native Gradle plugin path; use the helper or fallback for Maven and CLI-managed Kotlin repositories
 
 Scala-specific guidance:
 
 - for Scala repositories, IntelliJ IDEA with the Scala plugin is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
-- native `sbt`, Maven, or Gradle import resolves Scala project sources, but it does not resolve Microsmith script symbols on its own; use the helper project or the fallback jar for `.microsmith.kts`
+- Gradle-based Scala repositories should prefer the native Gradle plugin path; use the helper or fallback for `sbt`, Maven, and CLI-managed Scala repositories
 
 Ruby-specific guidance:
 
@@ -887,11 +1004,14 @@ jobs:
 
 ## Example fixtures
 
-The repository includes fixture repositories under `examples/non-gradle/` and `examples/jvm/`.
-Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.microsmith.kts` manual example, and a GitHub Actions example that exercises the init-first path.
+The repository includes fixture repositories under `examples/non-gradle/`, `examples/jvm/`, and `examples/gradle/`.
+CLI-managed fixtures exercise `microsmith init` and direct `microsmith run` flows. Native Gradle fixtures exercise `./gradlew microsmithGenerate`.
 
 | Fixture | Directory                    | Local command from fixture root                                                   | CI workflow                                                   |
 |---------|------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
+| Java (native Gradle)   | `examples/gradle/java`      | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                      | `examples/gradle/java/.github/workflows/microsmith.yml`       |
+| Kotlin (native Gradle) | `examples/gradle/kotlin`   | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                      | `examples/gradle/kotlin/.github/workflows/microsmith.yml`     |
+| Scala (native Gradle)  | `examples/gradle/scala`    | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                      | `examples/gradle/scala/.github/workflows/microsmith.yml`      |
 | Java    | `examples/jvm/java-maven`    | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/jvm/java-maven/.github/workflows/microsmith.yml`    |
 | Kotlin  | `examples/jvm/kotlin-gradle` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/jvm/kotlin-gradle/.github/workflows/microsmith.yml` |
 | Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
@@ -910,6 +1030,7 @@ Each fixture contains a repo marker used by `microsmith init`, a legacy `schema.
 | CLI help and README contract   | `build-and-qodana` on Ubuntu                         | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.   |
 | CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
 | Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
+| Native Gradle fixture smoke    | `build-and-qodana` on Ubuntu                         | Publishes required packages to `mavenLocal`, then runs `microsmithGenerate` for Java, Kotlin, and Scala Gradle fixtures. |
 | Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Kotlin, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
 | JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
 | Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
@@ -931,6 +1052,24 @@ Support policy:
 - supported products are IntelliJ IDEA, GoLand, Rider, PyCharm, RubyMine, and RustRover
 - supported release band is the current stable major line and the previous stable major line at release cut
 - EAP builds are best-effort only and do not block release
+
+### Native Gradle IDE validation
+
+| Product                    | Fixture root                | Required validation path |
+|---------------------------|-----------------------------|--------------------------|
+| IntelliJ IDEA            | `examples/gradle/java`      | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
+| IntelliJ IDEA            | `examples/gradle/kotlin`    | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
+| IntelliJ IDEA + Scala plugin | `examples/gradle/scala` | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
+
+Native Gradle checklist:
+
+1. Install or publish the release-candidate Microsmith Gradle plugin and runtime packages.
+2. Import the fixture root as a Gradle project in the target JetBrains IDE.
+3. Refresh Gradle indexing.
+4. Run `./gradlew microsmithGenerate`.
+5. Confirm `microsmith {}`, `schemas {}`, and `protobuf {}` resolve in `build.microsmith.kts` without importing `.microsmith/ide`.
+
+### Helper and fallback IDE validation
 
 | Product         | Fixture root                    | Required helper smoke path                              | Required fallback smoke path                             |
 |-----------------|---------------------------------|---------------------------------------------------------|----------------------------------------------------------|
@@ -1055,8 +1194,9 @@ What to do:
 
 ## Migration from Gradle
 
-Use the CLI when you want generation in repositories that do not carry a Gradle wrapper.
-The DSL surface and plugin architecture stay the same; the execution model changes.
+Keep the native Gradle plugin when the repository already uses Gradle and imported-project IDE support is part of the goal.
+Use the CLI when you want self-contained execution outside Gradle, or when the repository does not carry a Gradle wrapper.
+The DSL surface stays the same; the execution boundary changes.
 
 ### Command mapping
 
@@ -1067,7 +1207,7 @@ The DSL surface and plugin architecture stay the same; the execution model chang
 | local classpath jar wiring       | `--plugin-jar ./path/to/plugin.jar`                      |
 | Gradle offline mode              | `--offline`                                              |
 
-### Recommended migration sequence
+### Recommended migration sequence to the standalone CLI
 
 1. Move the DSL into `*.microsmith.kts` files.
 2. Replace Gradle-based generation commands in CI with `microsmith run`.

--- a/examples/gradle/java/.github/workflows/microsmith.yml
+++ b/examples/gradle/java/.github/workflows/microsmith.yml
@@ -1,0 +1,22 @@
+name: Microsmith Generate (Java Gradle Native Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 24
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: Generate protobuf
+        run: ./gradlew microsmithGenerate -PmicrosmithVersion="$MICROSMITH_VERSION"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/gradle/java/build.gradle.kts
+++ b/examples/gradle/java/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("me.liam.microsmith.gradle")
 }
 
-microsmithGradle {
+microsmith {
     scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
 }
 

--- a/examples/gradle/java/build.gradle.kts
+++ b/examples/gradle/java/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    java
+    id("me.liam.microsmith.gradle")
+}
+
+microsmithGradle {
+    scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("microsmithGenerate"))
+}

--- a/examples/gradle/java/schema.microsmith.kts
+++ b/examples/gradle/java/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("JavaGradleUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}

--- a/examples/gradle/java/settings.gradle.kts
+++ b/examples/gradle/java/settings.gradle.kts
@@ -1,4 +1,8 @@
 pluginManagement {
+    val microsmithVersion = providers.gradleProperty("microsmithVersion").orNull ?: error(
+        "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+    )
+
     repositories {
         mavenLocal()
         gradlePluginPortal()
@@ -14,15 +18,8 @@ pluginManagement {
             }
         }
     }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "me.liam.microsmith.gradle") {
-                val version = providers.gradleProperty("microsmithVersion").orNull ?: error(
-                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
-                )
-                useModule("me.liam.microsmith:gradle-plugin:$version")
-            }
-        }
+    plugins {
+        id("me.liam.microsmith.gradle") version microsmithVersion
     }
 }
 

--- a/examples/gradle/java/settings.gradle.kts
+++ b/examples/gradle/java/settings.gradle.kts
@@ -1,0 +1,46 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "me.liam.microsmith.gradle") {
+                val version = providers.gradleProperty("microsmithVersion").orNull ?: error(
+                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+                )
+                useModule("me.liam.microsmith:gradle-plugin:$version")
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+}
+
+rootProject.name = "java-gradle-native-fixture"

--- a/examples/gradle/java/src/main/java/example/App.java
+++ b/examples/gradle/java/src/main/java/example/App.java
@@ -1,0 +1,5 @@
+package example;
+
+public final class App {
+    private App() {}
+}

--- a/examples/gradle/kotlin/.github/workflows/microsmith.yml
+++ b/examples/gradle/kotlin/.github/workflows/microsmith.yml
@@ -1,0 +1,22 @@
+name: Microsmith Generate (Kotlin Gradle Native Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 24
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: Generate protobuf
+        run: ./gradlew microsmithGenerate -PmicrosmithVersion="$MICROSMITH_VERSION"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/gradle/kotlin/build.gradle.kts
+++ b/examples/gradle/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
     jvmToolchain(21)
 }
 
-microsmithGradle {
+microsmith {
     scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
 }
 

--- a/examples/gradle/kotlin/build.gradle.kts
+++ b/examples/gradle/kotlin/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm") version "2.2.21"
+    id("me.liam.microsmith.gradle")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+microsmithGradle {
+    scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("microsmithGenerate"))
+}

--- a/examples/gradle/kotlin/schema.microsmith.kts
+++ b/examples/gradle/kotlin/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("KotlinGradleUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}

--- a/examples/gradle/kotlin/settings.gradle.kts
+++ b/examples/gradle/kotlin/settings.gradle.kts
@@ -1,4 +1,8 @@
 pluginManagement {
+    val microsmithVersion = providers.gradleProperty("microsmithVersion").orNull ?: error(
+        "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+    )
+
     repositories {
         mavenLocal()
         gradlePluginPortal()
@@ -14,15 +18,8 @@ pluginManagement {
             }
         }
     }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "me.liam.microsmith.gradle") {
-                val version = providers.gradleProperty("microsmithVersion").orNull ?: error(
-                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
-                )
-                useModule("me.liam.microsmith:gradle-plugin:$version")
-            }
-        }
+    plugins {
+        id("me.liam.microsmith.gradle") version microsmithVersion
     }
 }
 

--- a/examples/gradle/kotlin/settings.gradle.kts
+++ b/examples/gradle/kotlin/settings.gradle.kts
@@ -1,0 +1,46 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "me.liam.microsmith.gradle") {
+                val version = providers.gradleProperty("microsmithVersion").orNull ?: error(
+                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+                )
+                useModule("me.liam.microsmith:gradle-plugin:$version")
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+}
+
+rootProject.name = "kotlin-gradle-native-fixture"

--- a/examples/gradle/kotlin/src/main/kotlin/example/App.kt
+++ b/examples/gradle/kotlin/src/main/kotlin/example/App.kt
@@ -1,0 +1,3 @@
+package example
+
+object App

--- a/examples/gradle/scala/.github/workflows/microsmith.yml
+++ b/examples/gradle/scala/.github/workflows/microsmith.yml
@@ -1,0 +1,22 @@
+name: Microsmith Generate (Scala Gradle Native Fixture)
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 24
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: Generate protobuf
+        run: ./gradlew microsmithGenerate -PmicrosmithVersion="$MICROSMITH_VERSION"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/gradle/scala/build.gradle.kts
+++ b/examples/gradle/scala/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    scala
+    id("me.liam.microsmith.gradle")
+}
+
+microsmithGradle {
+    scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("microsmithGenerate"))
+}

--- a/examples/gradle/scala/build.gradle.kts
+++ b/examples/gradle/scala/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("me.liam.microsmith.gradle")
 }
 
-microsmithGradle {
+microsmith {
     scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
 }
 

--- a/examples/gradle/scala/schema.microsmith.kts
+++ b/examples/gradle/scala/schema.microsmith.kts
@@ -1,0 +1,10 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("ScalaGradleUserCreated") {
+                int32("id") { index(1) }
+                string("email") { index(2) }
+            }
+        }
+    }
+}

--- a/examples/gradle/scala/settings.gradle.kts
+++ b/examples/gradle/scala/settings.gradle.kts
@@ -1,4 +1,8 @@
 pluginManagement {
+    val microsmithVersion = providers.gradleProperty("microsmithVersion").orNull ?: error(
+        "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+    )
+
     repositories {
         mavenLocal()
         gradlePluginPortal()
@@ -14,15 +18,8 @@ pluginManagement {
             }
         }
     }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "me.liam.microsmith.gradle") {
-                val version = providers.gradleProperty("microsmithVersion").orNull ?: error(
-                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
-                )
-                useModule("me.liam.microsmith:gradle-plugin:$version")
-            }
-        }
+    plugins {
+        id("me.liam.microsmith.gradle") version microsmithVersion
     }
 }
 

--- a/examples/gradle/scala/settings.gradle.kts
+++ b/examples/gradle/scala/settings.gradle.kts
@@ -1,0 +1,46 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "me.liam.microsmith.gradle") {
+                val version = providers.gradleProperty("microsmithVersion").orNull ?: error(
+                    "Set microsmithVersion in gradle.properties or pass -PmicrosmithVersion=<version>.",
+                )
+                useModule("me.liam.microsmith:gradle-plugin:$version")
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.github.com/lmliam/microsmith") {
+            credentials {
+                username = providers.gradleProperty("gpr.user")
+                    .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                    .orNull
+                password = providers.gradleProperty("gpr.key")
+                    .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                    .orNull
+            }
+        }
+    }
+}
+
+rootProject.name = "scala-gradle-native-fixture"

--- a/examples/gradle/scala/src/main/scala/example/App.scala
+++ b/examples/gradle/scala/src/main/scala/example/App.scala
@@ -1,0 +1,5 @@
+package example
+
+object App {
+  def main(args: Array[String]): Unit = println("hello")
+}

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
@@ -75,7 +75,8 @@ internal object InitSummaryEmitter {
         }
         emitter.info(
             "Gradle repository detected. Prefer the native Gradle plugin path when you want imported-project " +
-                "IDE support: apply plugin id 'me.liam.microsmith.gradle' and run './gradlew microsmithGenerate'.",
+                "IDE support: apply plugin id 'me.liam.microsmith.gradle', configure 'microsmith { ... }', " +
+                "and run './gradlew microsmithGenerate'.",
         )
     }
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
@@ -3,12 +3,16 @@ package me.liam.microsmith.cli.execution
 import me.liam.microsmith.cli.command.InitCommand
 import me.liam.microsmith.cli.diagnostics.CliDiagnosticEmitter
 import me.liam.microsmith.cli.init.InitBootstrapResult
+import me.liam.microsmith.cli.init.JavaOnboardingProfile
+import me.liam.microsmith.cli.init.KotlinOnboardingProfile
+import me.liam.microsmith.cli.init.ScalaOnboardingProfile
 
 internal object InitSummaryEmitter {
     fun emit(emitter: CliDiagnosticEmitter, command: InitCommand, result: InitBootstrapResult) {
         emitBootstrapSummary(emitter, command, result)
         emitIdeHelperSummary(emitter, result)
         emitter.info("Next: microsmith run build.microsmith.kts --out ./generated")
+        emitGradleNativeGuidance(emitter, result)
         result.repositoryDetection.profile.recommendedOutputDirectory?.let { outputDirectory ->
             emitter.info(
                 "Optional repository-native output path: microsmith run build.microsmith.kts --out $outputDirectory",
@@ -64,4 +68,29 @@ internal object InitSummaryEmitter {
         emitter.info("JetBrains IDE helper is $state at '$helperRoot'.")
         emitter.info("Import '${helperRoot.resolve("build.gradle.kts")}' as a Gradle project in JetBrains IDEs.")
     }
+
+    private fun emitGradleNativeGuidance(emitter: CliDiagnosticEmitter, result: InitBootstrapResult) {
+        if (!result.isGradleNativeCandidate()) {
+            return
+        }
+        emitter.info(
+            "Gradle repository detected. Prefer the native Gradle plugin path when you want imported-project " +
+                "IDE support: apply plugin id 'me.liam.microsmith.gradle' and run './gradlew microsmithGenerate'.",
+        )
+    }
 }
+
+private fun InitBootstrapResult.isGradleNativeCandidate(): Boolean {
+    val profile = repositoryDetection.profile
+    if (profile != JavaOnboardingProfile && profile != KotlinOnboardingProfile && profile != ScalaOnboardingProfile) {
+        return false
+    }
+    return repositoryDetection.matchedMarkers.any(::isGradleMarker)
+}
+
+private fun isGradleMarker(marker: String): Boolean = marker in setOf(
+    "build.gradle",
+    "build.gradle.kts",
+    "settings.gradle",
+    "settings.gradle.kts",
+)

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitTests.kt
@@ -347,6 +347,7 @@ class MicrosmithCliInitTests :
                 exitCode shouldBe 0
                 out.joinToString("\n").shouldContain("Detected repository profile: Java")
                 out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldNotContain("Prefer the native Gradle plugin path")
                 out.joinToString("\n").shouldNotContain("Optional repository-native output path")
                 err shouldBe emptyList()
             } finally {
@@ -354,7 +355,7 @@ class MicrosmithCliInitTests :
             }
         }
 
-        "init command keeps Kotlin on the canonical generated output path" {
+        "init command points Gradle-based Kotlin repositories toward the native Gradle plugin path" {
             val out = mutableListOf<String>()
             val err = mutableListOf<String>()
             val tempDir = createTempDirectory("microsmith-cli-init-kotlin")
@@ -392,6 +393,7 @@ class MicrosmithCliInitTests :
                 exitCode shouldBe 0
                 out.joinToString("\n").shouldContain("Detected repository profile: Kotlin")
                 out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldContain("Prefer the native Gradle plugin path")
                 out.joinToString("\n").shouldNotContain("Optional repository-native output path")
                 err shouldBe emptyList()
             } finally {
@@ -437,7 +439,96 @@ class MicrosmithCliInitTests :
                 exitCode shouldBe 0
                 out.joinToString("\n").shouldContain("Detected repository profile: Scala")
                 out.joinToString("\n").shouldContain("Next: microsmith run build.microsmith.kts --out ./generated")
+                out.joinToString("\n").shouldNotContain("Prefer the native Gradle plugin path")
                 out.joinToString("\n").shouldNotContain("Optional repository-native output path")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command points Gradle-based Java repositories toward the native Gradle plugin path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-java-gradle")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingProfileDetection(
+                                    profile = JavaOnboardingProfile,
+                                    selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                                    matchedMarkers = listOf("build.gradle.kts", "src/main/java"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = emptyList(),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Detected repository profile: Java")
+                out.joinToString("\n").shouldContain("Prefer the native Gradle plugin path")
+                err shouldBe emptyList()
+            } finally {
+                runCatching { tempDir.deleteRecursively() }
+            }
+        }
+
+        "init command points Gradle-based Scala repositories toward the native Gradle plugin path" {
+            val out = mutableListOf<String>()
+            val err = mutableListOf<String>()
+            val tempDir = createTempDirectory("microsmith-cli-init-scala-gradle")
+            try {
+                val helperRoot = tempDir.resolve(".microsmith/ide")
+                val cli =
+                    MicrosmithCli(
+                        stdout = out::add,
+                        stderr = err::add,
+                        initRunner = { command: InitCommand ->
+                            InitBootstrapResult(
+                                projectRoot = command.projectRoot.toAbsolutePath().normalize(),
+                                repositoryDetection =
+                                OnboardingProfileDetection(
+                                    profile = ScalaOnboardingProfile,
+                                    selectionReason = OnboardingProfileSelectionReason.MATCHED_PROFILE,
+                                    matchedMarkers = listOf("build.gradle", "src/main/scala"),
+                                ),
+                                createdFiles = listOf(tempDir.resolve("build.microsmith.kts")),
+                                overwrittenFiles = emptyList(),
+                                preservedFiles = emptyList(),
+                                ideHelperResult =
+                                IdeHelperRefreshResult(
+                                    projectRoot = tempDir,
+                                    helperRoot = helperRoot,
+                                    updatedFiles = emptyList(),
+                                    classpathEntries = listOf(tempDir.resolve("microsmith-cli-all.jar")),
+                                ),
+                            )
+                        },
+                    )
+
+                val exitCode = cli.run(arrayOf("init", "--repo-root", tempDir.toString()))
+
+                exitCode shouldBe 0
+                out.joinToString("\n").shouldContain("Detected repository profile: Scala")
+                out.joinToString("\n").shouldContain("Prefer the native Gradle plugin path")
                 err shouldBe emptyList()
             } finally {
                 runCatching { tempDir.deleteRecursively() }

--- a/modules/gradle-plugin/build.gradle
+++ b/modules/gradle-plugin/build.gradle
@@ -37,14 +37,6 @@ tasks.named('test') {
     enabled = true
 }
 
-tasks.named('check') {
-    dependsOn(tasks.named('test'))
-}
-
-tasks.named('build') {
-    dependsOn(tasks.named('test'))
-}
-
 tasks.named('jvmKotest') {
     enabled = false
 }

--- a/modules/gradle-plugin/build.gradle
+++ b/modules/gradle-plugin/build.gradle
@@ -1,0 +1,76 @@
+plugins {
+    id 'java-gradle-plugin'
+}
+
+def microsmithPluginVersion = project.version.toString()
+def generatedVersionResourceDir = layout.buildDirectory.dir('generated/resources/version')
+
+def generatePluginVersionResource = tasks.register('generatePluginVersionResource') {
+    inputs.property('microsmithVersion', microsmithPluginVersion)
+    outputs.dir(generatedVersionResourceDir)
+
+    doLast {
+        def outputFile = generatedVersionResourceDir.get().file('META-INF/microsmith/gradle-plugin-version.txt').asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.setText("${microsmithPluginVersion}\n", 'UTF-8')
+    }
+}
+
+sourceSets.main.resources.srcDir(generatedVersionResourceDir)
+
+dependencies {
+    compileOnly project(':runtime-scripting')
+    testImplementation gradleTestKit()
+    testImplementation project(':runtime-scripting')
+    testRuntimeOnly libs.kotest.runner.junit5
+}
+
+tasks.named('processResources') {
+    dependsOn(generatePluginVersionResource)
+}
+
+tasks.named('sourcesJar') {
+    dependsOn(generatePluginVersionResource)
+}
+
+tasks.named('test') {
+    enabled = true
+}
+
+tasks.named('check') {
+    dependsOn(tasks.named('test'))
+}
+
+tasks.named('build') {
+    dependsOn(tasks.named('test'))
+}
+
+tasks.named('jvmKotest') {
+    enabled = false
+}
+
+tasks.named('kotest') {
+    enabled = false
+}
+
+gradlePlugin {
+    plugins {
+        microsmithGradle {
+            id = 'me.liam.microsmith.gradle'
+            implementationClass = 'me.liam.microsmith.gradle.MicrosmithGradlePlugin'
+            displayName = 'Microsmith Gradle Plugin'
+            description = 'Native Microsmith integration for Gradle repositories'
+        }
+    }
+}
+
+afterEvaluate {
+    def gprPublication = publishing.publications.findByName('gpr')
+    if (gprPublication != null) {
+        publishing.publications.remove(gprPublication)
+    }
+}
+
+tasks.matching { task -> task.name.contains('GprPublication') }.configureEach {
+    enabled = false
+}

--- a/modules/gradle-plugin/build.gradle
+++ b/modules/gradle-plugin/build.gradle
@@ -47,7 +47,7 @@ tasks.named('kotest') {
 
 gradlePlugin {
     plugins {
-        microsmithGradle {
+        microsmithPlugin {
             id = 'me.liam.microsmith.gradle'
             implementationClass = 'me.liam.microsmith.gradle.MicrosmithGradlePlugin'
             displayName = 'Microsmith Gradle Plugin'

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/DefaultMicrosmithGradleWorkerProcessExecutor.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/DefaultMicrosmithGradleWorkerProcessExecutor.kt
@@ -1,0 +1,13 @@
+package me.liam.microsmith.gradle
+
+internal class DefaultMicrosmithGradleWorkerProcessExecutor : MicrosmithGradleWorkerProcessExecutor {
+    override fun execute(command: List<String>): MicrosmithGradleWorkerProcessOutcome {
+        val process =
+            ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start()
+        val processOutput = process.inputStream.bufferedReader().use { reader -> reader.readText().trim() }
+        val exitCode = process.waitFor()
+        return MicrosmithGradleWorkerProcessOutcome(exitCode, processOutput)
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/FilePathSeparator.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/FilePathSeparator.kt
@@ -1,0 +1,5 @@
+package me.liam.microsmith.gradle
+
+internal object FilePathSeparator {
+    val value: String = System.getProperty("path.separator") ?: ":"
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGenerateTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGenerateTask.kt
@@ -1,0 +1,89 @@
+package me.liam.microsmith.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(
+    because = "Microsmith maintains its own compilation cache and task-level caching needs deeper normalization.",
+)
+abstract class MicrosmithGenerateTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val scriptFile: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val variables: MapProperty<String, String>
+
+    @get:Input
+    abstract val flags: SetProperty<String>
+
+    @get:Classpath
+    abstract val pluginClasspath: ConfigurableFileCollection
+
+    @get:Classpath
+    abstract val runtimeClasspath: ConfigurableFileCollection
+
+    @get:Internal
+    abstract val cacheDirectory: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val request =
+            MicrosmithGradleWorkerRequest(
+                scriptPath = scriptFile.get().asFile.toPath(),
+                outputPath = outputDirectory.get().asFile.toPath(),
+                cacheDirectory = cacheDirectory.get().asFile.toPath(),
+                variables = variables.get().toSortedMap(),
+                flags = flags.get().toSortedSet(),
+                pluginClasspath =
+                pluginClasspath.files
+                    .map { file -> file.toPath().toAbsolutePath().normalize() }
+                    .sorted(),
+            )
+        val launcher = MicrosmithGradleWorkerLauncher()
+        val result =
+            launcher.execute(
+                request = request,
+                workDirectory = temporaryDir.toPath(),
+                runtimeClasspath =
+                runtimeClasspath.files
+                    .map { file -> file.toPath().toAbsolutePath().normalize() }
+                    .sorted(),
+            )
+
+        when (result) {
+            is MicrosmithGradleWorkerSuccess -> reportSuccess(result)
+            is MicrosmithGradleWorkerFailure -> throw GradleException(formatFailure(result))
+        }
+    }
+
+    private fun reportSuccess(result: MicrosmithGradleWorkerSuccess) {
+        result.warnings.forEach(logger::warn)
+        logger.lifecycle(
+            "Generated Microsmith outputs into '${outputDirectory.get().asFile}'. " +
+                "(compile-cache=${if (result.cacheHit) "hit" else "miss"}, elapsed=${result.elapsedMillis}ms)",
+        )
+    }
+
+    private fun formatFailure(result: MicrosmithGradleWorkerFailure): String = buildString {
+        appendLine("Microsmith generation failed (${result.type.lowercase()}).")
+        result.diagnostics.forEach(::appendLine)
+    }.trimEnd()
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleConfigurations.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleConfigurations.kt
@@ -4,6 +4,4 @@ internal object MicrosmithGradleConfigurations {
     const val IDE = "microsmithIde"
     const val PLUGINS = "microsmithPlugins"
     const val RUNTIME = "microsmithRuntime"
-    const val GENERATE_TASK = "microsmithGenerate"
-    const val EXTENSION = "microsmithGradle"
 }

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleConfigurations.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleConfigurations.kt
@@ -1,0 +1,9 @@
+package me.liam.microsmith.gradle
+
+internal object MicrosmithGradleConfigurations {
+    const val IDE = "microsmithIde"
+    const val PLUGINS = "microsmithPlugins"
+    const val RUNTIME = "microsmithRuntime"
+    const val GENERATE_TASK = "microsmithGenerate"
+    const val EXTENSION = "microsmithGradle"
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleDsl.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleDsl.kt
@@ -1,0 +1,5 @@
+package me.liam.microsmith.gradle
+
+internal object MicrosmithGradleDsl {
+    const val EXTENSION = "microsmith"
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleExtension.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleExtension.kt
@@ -1,0 +1,17 @@
+package me.liam.microsmith.gradle
+
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.SetProperty
+import javax.inject.Inject
+
+@Suppress("UnnecessaryAbstractClass") // Gradle instantiates managed extension properties through an abstract type.
+abstract class MicrosmithGradleExtension
+@Inject
+constructor() {
+    abstract val scriptFile: RegularFileProperty
+    abstract val outputDirectory: DirectoryProperty
+    abstract val variables: MapProperty<String, String>
+    abstract val flags: SetProperty<String>
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePlugin.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePlugin.kt
@@ -9,7 +9,7 @@ class MicrosmithGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val extension =
             project.extensions.create(
-                MicrosmithGradleConfigurations.EXTENSION,
+                MicrosmithGradleDsl.EXTENSION,
                 MicrosmithGradleExtension::class.java,
             )
         extension.scriptFile.convention(project.layout.projectDirectory.file("build.microsmith.kts"))
@@ -59,10 +59,10 @@ class MicrosmithGradlePlugin : Plugin<Project> {
         }
 
         project.tasks.register(
-            MicrosmithGradleConfigurations.GENERATE_TASK,
+            MicrosmithGradleTasks.GENERATE,
             MicrosmithGenerateTask::class.java,
         ) { task ->
-            task.group = "microsmith"
+            task.group = MicrosmithGradleTasks.GROUP
             task.description = "Generates artifacts from a .microsmith.kts script."
             task.scriptFile.convention(extension.scriptFile)
             task.outputDirectory.convention(extension.outputDirectory)

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePlugin.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePlugin.kt
@@ -1,0 +1,79 @@
+package me.liam.microsmith.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaPlugin
+
+class MicrosmithGradlePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension =
+            project.extensions.create(
+                MicrosmithGradleConfigurations.EXTENSION,
+                MicrosmithGradleExtension::class.java,
+            )
+        extension.scriptFile.convention(project.layout.projectDirectory.file("build.microsmith.kts"))
+        extension.outputDirectory.convention(project.layout.buildDirectory.dir("generated/microsmith"))
+        extension.variables.convention(emptyMap())
+        extension.flags.convention(emptySet())
+
+        val microsmithPlugins =
+            project.configurations.register(MicrosmithGradleConfigurations.PLUGINS) { configuration ->
+                configuration.isCanBeConsumed = false
+                configuration.isCanBeResolved = true
+                configuration.isVisible = false
+                configuration.description =
+                    "Classpath for external Microsmith generator plugins used by Gradle tasks."
+            }
+
+        val microsmithRuntime =
+            project.configurations.register(MicrosmithGradleConfigurations.RUNTIME) { configuration ->
+                configuration.isCanBeConsumed = false
+                configuration.isCanBeResolved = true
+                configuration.isVisible = false
+                configuration.description =
+                    "Classpath for the isolated Microsmith worker JVM used by Gradle tasks."
+                configuration.defaultDependencies { dependencies ->
+                    dependencies.add(
+                        project.dependencies.create(MicrosmithRuntimeDependencyNotation.runtimeScripting()),
+                    )
+                }
+            }
+
+        val microsmithIde =
+            project.configurations.register(MicrosmithGradleConfigurations.IDE) { configuration ->
+                configuration.isCanBeConsumed = false
+                configuration.isCanBeResolved = false
+                configuration.isVisible = false
+                configuration.description =
+                    "Microsmith script-definition and plugin classpath exposed to Gradle-imported IDEs."
+                configuration.extendsFrom(microsmithRuntime.get())
+                configuration.extendsFrom(microsmithPlugins.get())
+            }
+
+        project.plugins.withType(JavaBasePlugin::class.java) {
+            project.configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).configure {
+                    configuration ->
+                configuration.extendsFrom(microsmithIde.get())
+            }
+        }
+
+        project.tasks.register(
+            MicrosmithGradleConfigurations.GENERATE_TASK,
+            MicrosmithGenerateTask::class.java,
+        ) { task ->
+            task.group = "microsmith"
+            task.description = "Generates artifacts from a .microsmith.kts script."
+            task.scriptFile.convention(extension.scriptFile)
+            task.outputDirectory.convention(extension.outputDirectory)
+            task.variables.convention(extension.variables)
+            task.flags.convention(extension.flags)
+            task.pluginClasspath.from(microsmithPlugins)
+            task.runtimeClasspath.from(
+                project.files(task.javaClass.protectionDomain.codeSource.location),
+                microsmithRuntime,
+            )
+            task.cacheDirectory.convention(project.layout.buildDirectory.dir("tmp/microsmith/cache"))
+        }
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePluginVersion.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePluginVersion.kt
@@ -1,0 +1,12 @@
+package me.liam.microsmith.gradle
+
+internal object MicrosmithGradlePluginVersion {
+    val current: String =
+        checkNotNull(MicrosmithGradlePluginVersion::class.java.getResourceAsStream(VERSION_RESOURCE_PATH)) {
+            "Microsmith Gradle plugin version resource '$VERSION_RESOURCE_PATH' was not found."
+        }.bufferedReader().use { reader ->
+            reader.readText().trim()
+        }
+
+    private const val VERSION_RESOURCE_PATH = "/META-INF/microsmith/gradle-plugin-version.txt"
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleProperties.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleProperties.kt
@@ -1,0 +1,38 @@
+package me.liam.microsmith.gradle
+
+import java.nio.file.Path
+import java.util.Properties
+
+internal fun Properties.readPairs(countKey: String, keyPrefix: String, valuePrefix: String): Map<String, String> =
+    buildMap {
+        repeat(requiredInt(countKey)) { index ->
+            put(
+                getProperty("$keyPrefix$index") ?: missingProperty("$keyPrefix$index"),
+                getProperty("$valuePrefix$index") ?: missingProperty("$valuePrefix$index"),
+            )
+        }
+    }
+
+internal fun Properties.readValues(countKey: String, valuePrefix: String): List<String> =
+    List(requiredInt(countKey)) { index ->
+        getProperty("$valuePrefix$index") ?: missingProperty("$valuePrefix$index")
+    }
+
+internal fun Properties.requiredBoolean(key: String): Boolean {
+    val value = getProperty(key) ?: missingProperty(key)
+    return value.toBooleanStrictOrNull() ?: error("Property '$key' must be a boolean.")
+}
+
+internal fun Properties.requiredInt(key: String): Int {
+    val value = getProperty(key) ?: missingProperty(key)
+    return value.toIntOrNull() ?: error("Property '$key' must be an integer.")
+}
+
+internal fun Properties.requiredLong(key: String): Long {
+    val value = getProperty(key) ?: missingProperty(key)
+    return value.toLongOrNull() ?: error("Property '$key' must be a long.")
+}
+
+internal fun Properties.requiredPath(key: String): Path = Path.of(getProperty(key) ?: missingProperty(key))
+
+internal fun missingProperty(key: String): Nothing = error("Missing required property '$key'.")

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleTasks.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleTasks.kt
@@ -1,0 +1,6 @@
+package me.liam.microsmith.gradle
+
+internal object MicrosmithGradleTasks {
+    const val GROUP = "microsmith"
+    const val GENERATE = "microsmithGenerate"
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerExecutionOutcome.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerExecutionOutcome.kt
@@ -1,0 +1,7 @@
+package me.liam.microsmith.gradle
+
+internal data class MicrosmithGradleWorkerExecutionOutcome(
+    val exitCode: Int,
+    val processOutput: String,
+    val parsedResult: MicrosmithGradleWorkerResult?,
+)

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerFailure.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerFailure.kt
@@ -1,0 +1,6 @@
+package me.liam.microsmith.gradle
+
+internal data class MicrosmithGradleWorkerFailure(
+    val diagnostics: List<String>,
+    val type: String,
+) : MicrosmithGradleWorkerResult

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerLauncher.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerLauncher.kt
@@ -1,0 +1,70 @@
+package me.liam.microsmith.gradle
+
+import org.gradle.api.GradleException
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class MicrosmithGradleWorkerLauncher(
+    private val requestCodec: MicrosmithGradleWorkerRequestCodec = MicrosmithGradleWorkerRequestCodec(),
+    private val resultCodec: MicrosmithGradleWorkerResultCodec = MicrosmithGradleWorkerResultCodec(),
+) {
+    fun execute(
+        request: MicrosmithGradleWorkerRequest,
+        workDirectory: Path,
+        runtimeClasspath: List<Path>,
+    ): MicrosmithGradleWorkerResult {
+        val workspace = Files.createDirectories(workDirectory.resolve("microsmith-worker"))
+        val requestFile = workspace.resolve("request.properties")
+        val resultFile = workspace.resolve("result.properties")
+        requestCodec.write(requestFile, request)
+        val outcome = execute(runtimeClasspath, requestFile, resultFile)
+        return outcome.parsedResult ?: throw GradleException(formatFailure(outcome, resultFile))
+    }
+
+    private fun execute(
+        runtimeClasspath: List<Path>,
+        requestFile: Path,
+        resultFile: Path,
+    ): MicrosmithGradleWorkerExecutionOutcome {
+        val process =
+            ProcessBuilder(
+                buildCommand(runtimeClasspath, requestFile, resultFile),
+            ).redirectErrorStream(true)
+                .start()
+        val processOutput = process.inputStream.bufferedReader().use { reader -> reader.readText().trim() }
+        val exitCode = process.waitFor()
+        val parsedResult = runCatching { resultCodec.read(resultFile) }.getOrNull()
+        return MicrosmithGradleWorkerExecutionOutcome(exitCode, processOutput, parsedResult)
+    }
+
+    private fun buildCommand(runtimeClasspath: List<Path>, requestFile: Path, resultFile: Path): List<String> = listOf(
+        resolveJavaCommand().toString(),
+        "-cp",
+        runtimeClasspath.joinToString(FilePathSeparator.value),
+        MicrosmithGradleWorkerMain::class.java.name,
+        requestFile.toString(),
+        resultFile.toString(),
+    )
+
+    private fun resolveJavaCommand(): Path {
+        val javaHome = Path.of(System.getProperty("java.home"))
+        val executableName = if (isWindows()) "java.exe" else "java"
+        val executable = javaHome.resolve("bin").resolve(executableName)
+        require(Files.exists(executable) && Files.isRegularFile(executable)) {
+            "Could not locate Java executable at '$executable' for Microsmith Gradle worker."
+        }
+        return executable
+    }
+
+    private fun formatFailure(outcome: MicrosmithGradleWorkerExecutionOutcome, resultFile: Path): String = buildString {
+        appendLine("Microsmith Gradle worker did not produce a readable result.")
+        appendLine("Worker exit code: ${outcome.exitCode}")
+        appendLine("Expected result file: $resultFile")
+        if (outcome.processOutput.isNotBlank()) {
+            appendLine("Worker output:")
+            appendLine(outcome.processOutput)
+        }
+    }.trimEnd()
+
+    private fun isWindows(): Boolean = System.getProperty("os.name").orEmpty().lowercase().contains("windows")
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerLauncher.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerLauncher.kt
@@ -7,34 +7,44 @@ import java.nio.file.Path
 internal class MicrosmithGradleWorkerLauncher(
     private val requestCodec: MicrosmithGradleWorkerRequestCodec = MicrosmithGradleWorkerRequestCodec(),
     private val resultCodec: MicrosmithGradleWorkerResultCodec = MicrosmithGradleWorkerResultCodec(),
+    private val processExecutor: MicrosmithGradleWorkerProcessExecutor =
+        DefaultMicrosmithGradleWorkerProcessExecutor(),
 ) {
     fun execute(
         request: MicrosmithGradleWorkerRequest,
         workDirectory: Path,
         runtimeClasspath: List<Path>,
     ): MicrosmithGradleWorkerResult {
-        val workspace = Files.createDirectories(workDirectory.resolve("microsmith-worker"))
-        val requestFile = workspace.resolve("request.properties")
-        val resultFile = workspace.resolve("result.properties")
+        val workspace = createWorkspace(workDirectory)
+        val requestFile = workspace.resolve(WORKER_REQUEST_FILE_NAME)
+        val resultFile = workspace.resolve(WORKER_RESULT_FILE_NAME)
         requestCodec.write(requestFile, request)
-        val outcome = execute(runtimeClasspath, requestFile, resultFile)
+        val outcome = executeProcess(runtimeClasspath, requestFile, resultFile)
         return outcome.parsedResult ?: throw GradleException(formatFailure(outcome, resultFile))
     }
 
-    private fun execute(
+    private fun createWorkspace(workDirectory: Path): Path {
+        Files.createDirectories(workDirectory)
+        return Files.createTempDirectory(workDirectory, WORKER_DIRECTORY_PREFIX)
+    }
+
+    private fun executeProcess(
         runtimeClasspath: List<Path>,
         requestFile: Path,
         resultFile: Path,
     ): MicrosmithGradleWorkerExecutionOutcome {
-        val process =
-            ProcessBuilder(
+        val processOutcome =
+            processExecutor.execute(
                 buildCommand(runtimeClasspath, requestFile, resultFile),
-            ).redirectErrorStream(true)
-                .start()
-        val processOutput = process.inputStream.bufferedReader().use { reader -> reader.readText().trim() }
-        val exitCode = process.waitFor()
-        val parsedResult = runCatching { resultCodec.read(resultFile) }.getOrNull()
-        return MicrosmithGradleWorkerExecutionOutcome(exitCode, processOutput, parsedResult)
+            )
+        val parsedResult = resultFile.takeIf(Files::isRegularFile)?.let { file ->
+            runCatching { resultCodec.read(file) }.getOrNull()
+        }
+        return MicrosmithGradleWorkerExecutionOutcome(
+            exitCode = processOutcome.exitCode,
+            processOutput = processOutcome.processOutput,
+            parsedResult = parsedResult,
+        )
     }
 
     private fun buildCommand(runtimeClasspath: List<Path>, requestFile: Path, resultFile: Path): List<String> = listOf(
@@ -68,3 +78,7 @@ internal class MicrosmithGradleWorkerLauncher(
 
     private fun isWindows(): Boolean = System.getProperty("os.name").orEmpty().lowercase().contains("windows")
 }
+
+private const val WORKER_DIRECTORY_PREFIX = "microsmith-worker-"
+private const val WORKER_REQUEST_FILE_NAME = "request.properties"
+private const val WORKER_RESULT_FILE_NAME = "result.properties"

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerMain.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerMain.kt
@@ -1,0 +1,70 @@
+package me.liam.microsmith.gradle
+
+import me.liam.microsmith.runtime.scripting.host.MicrosmithScriptHost
+import me.liam.microsmith.runtime.scripting.model.ScriptRunFailure
+import me.liam.microsmith.runtime.scripting.model.ScriptRunRequest
+import me.liam.microsmith.runtime.scripting.model.ScriptRunSuccess
+import java.nio.file.Path
+import kotlin.system.exitProcess
+
+internal object MicrosmithGradleWorkerMain {
+    private val requestCodec = MicrosmithGradleWorkerRequestCodec()
+    private val resultCodec = MicrosmithGradleWorkerResultCodec()
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        if (args.size != EXPECTED_ARGS) {
+            System.err.println("Expected 2 arguments: <request.properties> <result.properties>.")
+            exitProcess(2)
+        }
+
+        val requestFile = Path.of(args[0])
+        val resultFile = Path.of(args[1])
+        val result = runWorker(requestFile)
+        runCatching { resultCodec.write(resultFile, result) }
+            .onFailure { error ->
+                val message = error.message ?: error::class.simpleName ?: "unknown result-write error"
+                System.err.println("Failed to write Microsmith Gradle worker result: $message")
+                exitProcess(2)
+            }
+        exitProcess(0)
+    }
+
+    private fun runWorker(requestFile: Path): MicrosmithGradleWorkerResult = runCatching {
+        val request = requestCodec.read(requestFile)
+        val host = MicrosmithScriptHost(cacheDirectory = request.cacheDirectory)
+        when (
+            val result =
+                host.run(
+                    ScriptRunRequest(
+                        script = request.scriptPath,
+                        outputDir = request.outputPath,
+                        variables = request.variables,
+                        flags = request.flags,
+                        pluginClasspath = request.pluginClasspath,
+                    ),
+                )
+        ) {
+            is ScriptRunSuccess ->
+                MicrosmithGradleWorkerSuccess(
+                    warnings = result.warnings,
+                    cacheHit = result.cacheHit,
+                    elapsedMillis = result.elapsedMillis,
+                )
+
+            is ScriptRunFailure ->
+                MicrosmithGradleWorkerFailure(
+                    diagnostics = result.diagnostics,
+                    type = result.type.name,
+                )
+        }
+    }.getOrElse { error ->
+        val message = error.message ?: error::class.simpleName ?: "unknown worker error"
+        MicrosmithGradleWorkerFailure(
+            diagnostics = listOf("Microsmith Gradle worker failure: $message"),
+            type = "HOST",
+        )
+    }
+}
+
+private const val EXPECTED_ARGS = 2

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerProcessExecutor.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerProcessExecutor.kt
@@ -1,0 +1,5 @@
+package me.liam.microsmith.gradle
+
+internal fun interface MicrosmithGradleWorkerProcessExecutor {
+    fun execute(command: List<String>): MicrosmithGradleWorkerProcessOutcome
+}

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerProcessOutcome.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerProcessOutcome.kt
@@ -1,0 +1,6 @@
+package me.liam.microsmith.gradle
+
+internal data class MicrosmithGradleWorkerProcessOutcome(
+    val exitCode: Int,
+    val processOutput: String,
+)

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerRequest.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerRequest.kt
@@ -1,0 +1,12 @@
+package me.liam.microsmith.gradle
+
+import java.nio.file.Path
+
+internal data class MicrosmithGradleWorkerRequest(
+    val scriptPath: Path,
+    val outputPath: Path,
+    val cacheDirectory: Path,
+    val variables: Map<String, String>,
+    val flags: Set<String>,
+    val pluginClasspath: List<Path>,
+)

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerRequestCodec.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerRequestCodec.kt
@@ -1,0 +1,66 @@
+package me.liam.microsmith.gradle
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Properties
+
+internal class MicrosmithGradleWorkerRequestCodec {
+    fun write(path: Path, request: MicrosmithGradleWorkerRequest) {
+        val properties = Properties()
+        properties[SCRIPT_PATH] = request.scriptPath.toString()
+        properties[OUTPUT_PATH] = request.outputPath.toString()
+        properties[CACHE_DIRECTORY] = request.cacheDirectory.toString()
+        properties[PLUGIN_CLASSPATH_COUNT] = request.pluginClasspath.size.toString()
+        request.pluginClasspath.forEachIndexed { index, pluginPath ->
+            properties["$PLUGIN_CLASSPATH_PREFIX$index"] = pluginPath.toString()
+        }
+        properties[VARIABLE_COUNT] = request.variables.size.toString()
+        request.variables.entries.sortedBy { (key, _) -> key }.forEachIndexed { index, (key, value) ->
+            properties["$VARIABLE_KEY_PREFIX$index"] = key
+            properties["$VARIABLE_VALUE_PREFIX$index"] = value
+        }
+        properties[FLAG_COUNT] = request.flags.size.toString()
+        request.flags.sorted().forEachIndexed { index, flag ->
+            properties["$FLAG_PREFIX$index"] = flag
+        }
+        path.parent?.let(Files::createDirectories)
+        Files.newOutputStream(path).use { output -> properties.store(output, null) }
+    }
+
+    fun read(path: Path): MicrosmithGradleWorkerRequest {
+        val properties = Properties()
+        Files.newInputStream(path).use { input -> properties.load(input) }
+        return MicrosmithGradleWorkerRequest(
+            scriptPath = properties.requiredPath(SCRIPT_PATH),
+            outputPath = properties.requiredPath(OUTPUT_PATH),
+            cacheDirectory = properties.requiredPath(CACHE_DIRECTORY),
+            variables =
+            properties.readPairs(
+                countKey = VARIABLE_COUNT,
+                keyPrefix = VARIABLE_KEY_PREFIX,
+                valuePrefix = VARIABLE_VALUE_PREFIX,
+            ),
+            flags =
+            properties.readValues(
+                countKey = FLAG_COUNT,
+                valuePrefix = FLAG_PREFIX,
+            ).toSortedSet(),
+            pluginClasspath =
+            properties.readValues(
+                countKey = PLUGIN_CLASSPATH_COUNT,
+                valuePrefix = PLUGIN_CLASSPATH_PREFIX,
+            ).map(Path::of),
+        )
+    }
+}
+
+private const val SCRIPT_PATH = "request.scriptPath"
+private const val OUTPUT_PATH = "request.outputPath"
+private const val CACHE_DIRECTORY = "request.cacheDirectory"
+private const val PLUGIN_CLASSPATH_COUNT = "request.pluginClasspath.count"
+private const val PLUGIN_CLASSPATH_PREFIX = "request.pluginClasspath."
+private const val VARIABLE_COUNT = "request.variables.count"
+private const val VARIABLE_KEY_PREFIX = "request.variables.key."
+private const val VARIABLE_VALUE_PREFIX = "request.variables.value."
+private const val FLAG_COUNT = "request.flags.count"
+private const val FLAG_PREFIX = "request.flags."

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerResult.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerResult.kt
@@ -1,0 +1,3 @@
+package me.liam.microsmith.gradle
+
+internal sealed interface MicrosmithGradleWorkerResult

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerResultCodec.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerResultCodec.kt
@@ -1,0 +1,65 @@
+package me.liam.microsmith.gradle
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Properties
+
+internal class MicrosmithGradleWorkerResultCodec {
+    fun write(path: Path, result: MicrosmithGradleWorkerResult) {
+        val properties = when (result) {
+            is MicrosmithGradleWorkerSuccess -> successProperties(result)
+            is MicrosmithGradleWorkerFailure -> failureProperties(result)
+        }
+        path.parent?.let(Files::createDirectories)
+        Files.newOutputStream(path).use { output -> properties.store(output, null) }
+    }
+
+    fun read(path: Path): MicrosmithGradleWorkerResult {
+        val properties = Properties()
+        Files.newInputStream(path).use { input -> properties.load(input) }
+        return when (properties.getProperty(RESULT_STATUS)?.trim()) {
+            RESULT_STATUS_SUCCESS -> MicrosmithGradleWorkerSuccess(
+                warnings = properties.readValues(RESULT_WARNING_COUNT, RESULT_WARNING_PREFIX),
+                cacheHit = properties.requiredBoolean(RESULT_CACHE_HIT),
+                elapsedMillis = properties.requiredLong(RESULT_ELAPSED_MILLIS),
+            )
+
+            RESULT_STATUS_FAILURE -> MicrosmithGradleWorkerFailure(
+                diagnostics = properties.readValues(RESULT_DIAGNOSTIC_COUNT, RESULT_DIAGNOSTIC_PREFIX),
+                type = properties.getProperty(RESULT_FAILURE_TYPE) ?: missingProperty(RESULT_FAILURE_TYPE),
+            )
+
+            else -> error("Missing or invalid worker result status.")
+        }
+    }
+
+    private fun successProperties(result: MicrosmithGradleWorkerSuccess): Properties = Properties().apply {
+        this[RESULT_STATUS] = RESULT_STATUS_SUCCESS
+        this[RESULT_ELAPSED_MILLIS] = result.elapsedMillis.toString()
+        this[RESULT_CACHE_HIT] = result.cacheHit.toString()
+        this[RESULT_WARNING_COUNT] = result.warnings.size.toString()
+        result.warnings.forEachIndexed { index, warning ->
+            this["$RESULT_WARNING_PREFIX$index"] = warning
+        }
+    }
+
+    private fun failureProperties(result: MicrosmithGradleWorkerFailure): Properties = Properties().apply {
+        this[RESULT_STATUS] = RESULT_STATUS_FAILURE
+        this[RESULT_FAILURE_TYPE] = result.type
+        this[RESULT_DIAGNOSTIC_COUNT] = result.diagnostics.size.toString()
+        result.diagnostics.forEachIndexed { index, diagnostic ->
+            this["$RESULT_DIAGNOSTIC_PREFIX$index"] = diagnostic
+        }
+    }
+}
+
+private const val RESULT_STATUS = "result.status"
+private const val RESULT_STATUS_SUCCESS = "success"
+private const val RESULT_STATUS_FAILURE = "failure"
+private const val RESULT_ELAPSED_MILLIS = "result.elapsedMillis"
+private const val RESULT_CACHE_HIT = "result.cacheHit"
+private const val RESULT_WARNING_COUNT = "result.warnings.count"
+private const val RESULT_WARNING_PREFIX = "result.warning."
+private const val RESULT_FAILURE_TYPE = "result.failureType"
+private const val RESULT_DIAGNOSTIC_COUNT = "result.diagnostics.count"
+private const val RESULT_DIAGNOSTIC_PREFIX = "result.diagnostic."

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerSuccess.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerSuccess.kt
@@ -1,0 +1,7 @@
+package me.liam.microsmith.gradle
+
+internal data class MicrosmithGradleWorkerSuccess(
+    val warnings: List<String>,
+    val cacheHit: Boolean,
+    val elapsedMillis: Long,
+) : MicrosmithGradleWorkerResult

--- a/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithRuntimeDependencyNotation.kt
+++ b/modules/gradle-plugin/src/main/kotlin/me/liam/microsmith/gradle/MicrosmithRuntimeDependencyNotation.kt
@@ -1,0 +1,5 @@
+package me.liam.microsmith.gradle
+
+internal object MicrosmithRuntimeDependencyNotation {
+    fun runtimeScripting(): String = "me.liam.microsmith:runtime-scripting:${MicrosmithGradlePluginVersion.current}"
+}

--- a/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradleFunctionalTestProject.kt
+++ b/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradleFunctionalTestProject.kt
@@ -1,0 +1,46 @@
+package me.liam.microsmith.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class MicrosmithGradleFunctionalTestProject private constructor(
+    private val rootDirectory: Path,
+) {
+    fun writeFile(relativePath: String, contents: String) {
+        val file = rootDirectory.resolve(relativePath)
+        val parent = file.parent
+        if (parent != null) {
+            Files.createDirectories(parent)
+        }
+        Files.writeString(file, "$contents\n")
+    }
+
+    fun build(vararg arguments: String): BuildResult = gradleRunner(*arguments).build()
+
+    fun buildAndFail(vararg arguments: String): BuildResult = gradleRunner(*arguments).buildAndFail()
+
+    fun file(relativePath: String): Path = rootDirectory.resolve(relativePath)
+
+    private fun gradleRunner(vararg arguments: String): GradleRunner = GradleRunner.create()
+        .withProjectDir(rootDirectory.toFile())
+        .withPluginClasspath()
+        .withArguments(*arguments, "--stacktrace")
+
+    companion object {
+        fun create(name: String, buildScript: String): MicrosmithGradleFunctionalTestProject {
+            val directory = Files.createTempDirectory(name)
+            val project = MicrosmithGradleFunctionalTestProject(directory)
+            project.writeFile("settings.gradle.kts", "rootProject.name = \"$name\"")
+            project.writeFile(
+                "build.gradle.kts",
+                listOf(
+                    buildScript,
+                    MicrosmithGradleFunctionalTestRuntimeClasspath.buildScriptDependencyBlock(),
+                ).joinToString(separator = "\n\n"),
+            )
+            return project
+        }
+    }
+}

--- a/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradleFunctionalTestRuntimeClasspath.kt
+++ b/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradleFunctionalTestRuntimeClasspath.kt
@@ -1,0 +1,32 @@
+package me.liam.microsmith.gradle
+
+import java.nio.file.Path
+
+internal object MicrosmithGradleFunctionalTestRuntimeClasspath {
+    fun buildScriptDependencyBlock(): String {
+        val files =
+            entries().joinToString(separator = ",\n        ") { path ->
+                "\"${path.toString().replace("\\", "\\\\")}\""
+            }
+        return """
+            dependencies {
+                add("${MicrosmithGradleConfigurations.RUNTIME}", files(
+                    $files
+                ))
+            }
+        """.trimIndent()
+    }
+
+    private fun entries(): List<Path> {
+        val classpath =
+            System.getProperty("java.class.path")
+                ?.takeIf(String::isNotBlank)
+                ?: error("Expected a non-empty java.class.path for Gradle functional tests.")
+        return classpath.split(FilePathSeparator.value)
+            .filter(String::isNotBlank)
+            .map(Path::of)
+            .map(Path::toAbsolutePath)
+            .map(Path::normalize)
+            .distinct()
+    }
+}

--- a/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePluginFunctionalTests.kt
+++ b/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePluginFunctionalTests.kt
@@ -19,16 +19,19 @@ class MicrosmithGradlePluginFunctionalTests : StringSpec() {
 
                 tasks.register("verifyMicrosmithWiring") {
                     doLast {
-                        val generateTask = tasks.named("microsmithGenerate").get()
+                        val generateTask = tasks.named("$GENERATE_TASK_NAME").get()
                         check(generateTask is me.liam.microsmith.gradle.MicrosmithGenerateTask)
+                        check(generateTask.group == "$TASK_GROUP_NAME")
 
-                        val ide = configurations.getByName("microsmithIde")
-                        val plugins = configurations.getByName("microsmithPlugins")
-                        val compileOnly = configurations.getByName("compileOnly")
+                        val ide = project.configurations.getByName("microsmithIde")
+                        val plugins = project.configurations.getByName("microsmithPlugins")
+                        val compileOnly = project.configurations.getByName("compileOnly")
+                        val extension = project.extensions.getByName("$EXTENSION_NAME")
 
                         check(ide.extendsFrom.contains(plugins))
                         check(compileOnly.extendsFrom.contains(ide))
                         check(!ide.isCanBeResolved)
+                        check(extension is me.liam.microsmith.gradle.MicrosmithGradleExtension)
                     }
                 }
                 """.trimIndent(),
@@ -78,7 +81,7 @@ class MicrosmithGradlePluginFunctionalTests : StringSpec() {
                     id("me.liam.microsmith.gradle")
                 }
 
-                microsmithGradle {
+                microsmith {
                     scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
                     outputDirectory.set(layout.projectDirectory.dir("custom-generated"))
                     variables.put("entityName", "GradleConfiguredUserCreated")
@@ -143,3 +146,7 @@ class MicrosmithGradlePluginFunctionalTests : StringSpec() {
         }
     }
 }
+
+private const val GENERATE_TASK_NAME = "microsmithGenerate"
+private const val TASK_GROUP_NAME = "microsmith"
+private const val EXTENSION_NAME = "microsmith"

--- a/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePluginFunctionalTests.kt
+++ b/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradlePluginFunctionalTests.kt
@@ -1,0 +1,145 @@
+package me.liam.microsmith.gradle
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.TaskOutcome
+
+class MicrosmithGradlePluginFunctionalTests : StringSpec() {
+    init {
+        "plugin registers task and IDE configurations for Java projects" {
+            val project = MicrosmithGradleFunctionalTestProject.create(
+                name = "microsmith-gradle-plugin-java-wiring",
+                buildScript = """
+                plugins {
+                    java
+                    id("me.liam.microsmith.gradle")
+                }
+
+                tasks.register("verifyMicrosmithWiring") {
+                    doLast {
+                        val generateTask = tasks.named("microsmithGenerate").get()
+                        check(generateTask is me.liam.microsmith.gradle.MicrosmithGenerateTask)
+
+                        val ide = configurations.getByName("microsmithIde")
+                        val plugins = configurations.getByName("microsmithPlugins")
+                        val compileOnly = configurations.getByName("compileOnly")
+
+                        check(ide.extendsFrom.contains(plugins))
+                        check(compileOnly.extendsFrom.contains(ide))
+                        check(!ide.isCanBeResolved)
+                    }
+                }
+                """.trimIndent(),
+            )
+
+            val result = project.build("verifyMicrosmithWiring")
+
+            result.task(":verifyMicrosmithWiring")?.outcome shouldBe TaskOutcome.SUCCESS
+        }
+
+        "microsmithGenerate uses the default script and output layout" {
+            val project = MicrosmithGradleFunctionalTestProject.create(
+                name = "microsmith-gradle-plugin-default-generate",
+                buildScript = """
+                plugins {
+                    id("me.liam.microsmith.gradle")
+                }
+                """.trimIndent(),
+            )
+            project.writeFile(
+                "build.microsmith.kts",
+                """
+                microsmith {
+                    schemas {
+                        protobuf {
+                            message("GradleDefaultUserCreated") {
+                                int32("id") { index(1) }
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+
+            val result = project.build("microsmithGenerate")
+
+            result.task(":microsmithGenerate")?.outcome shouldBe TaskOutcome.SUCCESS
+            project.file("build/generated/microsmith/proto/GradleDefaultUserCreated.proto").toFile().shouldExist()
+            result.output shouldContain "Generated Microsmith outputs into"
+        }
+
+        "microsmithGenerate honors custom script, output, vars, and flags" {
+            val project = MicrosmithGradleFunctionalTestProject.create(
+                name = "microsmith-gradle-plugin-custom-generate",
+                buildScript = """
+                plugins {
+                    id("me.liam.microsmith.gradle")
+                }
+
+                microsmithGradle {
+                    scriptFile.set(layout.projectDirectory.file("schema.microsmith.kts"))
+                    outputDirectory.set(layout.projectDirectory.dir("custom-generated"))
+                    variables.put("entityName", "GradleConfiguredUserCreated")
+                    flags.add("emit")
+                }
+                """.trimIndent(),
+            )
+            project.writeFile(
+                "schema.microsmith.kts",
+                """
+                val entityName = requireVar("entityName")
+                if (!hasFlag("emit")) {
+                    error("Expected emit flag")
+                }
+
+                emit(
+                    microsmith {
+                        schemas {
+                            protobuf {
+                                message(entityName) {
+                                    int32("id") { index(1) }
+                                }
+                            }
+                        }
+                    },
+                )
+                """.trimIndent(),
+            )
+
+            val result = project.build("microsmithGenerate")
+
+            result.task(":microsmithGenerate")?.outcome shouldBe TaskOutcome.SUCCESS
+            project.file("custom-generated/proto/GradleConfiguredUserCreated.proto").toFile().shouldExist()
+        }
+
+        "microsmithGenerate fails with script diagnostics" {
+            val project = MicrosmithGradleFunctionalTestProject.create(
+                name = "microsmith-gradle-plugin-failure",
+                buildScript = """
+                plugins {
+                    id("me.liam.microsmith.gradle")
+                }
+                """.trimIndent(),
+            )
+            project.writeFile(
+                "build.microsmith.kts",
+                """
+                microsmith {
+                    schemas {
+                        protobuf {
+                            unknownCall()
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+
+            val result = project.buildAndFail("microsmithGenerate")
+
+            result.output shouldContain "Microsmith generation failed"
+            result.output shouldContain "Unresolved reference 'unknownCall'"
+        }
+    }
+}

--- a/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerLauncherTests.kt
+++ b/modules/gradle-plugin/src/test/kotlin/me/liam/microsmith/gradle/MicrosmithGradleWorkerLauncherTests.kt
@@ -1,0 +1,93 @@
+package me.liam.microsmith.gradle
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.api.GradleException
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
+
+@OptIn(ExperimentalPathApi::class)
+class MicrosmithGradleWorkerLauncherTests :
+    StringSpec({
+        "launcher reads the worker result written for the current execution" {
+            val workDirectory = Files.createTempDirectory("microsmith-gradle-worker-launcher-success")
+            try {
+                val resultCodec = MicrosmithGradleWorkerResultCodec()
+                val launcher =
+                    MicrosmithGradleWorkerLauncher(
+                        resultCodec = resultCodec,
+                        processExecutor = MicrosmithGradleWorkerProcessExecutor { command ->
+                            val resultFile = Path.of(command.last())
+                            resultCodec.write(
+                                resultFile,
+                                MicrosmithGradleWorkerSuccess(
+                                    warnings = listOf("warning"),
+                                    cacheHit = true,
+                                    elapsedMillis = 12,
+                                ),
+                            )
+                            MicrosmithGradleWorkerProcessOutcome(exitCode = 0, processOutput = "")
+                        },
+                    )
+
+                val result = launcher.execute(sampleRequest(), workDirectory, sampleRuntimeClasspath())
+
+                result shouldBe MicrosmithGradleWorkerSuccess(
+                    warnings = listOf("warning"),
+                    cacheHit = true,
+                    elapsedMillis = 12,
+                )
+            } finally {
+                workDirectory.deleteRecursively()
+            }
+        }
+
+        "launcher ignores stale result files from previous executions" {
+            val workDirectory = Files.createTempDirectory("microsmith-gradle-worker-launcher-stale")
+            try {
+                val staleWorkspace = Files.createDirectories(workDirectory.resolve("microsmith-worker"))
+                MicrosmithGradleWorkerResultCodec().write(
+                    staleWorkspace.resolve("result.properties"),
+                    MicrosmithGradleWorkerSuccess(
+                        warnings = emptyList(),
+                        cacheHit = true,
+                        elapsedMillis = 1,
+                    ),
+                )
+                val launcher =
+                    MicrosmithGradleWorkerLauncher(
+                        processExecutor = MicrosmithGradleWorkerProcessExecutor {
+                            MicrosmithGradleWorkerProcessOutcome(
+                                exitCode = 2,
+                                processOutput = "worker crashed before writing a result",
+                            )
+                        },
+                    )
+
+                val failure =
+                    shouldThrow<GradleException> {
+                        launcher.execute(sampleRequest(), workDirectory, sampleRuntimeClasspath())
+                    }
+
+                failure.message.shouldContain("Worker exit code: 2")
+                failure.message.shouldContain("worker crashed before writing a result")
+            } finally {
+                workDirectory.deleteRecursively()
+            }
+        }
+    })
+
+private fun sampleRequest(): MicrosmithGradleWorkerRequest = MicrosmithGradleWorkerRequest(
+    scriptPath = Path.of("/tmp/build.microsmith.kts"),
+    outputPath = Path.of("/tmp/generated"),
+    cacheDirectory = Path.of("/tmp/cache"),
+    variables = mapOf("entityName" to "WorkerUserCreated"),
+    flags = setOf("emit"),
+    pluginClasspath = emptyList(),
+)
+
+private fun sampleRuntimeClasspath(): List<Path> = listOf(Path.of("/tmp/runtime-scripting.jar"))

--- a/settings.gradle
+++ b/settings.gradle
@@ -64,6 +64,7 @@ rootProject.name = 'microsmith'
     'gen-schemas-protobuf',
     'runtime-scripting',
     'cli',
+    'gradle-plugin',
     'kotest',
 ].each { moduleName ->
     include moduleName


### PR DESCRIPTION
## Why
Gradle-based JVM repositories should not be treated like generic external-tool consumers. For Java, Kotlin, and Scala projects that already import through Gradle, the best practical Microsmith experience is a native Gradle integration path that keeps `.microsmith.kts` authoring and generation inside the existing build instead of routing users through the CLI helper-first path.

This PR implements that native path and makes it the primary recommendation for Gradle-based JVM repositories, while keeping the standalone CLI, helper flow, and fallback JAR available for other repository types and secondary cases.

## What Changed
- added a new `modules/gradle-plugin` module with plugin id `me.liam.microsmith.gradle`
- added a dedicated `microsmithGenerate` task in the `microsmith` task group and a native `microsmith { ... }` extension for Gradle Kotlin DSL builds
- isolated script execution into a dedicated worker JVM so the plugin does not fight Gradle's embedded Kotlin runtime
- introduced hidden Gradle configurations for runtime, plugin, and IDE classpaths so IDE import can see the Microsmith script-definition surface without leaking unnecessary runtime wiring into consumer builds
- updated CLI onboarding summaries so Gradle-based Java, Kotlin, and Scala repositories are pointed at the native Gradle path instead of the generic helper-first path
- added representative native Gradle fixtures for:
  - `examples/gradle/java`
  - `examples/gradle/kotlin`
  - `examples/gradle/scala`
- switched fixture and README setup from custom `resolutionStrategy { eachPlugin { useModule(...) } }` wiring to standard `pluginManagement { plugins { id("me.liam.microsmith.gradle") version microsmithVersion } }`
- removed the unnecessary custom Kotlin DSL import/helper path; consumer `build.gradle.kts` files now use plain `microsmith { ... }` with no extra import
- expanded CI to publish the required Microsmith packages to `mavenLocal`, execute the native Gradle fixtures end to end, and validate generated outputs dynamically instead of hard-coding specific proto filenames
- updated `README.md` to document the native Gradle contract, fixture inventory, validation matrix, and the primary-vs-secondary guidance for JVM repositories

## Design Notes
- The worker JVM is deliberate. Running the scripting host inside the Gradle daemon caused embedded-Kotlin incompatibilities, so the plugin now launches generation out-of-process with an explicit runtime classpath.
- The native Gradle path is now the recommended path for Gradle-based JVM repositories.
- The standalone CLI remains the portable baseline for non-Gradle repositories and for users who do not want build-tool integration.
- The helper and fallback paths remain available, but they are secondary for Gradle-based JVM repositories.
- The plugin version still has to be declared externally through Gradle plugin management. Gradle resolves plugin versions before plugin code runs, so the plugin cannot self-select or self-upgrade its own version.

## Validation
- `./gradlew :gradle-plugin:check :gradle-plugin:test --rerun-tasks --no-build-cache`
- `./gradlew :cli:check :cli:jvmKotest --rerun-tasks --no-build-cache`
- `./gradlew :cli:releaseArtifacts --stacktrace`
- `./gradlew publishToMavenLocal --rerun-tasks --no-build-cache`
- native Gradle fixture smoke with JDK 24:
  - `./gradlew -p examples/gradle/java microsmithGenerate -PmicrosmithVersion=<version> --stacktrace`
  - `./gradlew -p examples/gradle/kotlin microsmithGenerate -PmicrosmithVersion=<version> --stacktrace`
  - `./gradlew -p examples/gradle/scala microsmithGenerate -PmicrosmithVersion=<version> --stacktrace`
- `./modules/cli/build/microsmith-cli-dist/bin/microsmith --help > /tmp/microsmith-cli-help.txt && python3 scripts/verify_readme_cli_usage.py README.md /tmp/microsmith-cli-help.txt`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_test_qodana.yml")'`
- `./gradlew build --rerun-tasks --no-build-cache`
- `git diff --check`

Closes #100
