### PR TITLE
feat(jvm-sbt): support native Microsmith integration in sbt repositories

### DIFF
--- a/.github/workflows/build_test_qodana.yml
+++ b/.github/workflows/build_test_qodana.yml
@@ -45,7 +45,10 @@ jobs:
             :runtime-scripting:publishToMavenLocal \
             :gradle-plugin:publishToMavenLocal \
             :maven-plugin:publishToMavenLocal \
+            :sbt-plugin:publishToMavenLocal \
             --stacktrace
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
       - name: Validate native Gradle fixtures
         run: |
           set -euo pipefail
@@ -79,6 +82,21 @@ jobs:
           validate_maven_fixture examples/maven/java
           validate_maven_fixture examples/maven/kotlin
           validate_maven_fixture examples/maven/scala
+      - name: Validate native sbt fixtures
+        run: |
+          set -euo pipefail
+          VERSION="$(./gradlew -q properties | sed -n 's/^version: //p' | head -n 1)"
+
+          validate_sbt_fixture() {
+            local repo_root="$1"
+            local generated_root="$repo_root/target/generated/microsmith/proto"
+
+            (cd "$repo_root" && sbt -batch -Dsbt.supershell=false -Dmicrosmith.version="$VERSION" microsmithGenerate)
+            test -d "$generated_root"
+            find "$generated_root" -maxdepth 1 -type f -name '*.proto' | grep -q .
+          }
+
+          validate_sbt_fixture examples/sbt/scala
       - name: Validate IDE fallback release assets
         run: |
           ./gradlew :runtime-scripting:ideFallbackArtifacts :runtime-scripting:generateIdeFallbackChecksums --stacktrace

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This README is the canonical repository documentation.
 - Standalone CLI for consumer repositories
 - Native Gradle integration
 - Native Maven integration
+- Native sbt integration
 - Installation and verification
 - Command reference
 - JetBrains IDE helper
@@ -37,6 +38,7 @@ Microsmith provides:
 - bundled built-in providers for the default schema and protobuf workflows
 - a native Gradle plugin for Java, Kotlin, and Scala repositories that want imported-project build alignment
 - a native Maven plugin for Java, Kotlin, and Scala repositories that want imported-project build alignment
+- a native sbt plugin for Scala repositories that want build-aligned generation inside sbt
 - a JetBrains IDE helper workflow for stronger type resolution in consumer repositories
 
 ## Repository modules
@@ -51,6 +53,7 @@ Microsmith provides:
 - `cli`: command-line entrypoint, diagnostics, installer packaging, and IDE helper support
 - `gradle-plugin`: native Gradle integration for `.microsmith.kts` execution and imported-project IDE alignment
 - `maven-plugin`: native Maven integration for `.microsmith.kts` execution and imported-project IDE alignment
+- `sbt-plugin`: native sbt integration for `.microsmith.kts` execution inside Scala sbt builds
 - `kotest`: shared Kotest configuration used by repository test suites
 
 ### Module boundary map
@@ -64,11 +67,12 @@ Microsmith provides:
 - `cli` is the application layer for command parsing, diagnostics, repository onboarding, plugin resolution, installation, and JetBrains IDE helper workflows. Lower layers must not depend on `cli`.
 - `gradle-plugin` is the native Gradle integration surface for Gradle-imported JVM repositories. It should stay thin, Gradle-conventional, and explicit about task/configuration wiring rather than absorbing CLI concerns.
 - `maven-plugin` is the native Maven integration surface for Maven-imported JVM repositories. It should stay thin, Maven-conventional, and explicit about plugin configuration, generated-source wiring, and imported-project IDE expectations rather than absorbing CLI concerns.
+- `sbt-plugin` is the native sbt integration surface for Scala repositories. It should stay thin, sbt-conventional, and explicit about plugin keys, task wiring, and when helper or fallback IDE support is still needed.
 - `kotest` is test support only and should not become a production dependency surface.
 
 ## Repository layout
 
-- `modules/`: production Gradle subprojects, including `cli`, `dsl`, `dsl-schemas`, `dsl-schemas-protobuf`, `gen`, `gen-schemas`, `gen-schemas-protobuf`, `runtime-scripting`, `gradle-plugin`, `maven-plugin`, and `kotest`
+- `modules/`: production Gradle subprojects, including `cli`, `dsl`, `dsl-schemas`, `dsl-schemas-protobuf`, `gen`, `gen-schemas`, `gen-schemas-protobuf`, `runtime-scripting`, `gradle-plugin`, `maven-plugin`, `sbt-plugin`, and `kotest`
 - `build-logic/`: included Gradle build that owns repository-specific plugins and quality tasks
 - `examples/`: consumer-repository fixtures and onboarding examples
 - `gradle/`: wrapper files, version catalog, and dependency locks
@@ -295,7 +299,7 @@ Kotlin-specific guidance:
 
 Scala-specific guidance:
 
-- `sbt`-based Scala repositories: keep Microsmith CLI-managed during onboarding until native `sbt` integration is configured separately
+- `sbt`-based Scala repositories: prefer the native sbt integration path documented below when you want build-aligned generation inside sbt
 - Maven Scala repositories: prefer the native Maven integration path documented below when you want imported-project IDE support and Maven-goal execution
 - Gradle Scala repositories: prefer the native Gradle integration path documented below when you want imported-project IDE support and Gradle-task execution
 - test-only Scala roots stay on the generic onboarding path until a Scala main source root exists
@@ -506,6 +510,107 @@ Coexistence with the CLI, helper, and fallback paths:
 - once native Maven integration is adopted, use `mvn microsmith:generate` as the primary generation path
 - the JetBrains IDE helper and fallback jar remain useful when you intentionally keep Microsmith outside Maven, or when a Maven-imported IDE project needs plugin-provided types that are not mirrored as project dependencies
 - representative native Maven fixtures live in `examples/maven/java`, `examples/maven/kotlin`, and `examples/maven/scala`
+
+## Native sbt integration
+
+Use the sbt plugin as the primary path for Scala repositories that already build with sbt and want build-aligned Microsmith generation without leaving the host build.
+
+Prefer this path when:
+
+- the repository already uses sbt as its main build tool
+- generation should run as `sbt microsmithGenerate`
+- you want Microsmith execution, cache paths, and generated outputs to stay inside sbt conventions
+
+Canonical contract:
+
+1. Keep Microsmith authoring in `build.microsmith.kts` or another `*.microsmith.kts` file.
+2. Add `me.liam.microsmith` `%` `sbt-microsmith` in `project/plugins.sbt`.
+3. Add `me.liam.microsmith:runtime-scripting` as a `Provided` dependency in `build.sbt` so sbt-imported IDE projects can see the built-in Microsmith script-definition/runtime types.
+4. Enable `MicrosmithSbtPlugin` in `build.sbt`.
+5. Run `sbt microsmithGenerate`.
+
+Minimal `project/plugins.sbt` example:
+
+```scala
+val microsmithVersion =
+  sys.props.getOrElse(
+    "microsmith.version",
+    sys.error("Pass -Dmicrosmith.version=<version>."),
+  )
+
+def githubMicrosmithCredentials: Seq[Credentials] =
+  for {
+    actor <- sys.env.get("GITHUB_ACTOR").toSeq
+    token <- sys.env.get("GITHUB_TOKEN").toSeq
+  } yield Credentials("GitHub Package Registry", "maven.pkg.github.com", actor, token)
+
+resolvers += Resolver.mavenLocal
+resolvers += "GitHub Microsmith" at "https://maven.pkg.github.com/lmliam/microsmith"
+credentials ++= githubMicrosmithCredentials
+
+addSbtPlugin("me.liam.microsmith" % "sbt-microsmith" % microsmithVersion)
+```
+
+Minimal `build.sbt` example:
+
+```scala
+ThisBuild / scalaVersion := "3.7.1"
+
+val microsmithVersion =
+  sys.props.getOrElse(
+    "microsmith.version",
+    sys.error("Pass -Dmicrosmith.version=<version>."),
+  )
+
+def githubMicrosmithCredentials: Seq[Credentials] =
+  for {
+    actor <- sys.env.get("GITHUB_ACTOR").toSeq
+    token <- sys.env.get("GITHUB_TOKEN").toSeq
+  } yield Credentials("GitHub Package Registry", "maven.pkg.github.com", actor, token)
+
+lazy val root = (project in file("."))
+  .enablePlugins(MicrosmithSbtPlugin)
+  .settings(
+    resolvers += Resolver.mavenLocal,
+    resolvers += "GitHub Microsmith" at "https://maven.pkg.github.com/lmliam/microsmith",
+    credentials ++= githubMicrosmithCredentials,
+    libraryDependencies += "me.liam.microsmith" % "runtime-scripting" % microsmithVersion % Provided,
+  )
+```
+
+The native sbt plugin exposes:
+
+- `microsmithGenerate`: runs the configured `.microsmith.kts` script and returns the generated files
+- `microsmithScriptFile`: defaults to `build.microsmith.kts`
+- `microsmithOutputDirectory`: defaults to `target/generated/microsmith`
+- `microsmithCacheDirectory`: defaults to `target/tmp/microsmith/cache`
+- `microsmithVariables`: string variables exposed to the script via `requireVar` and `hasVar`
+- `microsmithFlags`: flags exposed to the script via `hasFlag`
+
+Repository credentials:
+
+- the local Maven repository at `~/.m2/repository` is enough for local fixture validation after `publishToMavenLocal`
+- when consuming releases from GitHub Packages, add matching credentials in `project/plugins.sbt` and `build.sbt` as shown above
+
+Generated-output guidance:
+
+- Microsmith does not auto-register generated directories as Scala, Java, or resource roots in sbt
+- keep the default `target/generated/microsmith` output root unless a generator has a concrete source-emission contract for that repository
+- only wire specific generated subdirectories into sbt when you have a real downstream source or resource consumer
+- do not add the entire output root blindly to `Compile / unmanagedSourceDirectories` or similar settings
+
+JetBrains and helper/fallback guidance:
+
+- start with the native sbt plugin plus the `Provided` `runtime-scripting` dependency when you want imported-project indexing to see built-in Microsmith types
+- if an sbt-imported JetBrains project still leaves `.microsmith.kts` unresolved, use `microsmith ide refresh` or the fallback jar as the supported recovery path
+- the helper and fallback remain compatible with native sbt integration; they are secondary IDE-support paths, not the primary generation path
+
+Coexistence with the CLI, helper, and fallback paths:
+
+- `microsmith init` still works in sbt repositories and is the fastest way to scaffold `build.microsmith.kts`
+- once native sbt integration is adopted, use `sbt microsmithGenerate` as the primary generation path
+- the JetBrains IDE helper and fallback jar remain useful when you intentionally keep Microsmith outside sbt, or when sbt-imported IDE indexing still needs explicit script-definition support
+- the representative native sbt fixture lives in `examples/sbt/scala`
 
 ### Direct script execution
 
@@ -798,7 +903,10 @@ Kotlin-specific guidance:
 Scala-specific guidance:
 
 - for Scala repositories, IntelliJ IDEA with the Scala plugin is the recommended JetBrains IDE path when you want `.microsmith.kts` authoring support
-- Gradle-based Scala repositories should prefer the native Gradle plugin path; use the helper or fallback for `sbt`, Maven, and CLI-managed Scala repositories
+- Gradle-based Scala repositories should prefer the native Gradle plugin path
+- Maven-based Scala repositories should prefer the native Maven plugin path
+- sbt-based Scala repositories should prefer the native sbt plugin path for generation; keep the helper or fallback as the supported recovery path when sbt-imported indexing still needs explicit `.microsmith.kts` support
+- CLI-managed Scala repositories should use the helper or fallback directly
 
 Ruby-specific guidance:
 
@@ -1105,7 +1213,7 @@ jobs:
 ## Example fixtures
 
 The repository includes fixture repositories under `examples/non-gradle/`, `examples/jvm/`, `examples/gradle/`, and `examples/maven/`.
-CLI-managed fixtures exercise `microsmith init` and direct `microsmith run` flows. Native Gradle fixtures exercise `./gradlew microsmithGenerate`. Native Maven fixtures exercise `mvn microsmith:generate`.
+CLI-managed fixtures exercise `microsmith init` and direct `microsmith run` flows. Native Gradle fixtures exercise `./gradlew microsmithGenerate`. Native Maven fixtures exercise `mvn microsmith:generate`. Native sbt fixtures exercise `sbt microsmithGenerate`.
 
 | Fixture | Directory                    | Local command from fixture root                                                   | CI workflow                                                   |
 |---------|------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
@@ -1115,8 +1223,10 @@ CLI-managed fixtures exercise `microsmith init` and direct `microsmith run` flow
 | Java (native Maven)    | `examples/maven/java`      | `mvn microsmith:generate -Dmicrosmith.version=<version>`                          | `examples/maven/java/.github/workflows/microsmith.yml`        |
 | Kotlin (native Maven)  | `examples/maven/kotlin`    | `mvn microsmith:generate -Dmicrosmith.version=<version>`                          | `examples/maven/kotlin/.github/workflows/microsmith.yml`      |
 | Scala (native Maven)   | `examples/maven/scala`     | `mvn microsmith:generate -Dmicrosmith.version=<version>`                          | `examples/maven/scala/.github/workflows/microsmith.yml`       |
+| Scala (native sbt)     | `examples/sbt/scala`       | `sbt -Dmicrosmith.version=<version> microsmithGenerate`                           | `examples/sbt/scala/.github/workflows/microsmith.yml`         |
 | Java    | `examples/jvm/java-maven`    | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/jvm/java-maven/.github/workflows/microsmith.yml`    |
 | Kotlin  | `examples/jvm/kotlin-gradle` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/jvm/kotlin-gradle/.github/workflows/microsmith.yml` |
+| Scala   | `examples/jvm/scala-sbt`     | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/jvm/scala-sbt/.github/workflows/microsmith.yml`     |
 | Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
 | Go      | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts --out ./internal/gen` | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
 | Python  | `examples/non-gradle/python` | `microsmith init` then `microsmith run build.microsmith.kts --out ./generated`    | `examples/non-gradle/python/.github/workflows/microsmith.yml` |
@@ -1135,7 +1245,8 @@ CLI-managed fixtures exercise `microsmith init` and direct `microsmith run` flow
 | Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
 | Native Gradle fixture smoke    | `build-and-qodana` on Ubuntu                         | Publishes required packages to `mavenLocal`, then runs `microsmithGenerate` for Java, Kotlin, and Scala Gradle fixtures. |
 | Native Maven fixture smoke     | `build-and-qodana` on Ubuntu                         | Publishes required packages to `mavenLocal`, then runs `mvn microsmith:generate` for Java, Kotlin, and Scala Maven fixtures. |
-| Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Kotlin, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
+| Native sbt fixture smoke       | `build-and-qodana` on Ubuntu                         | Publishes required packages to `mavenLocal`, then runs `sbt microsmithGenerate` for the Scala sbt fixture. |
+| Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
 | JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
 | Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
 | Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
@@ -1173,6 +1284,12 @@ Support policy:
 | IntelliJ IDEA            | `examples/maven/kotlin`   | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
 | IntelliJ IDEA + Scala plugin | `examples/maven/scala` | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
 
+### Native sbt IDE validation
+
+| Product                    | Fixture root           | Required validation path |
+|---------------------------|------------------------|--------------------------|
+| IntelliJ IDEA + Scala plugin | `examples/sbt/scala` | Import the fixture root as an sbt project, reload sbt indexing, and confirm the `Provided` `runtime-scripting` dependency exposes the built-in Microsmith DSL symbols in `build.microsmith.kts`. If imported sbt indexing still leaves `.microsmith.kts` unresolved, confirm the helper or fallback path restores resolution without changing the native sbt generation path. |
+
 Native Gradle checklist:
 
 1. Install or publish the release-candidate Microsmith Gradle plugin and runtime packages.
@@ -1180,6 +1297,15 @@ Native Gradle checklist:
 3. Refresh Gradle indexing.
 4. Run `./gradlew microsmithGenerate`.
 5. Confirm `microsmith {}`, `schemas {}`, and `protobuf {}` resolve in `build.microsmith.kts` without importing `.microsmith/ide`.
+
+Native sbt checklist:
+
+1. Install or publish the release-candidate Microsmith sbt plugin and runtime packages.
+2. Import the fixture root as an sbt project in IntelliJ IDEA with the Scala plugin.
+3. Reload sbt indexing.
+4. Run `sbt microsmithGenerate`.
+5. Confirm `microsmith {}`, `schemas {}`, and `protobuf {}` resolve in `build.microsmith.kts`.
+6. If indexing is still incomplete, validate that `microsmith ide refresh` or the fallback jar restores script resolution without changing the native sbt generation path.
 
 ### Helper and fallback IDE validation
 

--- a/examples/sbt/scala/.github/workflows/microsmith.yml
+++ b/examples/sbt/scala/.github/workflows/microsmith.yml
@@ -1,0 +1,33 @@
+name: Microsmith (Scala sbt Native Fixture)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "build.microsmith.kts"
+      - "build.sbt"
+      - "project/build.properties"
+      - "project/plugins.sbt"
+      - ".github/workflows/microsmith.yml"
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 24
+          cache: sbt
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+      - name: Generate with Microsmith sbt plugin
+        run: sbt -batch -Dmicrosmith.version=<version> microsmithGenerate
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/sbt/scala/build.microsmith.kts
+++ b/examples/sbt/scala/build.microsmith.kts
@@ -1,0 +1,9 @@
+microsmith {
+    schemas {
+        protobuf {
+            message("ScalaSbtUserCreated") {
+                int32("id") { index(1) }
+            }
+        }
+    }
+}

--- a/examples/sbt/scala/build.sbt
+++ b/examples/sbt/scala/build.sbt
@@ -1,0 +1,23 @@
+ThisBuild / scalaVersion := "3.7.1"
+
+val microsmithVersion =
+  sys.props.getOrElse(
+    "microsmith.version",
+    sys.error("Pass -Dmicrosmith.version=<version>."),
+  )
+
+def githubMicrosmithCredentials: Seq[Credentials] =
+  for {
+    actor <- sys.env.get("GITHUB_ACTOR").toSeq
+    token <- sys.env.get("GITHUB_TOKEN").toSeq
+  } yield Credentials("GitHub Package Registry", "maven.pkg.github.com", actor, token)
+
+lazy val root = (project in file("."))
+  .enablePlugins(MicrosmithSbtPlugin)
+  .settings(
+    name := "scala-sbt-native-fixture",
+    resolvers += Resolver.mavenLocal,
+    resolvers += "GitHub Microsmith" at "https://maven.pkg.github.com/lmliam/microsmith",
+    credentials ++= githubMicrosmithCredentials,
+    libraryDependencies += "me.liam.microsmith" % "runtime-scripting" % microsmithVersion % Provided,
+  )

--- a/examples/sbt/scala/project/build.properties
+++ b/examples/sbt/scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.7

--- a/examples/sbt/scala/project/plugins.sbt
+++ b/examples/sbt/scala/project/plugins.sbt
@@ -1,0 +1,17 @@
+val microsmithVersion =
+  sys.props.getOrElse(
+    "microsmith.version",
+    sys.error("Pass -Dmicrosmith.version=<version>."),
+  )
+
+def githubMicrosmithCredentials: Seq[Credentials] =
+  for {
+    actor <- sys.env.get("GITHUB_ACTOR").toSeq
+    token <- sys.env.get("GITHUB_TOKEN").toSeq
+  } yield Credentials("GitHub Package Registry", "maven.pkg.github.com", actor, token)
+
+resolvers += Resolver.mavenLocal
+resolvers += "GitHub Microsmith" at "https://maven.pkg.github.com/lmliam/microsmith"
+credentials ++= githubMicrosmithCredentials
+
+addSbtPlugin("me.liam.microsmith" % "sbt-microsmith" % microsmithVersion)

--- a/examples/sbt/scala/src/main/scala/example/App.scala
+++ b/examples/sbt/scala/src/main/scala/example/App.scala
@@ -1,0 +1,5 @@
+package example
+
+object App {
+  def message: String = "Microsmith Scala sbt fixture"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ coroutines = "1.10.2"
 spiTooling = "0.1.22"
 mavenResolver = "1.9.22"
 mavenPluginApi = "3.9.9"
+sbt = "1.11.7"
+scala212 = "2.12.20"
 
 [libraries]
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
@@ -82,6 +82,11 @@ internal object InitSummaryEmitter {
                     "IDE support: add 'me.liam.microsmith:runtime-scripting' as a provided dependency, " +
                     "configure 'me.liam.microsmith:microsmith-maven-plugin', and run 'mvn microsmith:generate'.",
             )
+            JvmNativeBuildSystem.SBT -> emitter.info(
+                "sbt repository detected. Prefer the native sbt plugin path when you want build-aligned " +
+                    "generation: add 'me.liam.microsmith' % 'sbt-microsmith' in project/plugins.sbt, " +
+                    "enable 'MicrosmithSbtPlugin', and run 'sbt microsmithGenerate'.",
+            )
         }
     }
 }
@@ -96,6 +101,8 @@ private fun InitBootstrapResult.nativeJvmBuildSystem(): JvmNativeBuildSystem? {
     return when {
         hasGradleMarker && !hasMavenMarker -> JvmNativeBuildSystem.GRADLE
         hasMavenMarker && !hasGradleMarker -> JvmNativeBuildSystem.MAVEN
+        repositoryDetection.matchedMarkers.any(::isSbtMarker) && !hasGradleMarker && !hasMavenMarker ->
+            JvmNativeBuildSystem.SBT
         else -> null
     }
 }
@@ -109,7 +116,13 @@ private fun isGradleMarker(marker: String): Boolean = marker in setOf(
 
 private fun isMavenMarker(marker: String): Boolean = marker == "pom.xml"
 
+private fun isSbtMarker(marker: String): Boolean = marker in setOf(
+    "build.sbt",
+    "project/build.properties",
+)
+
 private enum class JvmNativeBuildSystem {
     GRADLE,
     MAVEN,
+    SBT,
 }

--- a/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
+++ b/modules/cli/src/main/kotlin/me/liam/microsmith/cli/execution/InitSummaryEmitter.kt
@@ -98,11 +98,11 @@ private fun InitBootstrapResult.nativeJvmBuildSystem(): JvmNativeBuildSystem? {
     }
     val hasGradleMarker = repositoryDetection.matchedMarkers.any(::isGradleMarker)
     val hasMavenMarker = repositoryDetection.matchedMarkers.any(::isMavenMarker)
+    val hasSbtMarker = repositoryDetection.matchedMarkers.any(::isSbtMarker)
     return when {
-        hasGradleMarker && !hasMavenMarker -> JvmNativeBuildSystem.GRADLE
-        hasMavenMarker && !hasGradleMarker -> JvmNativeBuildSystem.MAVEN
-        repositoryDetection.matchedMarkers.any(::isSbtMarker) && !hasGradleMarker && !hasMavenMarker ->
-            JvmNativeBuildSystem.SBT
+        hasGradleMarker && !hasMavenMarker && !hasSbtMarker -> JvmNativeBuildSystem.GRADLE
+        hasMavenMarker && !hasGradleMarker && !hasSbtMarker -> JvmNativeBuildSystem.MAVEN
+        hasSbtMarker && !hasGradleMarker && !hasMavenMarker -> JvmNativeBuildSystem.SBT
         else -> null
     }
 }

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitNativeJvmGuidanceTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitNativeJvmGuidanceTests.kt
@@ -63,13 +63,15 @@ class MicrosmithCliInitNativeJvmGuidanceTests :
             )
         }
 
-        "init command keeps sbt-style Scala repositories on the canonical generated output path" {
+        "init command points sbt-based Scala repositories toward the native sbt plugin path" {
             assertNativeJvmGuidance(
                 profile = ScalaOnboardingProfile,
                 matchedMarkers = listOf("build.sbt", "src/main/scala"),
                 expectedOutput = listOf(
                     "Detected repository profile: Scala",
                     "Next: microsmith run build.microsmith.kts --out ./generated",
+                    "Prefer the native sbt plugin path",
+                    "sbt microsmithGenerate",
                 ),
                 unexpectedOutput = listOf(
                     "Prefer the native Gradle plugin path",

--- a/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitNativeJvmGuidanceTests.kt
+++ b/modules/cli/src/test/kotlin/me/liam/microsmith/cli/MicrosmithCliInitNativeJvmGuidanceTests.kt
@@ -118,6 +118,23 @@ class MicrosmithCliInitNativeJvmGuidanceTests :
                 tempDirectoryPrefix = "microsmith-cli-init-scala-gradle",
             )
         }
+
+        "init command does not guess a native build tool when Scala repositories expose mixed native markers" {
+            assertNativeJvmGuidance(
+                profile = ScalaOnboardingProfile,
+                matchedMarkers = listOf("build.sbt", "build.gradle.kts", "src/main/scala"),
+                expectedOutput = listOf(
+                    "Detected repository profile: Scala",
+                    "Next: microsmith run build.microsmith.kts --out ./generated",
+                ),
+                unexpectedOutput = listOf(
+                    "Prefer the native Gradle plugin path",
+                    "Prefer the native Maven plugin path",
+                    "Prefer the native sbt plugin path",
+                ),
+                tempDirectoryPrefix = "microsmith-cli-init-scala-mixed-native-markers",
+            )
+        }
     })
 
 @OptIn(ExperimentalPathApi::class)

--- a/modules/sbt-plugin/build.gradle
+++ b/modules/sbt-plugin/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'scala'
+}
+
+def sbtPluginArtifactId = "sbt-microsmith_2.12_1.0"
+
+dependencies {
+    implementation project(':runtime-scripting')
+    compileOnly "org.scala-sbt:main_2.12:${libs.versions.sbt.get()}"
+    compileOnly "org.scala-sbt:main-settings_2.12:${libs.versions.sbt.get()}"
+    compileOnly "org.scala-lang:scala-library:${libs.versions.scala212.get()}"
+    testImplementation project(':runtime-scripting')
+    testRuntimeOnly libs.kotest.runner.junit5
+}
+
+tasks.withType(ScalaCompile).configureEach {
+    scalaCompileOptions.additionalParameters = ['-target:jvm-1.8']
+}
+
+tasks.named('compileScala', ScalaCompile).configure {
+    dependsOn(tasks.named('compileKotlin'))
+    classpath += files(layout.buildDirectory.dir('classes/kotlin/main'))
+}
+
+publishing {
+    publications {
+        named('gpr', MavenPublication) {
+            artifactId = sbtPluginArtifactId
+        }
+    }
+}

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/DefaultMicrosmithSbtScriptHostRunner.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/DefaultMicrosmithSbtScriptHostRunner.kt
@@ -1,0 +1,11 @@
+package me.liam.microsmith.sbt
+
+import me.liam.microsmith.runtime.scripting.host.MicrosmithScriptHost
+import me.liam.microsmith.runtime.scripting.model.ScriptRunRequest
+import me.liam.microsmith.runtime.scripting.model.ScriptRunResult
+import java.nio.file.Path
+
+object DefaultMicrosmithSbtScriptHostRunner : MicrosmithSbtScriptHostRunner {
+    override fun run(cacheDirectory: Path, request: ScriptRunRequest): ScriptRunResult =
+        MicrosmithScriptHost(cacheDirectory).run(request)
+}

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionConfiguration.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionConfiguration.kt
@@ -1,0 +1,12 @@
+package me.liam.microsmith.sbt
+
+import java.nio.file.Path
+
+data class MicrosmithSbtExecutionConfiguration(
+    val baseDirectory: Path,
+    val scriptFile: Path,
+    val outputDirectory: Path,
+    val cacheDirectory: Path,
+    val variables: Map<String, String>,
+    val flags: Set<String>,
+)

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionOutcome.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionOutcome.kt
@@ -1,0 +1,10 @@
+package me.liam.microsmith.sbt
+
+import java.nio.file.Path
+
+data class MicrosmithSbtExecutionOutcome(
+    val outputDirectory: Path,
+    val warnings: List<String>,
+    val cacheHit: Boolean,
+    val elapsedMillis: Long,
+)

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionRequest.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionRequest.kt
@@ -1,0 +1,10 @@
+package me.liam.microsmith.sbt
+
+import me.liam.microsmith.runtime.scripting.model.ScriptRunRequest
+import java.nio.file.Path
+
+data class MicrosmithSbtExecutionRequest(
+    val scriptRunRequest: ScriptRunRequest,
+    val outputDirectory: Path,
+    val cacheDirectory: Path,
+)

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionRequestFactory.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionRequestFactory.kt
@@ -1,0 +1,27 @@
+package me.liam.microsmith.sbt
+
+import me.liam.microsmith.runtime.scripting.model.ScriptRunRequest
+import java.nio.file.Path
+
+class MicrosmithSbtExecutionRequestFactory {
+    fun create(configuration: MicrosmithSbtExecutionConfiguration): MicrosmithSbtExecutionRequest {
+        val baseDirectory = configuration.baseDirectory.toAbsolutePath().normalize()
+        val scriptPath = resolveAgainstBaseDirectory(baseDirectory, configuration.scriptFile)
+        val outputPath = resolveAgainstBaseDirectory(baseDirectory, configuration.outputDirectory)
+        val cachePath = resolveAgainstBaseDirectory(baseDirectory, configuration.cacheDirectory)
+        return MicrosmithSbtExecutionRequest(
+            scriptRunRequest =
+            ScriptRunRequest(
+                script = scriptPath,
+                outputDir = outputPath,
+                variables = configuration.variables.toSortedMap(),
+                flags = configuration.flags.toSortedSet(),
+            ),
+            outputDirectory = outputPath,
+            cacheDirectory = cachePath,
+        )
+    }
+
+    private fun resolveAgainstBaseDirectory(baseDirectory: Path, path: Path): Path =
+        path.takeIf(Path::isAbsolute)?.normalize() ?: baseDirectory.resolve(path).normalize()
+}

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionService.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionService.kt
@@ -1,0 +1,34 @@
+package me.liam.microsmith.sbt
+
+class MicrosmithSbtExecutionService(
+    private val requestFactory: MicrosmithSbtExecutionRequestFactory = MicrosmithSbtExecutionRequestFactory(),
+    private val scriptHostRunner: MicrosmithSbtScriptHostRunner = DefaultMicrosmithSbtScriptHostRunner,
+    private val resultInterpreter: MicrosmithSbtResultInterpreter = MicrosmithSbtResultInterpreter(),
+) {
+    fun execute(configuration: MicrosmithSbtExecutionConfiguration): MicrosmithSbtExecutionOutcome =
+        runWithHostFailureMapping {
+            val request = requestFactory.create(configuration)
+            val result = scriptHostRunner.run(request.cacheDirectory, request.scriptRunRequest)
+            resultInterpreter.interpret(request.outputDirectory, result)
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private inline fun runWithHostFailureMapping(
+        action: () -> MicrosmithSbtExecutionOutcome,
+    ): MicrosmithSbtExecutionOutcome {
+        try {
+            return action()
+        } catch (error: RuntimeException) {
+            throw error.toHostFailure()
+        }
+    }
+
+    private fun RuntimeException.toHostFailure(): RuntimeException = when (this) {
+        is MicrosmithSbtScriptFailureException -> this
+        is MicrosmithSbtHostFailureException -> this
+        else -> MicrosmithSbtHostFailureException(
+            "Microsmith sbt plugin failed before generation completed.",
+            this,
+        )
+    }
+}

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtHostFailureException.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtHostFailureException.kt
@@ -1,0 +1,6 @@
+package me.liam.microsmith.sbt
+
+class MicrosmithSbtHostFailureException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtResultInterpreter.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtResultInterpreter.kt
@@ -1,0 +1,38 @@
+package me.liam.microsmith.sbt
+
+import me.liam.microsmith.runtime.scripting.model.ScriptFailureType
+import me.liam.microsmith.runtime.scripting.model.ScriptRunFailure
+import me.liam.microsmith.runtime.scripting.model.ScriptRunResult
+import me.liam.microsmith.runtime.scripting.model.ScriptRunSuccess
+import java.nio.file.Path
+import java.util.Locale
+
+class MicrosmithSbtResultInterpreter {
+    fun interpret(outputDirectory: Path, result: ScriptRunResult): MicrosmithSbtExecutionOutcome {
+        return when (result) {
+            is ScriptRunSuccess -> MicrosmithSbtExecutionOutcome(
+                outputDirectory = outputDirectory,
+                warnings = result.warnings,
+                cacheHit = result.cacheHit,
+                elapsedMillis = result.elapsedMillis,
+            )
+            is ScriptRunFailure -> throw buildFailure(result)
+        }
+    }
+
+    private fun buildFailure(result: ScriptRunFailure): RuntimeException {
+        val message = buildFailureMessage(result)
+        return when (result.type) {
+            ScriptFailureType.VALIDATION,
+            ScriptFailureType.COMPILATION,
+            ScriptFailureType.EVALUATION,
+            -> MicrosmithSbtScriptFailureException(message)
+            ScriptFailureType.HOST -> MicrosmithSbtHostFailureException(message)
+        }
+    }
+
+    private fun buildFailureMessage(result: ScriptRunFailure): String = buildString {
+        appendLine("Microsmith generation failed (${result.type.name.lowercase(Locale.ROOT)}).")
+        result.diagnostics.forEach(::appendLine)
+    }.trimEnd()
+}

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtScriptFailureException.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtScriptFailureException.kt
@@ -1,0 +1,3 @@
+package me.liam.microsmith.sbt
+
+class MicrosmithSbtScriptFailureException(message: String) : RuntimeException(message)

--- a/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtScriptHostRunner.kt
+++ b/modules/sbt-plugin/src/main/kotlin/me/liam/microsmith/sbt/MicrosmithSbtScriptHostRunner.kt
@@ -1,0 +1,9 @@
+package me.liam.microsmith.sbt
+
+import me.liam.microsmith.runtime.scripting.model.ScriptRunRequest
+import me.liam.microsmith.runtime.scripting.model.ScriptRunResult
+import java.nio.file.Path
+
+fun interface MicrosmithSbtScriptHostRunner {
+    fun run(cacheDirectory: Path, request: ScriptRunRequest): ScriptRunResult
+}

--- a/modules/sbt-plugin/src/main/resources/sbt/sbt.autoplugins
+++ b/modules/sbt-plugin/src/main/resources/sbt/sbt.autoplugins
@@ -1,0 +1,1 @@
+me.liam.microsmith.sbt.MicrosmithSbtPlugin

--- a/modules/sbt-plugin/src/main/scala/me/liam/microsmith/sbt/MicrosmithSbtPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/me/liam/microsmith/sbt/MicrosmithSbtPlugin.scala
@@ -1,0 +1,114 @@
+package me.liam.microsmith.sbt
+
+import _root_.sbt._
+import _root_.sbt.Keys._
+import _root_.sbt.internal.util.MessageOnlyException
+import _root_.sbt.util.Logger
+
+import scala.collection.JavaConverters._
+import java.io.File
+import java.nio.file.Files
+
+object MicrosmithSbtPlugin extends AutoPlugin {
+  override def requires: Plugins = plugins.JvmPlugin
+  override def trigger: PluginTrigger = noTrigger
+
+  object autoImport {
+    val microsmithGenerate = TaskKey[Seq[File]](
+      "microsmithGenerate",
+      "Generates artifacts from a .microsmith.kts script.",
+    )
+    val microsmithScriptFile = SettingKey[File](
+      "microsmithScriptFile",
+      "Path to the .microsmith.kts script to execute.",
+    )
+    val microsmithOutputDirectory = SettingKey[File](
+      "microsmithOutputDirectory",
+      "Directory where generated outputs are written.",
+    )
+    val microsmithCacheDirectory = SettingKey[File](
+      "microsmithCacheDirectory",
+      "Directory used for Microsmith script compilation cache entries.",
+    )
+    val microsmithVariables = SettingKey[Map[String, String]](
+      "microsmithVariables",
+      "Variables exposed to the script via requireVar and hasVar.",
+    )
+    val microsmithFlags = SettingKey[Set[String]](
+      "microsmithFlags",
+      "Flags exposed to the script via hasFlag.",
+    )
+  }
+
+  import autoImport._
+
+  private val executionService = new MicrosmithSbtExecutionService()
+
+  override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
+    microsmithScriptFile := new File(baseDirectory.value, "build.microsmith.kts"),
+    microsmithOutputDirectory := new File(new File(target.value, "generated"), "microsmith"),
+    microsmithCacheDirectory := new File(new File(new File(target.value, "tmp"), "microsmith"), "cache"),
+    microsmithVariables := Map.empty,
+    microsmithFlags := Set.empty,
+    microsmithGenerate := generate(
+      logger = streams.value.log,
+      baseDirectory = baseDirectory.value,
+      scriptFile = microsmithScriptFile.value,
+      outputDirectory = microsmithOutputDirectory.value,
+      cacheDirectory = microsmithCacheDirectory.value,
+      variables = microsmithVariables.value,
+      flags = microsmithFlags.value,
+    ),
+  )
+
+  private def generate(
+    logger: Logger,
+    baseDirectory: File,
+    scriptFile: File,
+    outputDirectory: File,
+    cacheDirectory: File,
+    variables: Map[String, String],
+    flags: Set[String],
+  ): Seq[File] = {
+    val configuration = new MicrosmithSbtExecutionConfiguration(
+      baseDirectory.toPath,
+      scriptFile.toPath,
+      outputDirectory.toPath,
+      cacheDirectory.toPath,
+      variables.asJava,
+      flags.asJava,
+    )
+
+    try {
+      val outcome = executionService.execute(configuration)
+      outcome.getWarnings.asScala.foreach(message => logger.warn(message))
+      logger.info(
+        s"Generated Microsmith outputs into '${outcome.getOutputDirectory}'. " +
+          s"(compile-cache=${if (outcome.getCacheHit) "hit" else "miss"}, elapsed=${outcome.getElapsedMillis}ms)"
+      )
+      generatedFiles(outputDirectory)
+    } catch {
+      case error: MicrosmithSbtScriptFailureException =>
+        throw new MessageOnlyException(error.getMessage)
+      case error: MicrosmithSbtHostFailureException =>
+        throw new IllegalStateException(error.getMessage, error)
+    }
+  }
+
+  private def generatedFiles(outputDirectory: File): Seq[File] = {
+    if (!outputDirectory.isDirectory) {
+      return Seq.empty
+    }
+
+    val stream = Files.walk(outputDirectory.toPath)
+    try {
+      stream.iterator.asScala
+        .filter(Files.isRegularFile(_))
+        .map(_.toFile)
+        .toVector
+        .sortBy(_.getAbsolutePath)
+    } finally {
+      stream.close()
+    }
+  }
+}

--- a/modules/sbt-plugin/src/test/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionServiceTests.kt
+++ b/modules/sbt-plugin/src/test/kotlin/me/liam/microsmith/sbt/MicrosmithSbtExecutionServiceTests.kt
@@ -1,0 +1,128 @@
+package me.liam.microsmith.sbt
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.liam.microsmith.runtime.scripting.model.ScriptFailureType
+import me.liam.microsmith.runtime.scripting.model.ScriptRunFailure
+
+class MicrosmithSbtExecutionServiceTests : StringSpec() {
+    init {
+        "execute generates outputs from the configured script" {
+            val fixture = MicrosmithSbtTestProject.create("microsmith-sbt-plugin-generate")
+            fixture.writeFile(
+                "build.microsmith.kts",
+                """
+                microsmith {
+                    schemas {
+                        protobuf {
+                            message("SbtUserCreated") {
+                                int32("id") { index(1) }
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+
+            val result = MicrosmithSbtExecutionService().execute(fixture.executionConfiguration())
+
+            result.outputDirectory shouldBe fixture.file("target/generated/microsmith")
+            fixture.file("target/generated/microsmith/proto/SbtUserCreated.proto").toFile().shouldExist()
+        }
+
+        "execute forwards vars and flags to the script" {
+            val fixture = MicrosmithSbtTestProject.create("microsmith-sbt-plugin-vars-flags")
+            fixture.writeFile(
+                "build.microsmith.kts",
+                """
+                val entityName = requireVar("entityName")
+                if (!hasFlag("emit")) {
+                    error("Expected emit flag")
+                }
+
+                emit(
+                    microsmith {
+                        schemas {
+                            protobuf {
+                                message(entityName) {
+                                    int32("id") { index(1) }
+                                }
+                            }
+                        }
+                    },
+                )
+                """.trimIndent(),
+            )
+
+            val result = MicrosmithSbtExecutionService().execute(
+                fixture.executionConfiguration(
+                    outputDirectory = fixture.file("target/generated/custom"),
+                    variables = mapOf("entityName" to "SbtConfiguredUserCreated"),
+                    flags = setOf("emit"),
+                ),
+            )
+
+            result.outputDirectory shouldBe fixture.file("target/generated/custom")
+            fixture.file("target/generated/custom/proto/SbtConfiguredUserCreated.proto").toFile().shouldExist()
+        }
+
+        "script compilation failures surface as MicrosmithSbtScriptFailureException" {
+            val fixture = MicrosmithSbtTestProject.create("microsmith-sbt-plugin-compilation-failure")
+            fixture.writeFile(
+                "build.microsmith.kts",
+                """
+                microsmith {
+                    schemas {
+                        protobuf {
+                            unknownCall()
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+
+            val error = shouldThrow<MicrosmithSbtScriptFailureException> {
+                MicrosmithSbtExecutionService().execute(fixture.executionConfiguration())
+            }
+
+            error.message shouldContain "Microsmith generation failed"
+            error.message shouldContain "Unresolved reference 'unknownCall'"
+        }
+
+        "host failures surface as MicrosmithSbtHostFailureException" {
+            val fixture = MicrosmithSbtTestProject.create("microsmith-sbt-plugin-host-failure")
+            fixture.writeFile("build.microsmith.kts", "emit(microsmith { })")
+            val service = MicrosmithSbtExecutionService(
+                scriptHostRunner = MicrosmithSbtScriptHostRunner { _, _ ->
+                    ScriptRunFailure(listOf("Host failure"), ScriptFailureType.HOST)
+                },
+            )
+
+            val error = shouldThrow<MicrosmithSbtHostFailureException> {
+                service.execute(fixture.executionConfiguration())
+            }
+
+            error.message shouldContain "Microsmith generation failed"
+            error.message shouldContain "Host failure"
+        }
+
+        "generic runtime failures surface as MicrosmithSbtHostFailureException with the original cause" {
+            val fixture = MicrosmithSbtTestProject.create("microsmith-sbt-plugin-runtime-failure")
+            fixture.writeFile("build.microsmith.kts", "emit(microsmith { })")
+            val failure = RuntimeException("Unexpected runtime failure")
+            val service = MicrosmithSbtExecutionService(
+                scriptHostRunner = MicrosmithSbtScriptHostRunner { _, _ -> throw failure },
+            )
+
+            val error = shouldThrow<MicrosmithSbtHostFailureException> {
+                service.execute(fixture.executionConfiguration())
+            }
+
+            error.message shouldContain "Microsmith sbt plugin failed before generation completed."
+            error.cause shouldBe failure
+        }
+    }
+}

--- a/modules/sbt-plugin/src/test/kotlin/me/liam/microsmith/sbt/MicrosmithSbtTestProject.kt
+++ b/modules/sbt-plugin/src/test/kotlin/me/liam/microsmith/sbt/MicrosmithSbtTestProject.kt
@@ -1,0 +1,36 @@
+package me.liam.microsmith.sbt
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class MicrosmithSbtTestProject private constructor(
+    private val rootDirectory: Path,
+) {
+    fun writeFile(relativePath: String, contents: String) {
+        val file = file(relativePath)
+        Files.createDirectories(checkNotNull(file.parent))
+        Files.writeString(file, "$contents\n")
+    }
+
+    fun file(relativePath: String): Path = rootDirectory.resolve(relativePath)
+
+    fun executionConfiguration(
+        scriptFile: Path = file("build.microsmith.kts"),
+        outputDirectory: Path = file("target/generated/microsmith"),
+        cacheDirectory: Path = file("target/tmp/microsmith/cache"),
+        variables: Map<String, String> = emptyMap(),
+        flags: Set<String> = emptySet(),
+    ): MicrosmithSbtExecutionConfiguration = MicrosmithSbtExecutionConfiguration(
+        baseDirectory = rootDirectory,
+        scriptFile = scriptFile,
+        outputDirectory = outputDirectory,
+        cacheDirectory = cacheDirectory,
+        variables = variables,
+        flags = flags,
+    )
+
+    companion object {
+        fun create(prefix: String): MicrosmithSbtTestProject =
+            MicrosmithSbtTestProject(Files.createTempDirectory(prefix))
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,9 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         maven {
+            url = uri("https://repo.scala-sbt.org/scalasbt/maven-releases/")
+        }
+        maven {
             url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
             mavenContent {
                 snapshotsOnly()
@@ -66,6 +69,7 @@ rootProject.name = 'microsmith'
     'cli',
     'gradle-plugin',
     'maven-plugin',
+    'sbt-plugin',
     'kotest',
 ].each { moduleName ->
     include moduleName


### PR DESCRIPTION
## Why

Scala `sbt` repositories still had no native Microsmith integration path after the Gradle and Maven work landed.
That left three gaps:

- Scala users had no build-tool-native generation path inside existing `sbt` builds.
- `microsmith init` could not steer `sbt` repositories toward a first-class native option.
- The repository had no representative `sbt` fixture or CI validation for the native Scala build-tool path.

This PR closes that gap with a native `sbt` plugin, fixture coverage, and the README contract for when native `sbt`, helper, and fallback paths should be used.

Closes #102.

## What Changed

### Native sbt plugin

- added new module `modules/sbt-plugin`
- added `MicrosmithSbtPlugin` as an `AutoPlugin`
- exposed the native sbt surface:
  - `microsmithGenerate`
  - `microsmithScriptFile`
  - `microsmithOutputDirectory`
  - `microsmithCacheDirectory`
  - `microsmithVariables`
  - `microsmithFlags`
- kept the plugin thin by separating:
  - execution request construction
  - host execution
  - result interpretation
  - sbt-facing task wiring
- published the plugin under the sbt cross artifact id `sbt-microsmith_2.12_1.0`

### CLI onboarding guidance

- updated `microsmith init` summary output so Scala repositories with `sbt` markers are steered toward the native sbt path
- added regression coverage for the new sbt-native guidance path

### Fixtures and CI

- added representative native sbt fixture under `examples/sbt/scala`
- added fixture workflow at `examples/sbt/scala/.github/workflows/microsmith.yml`
- extended `.github/workflows/build_test_qodana.yml` to:
  - publish `:sbt-plugin` to `mavenLocal`
  - install `sbt`
  - validate the native sbt fixture via `sbt microsmithGenerate`

### Documentation

- added a dedicated `Native sbt integration` section to `README.md`
- documented:
  - native sbt setup
  - resolver and credential shape
  - required `Provided` `runtime-scripting` dependency for imported-project IDE types
  - generated-output guidance
  - helper/fallback coexistence rules
- updated fixture inventory, validation matrix, and IDE validation checklist to include native sbt coverage

## Validation

Executed locally:

```bash
./gradlew :sbt-plugin:check :sbt-plugin:jvmKotest --rerun-tasks --no-build-cache
./gradlew :cli:check :cli:jvmKotest :sbt-plugin:check :sbt-plugin:jvmKotest :sbt-plugin:publishToMavenLocal --rerun-tasks --no-build-cache
./gradlew build --rerun-tasks --no-build-cache
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_test_qodana.yml"); YAML.load_file("examples/sbt/scala/.github/workflows/microsmith.yml")'
./modules/cli/build/microsmith-cli-dist/bin/microsmith --help > /tmp/microsmith-cli-help.txt && python3 scripts/verify_readme_cli_usage.py README.md /tmp/microsmith-cli-help.txt
git diff --check
```

Additional local validation:

- verified `:sbt-plugin:publishToMavenLocal` publishes `~/.m2/repository/me/liam/microsmith/sbt-microsmith_2.12_1.0/...`
- verified the new native sbt guidance path through `MicrosmithCliInitNativeJvmGuidanceTests`

## Notes

- A real end-to-end `sbt` fixture run is now wired into GitHub Actions. There is no local `sbt` binary installed in this environment, so the actual `sbt microsmithGenerate` smoke remains CI-validated rather than locally executed.
- The helper and fallback paths remain supported for JetBrains `.microsmith.kts` indexing in sbt repositories when imported-project indexing is not sufficient.
