### PR TITLE
feat(services-core): add microservice DSL and generation foundations

### DIFF
--- a/modules/dsl-services/build.gradle
+++ b/modules/dsl-services/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(":dsl")
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/MicrosmithScopeServicesExtensions.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/MicrosmithScopeServicesExtensions.kt
@@ -1,0 +1,24 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.github.lmliam.microsmith.dsl.core.MicrosmithBuilder
+import io.github.lmliam.microsmith.dsl.core.MicrosmithScope
+import io.github.lmliam.microsmith.dsl.helpers.put
+
+/**
+ * Start a `services { ... }` block in the Microsmith DSL.
+ */
+fun MicrosmithScope.services(block: ServicesScope.() -> Unit) {
+    val builder = ServicesBuilder().apply(block)
+    val newExt = builder.toExtension()
+
+    val microsmithBuilder =
+        this as? MicrosmithBuilder
+            ?: error("services { ... } can only be invoked within a MicrosmithBuilder scope.")
+    val existing = microsmithBuilder.model.get<ServicesExtension>()
+
+    if (existing != null) {
+        microsmithBuilder.put(existing.merge(newExt))
+    } else {
+        microsmithBuilder.put(newExt)
+    }
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/Service.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/Service.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+/**
+ * Immutable service declaration produced by the core service DSL.
+ */
+data class Service(
+    val name: String,
+    val model: ServiceModel,
+) {
+    init {
+        require(name.isNotBlank()) { "Service name cannot be blank." }
+    }
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceBuilder.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceBuilder.kt
@@ -1,0 +1,18 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Internal builder used to construct a [Service] from DSL blocks.
+ */
+class ServiceBuilder(
+    private val name: String,
+) : ServiceScope {
+    private var model = ServiceModel.empty()
+
+    fun <T : ServiceExtension> put(type: KClass<T>, ext: T) {
+        model = model.with(type, ext)
+    }
+
+    fun build() = Service(name = name, model = model)
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceExtension.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceExtension.kt
@@ -1,0 +1,8 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.github.lmliam.microsmith.dsl.core.ModelExtension
+
+/**
+ * Marker interface for service-scoped extension payloads.
+ */
+interface ServiceExtension : ModelExtension

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceKey.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceKey.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+internal data class ServiceKey(val name: String) {
+    init {
+        require(name.isNotBlank()) { "Service name cannot be blank." }
+    }
+
+    override fun toString() = name
+
+    companion object {
+        fun of(service: Service) = ServiceKey(service.name)
+    }
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModel.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModel.kt
@@ -1,0 +1,25 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Immutable snapshot of the service-scoped extension payloads attached to a service.
+ */
+class ServiceModel internal constructor(
+    private val extensions: Map<KClass<out ServiceExtension>, ServiceExtension>,
+) {
+    @Suppress("UNCHECKED_CAST")
+    fun <T : ServiceExtension> get(type: KClass<T>) = extensions[type] as? T?
+
+    inline fun <reified T : ServiceExtension> get(): T? = get(T::class)
+
+    internal fun <T : ServiceExtension> with(type: KClass<T>, value: T) = ServiceModel(
+        extensions + (mapOf(type to value)),
+    )
+
+    fun keys() = extensions.keys
+
+    companion object {
+        fun empty() = ServiceModel(emptyMap())
+    }
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModel.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModel.kt
@@ -19,6 +19,12 @@ class ServiceModel internal constructor(
 
     fun keys() = extensions.keys
 
+    override fun equals(other: Any?): Boolean {
+        return other is ServiceModel && extensions == other.extensions
+    }
+
+    override fun hashCode(): Int = extensions.hashCode()
+
     companion object {
         fun empty() = ServiceModel(emptyMap())
     }

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceScope.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceScope.kt
@@ -1,0 +1,12 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.github.lmliam.microsmith.dsl.core.MicrosmithDsl
+
+/**
+ * Marker interface for a named service block inside `services { ... }`.
+ *
+ * Feature modules add their own service-scoped entrypoints here
+ * (for example, `fun ServiceScope.dotnet { ... }`).
+ */
+@MicrosmithDsl
+interface ServiceScope

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesBuilder.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesBuilder.kt
@@ -1,0 +1,26 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+/**
+ * Internal builder used within the `services { ... }` DSL block.
+ */
+class ServicesBuilder : ServicesScope {
+    private val servicesByKey = linkedMapOf<ServiceKey, Service>()
+    internal val services: Set<Service>
+        get() = servicesByKey.values.toSet()
+
+    fun register(service: Service) {
+        val serviceKey = ServiceKey.of(service)
+        require(serviceKey !in servicesByKey) {
+            "Duplicate service registration for '$serviceKey'."
+        }
+
+        servicesByKey[serviceKey] = service
+    }
+
+    fun toExtension() = ServicesExtension(services)
+
+    override fun String.invoke(block: ServiceScope.() -> Unit) {
+        require(isNotBlank()) { "Service name cannot be blank." }
+        register(ServiceBuilder(this).apply(block).build())
+    }
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesExtension.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesExtension.kt
@@ -1,0 +1,49 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.github.lmliam.microsmith.dsl.core.MicrosmithExtension
+
+/**
+ * Root extension that holds all declared services.
+ */
+data class ServicesExtension(val services: Set<Service>) : MicrosmithExtension {
+    init {
+        val duplicateKeys =
+            services
+                .groupBy(ServiceKey::of)
+                .filterValues { it.size > 1 }
+                .keys
+                .map(ServiceKey::toString)
+                .sorted()
+
+        require(duplicateKeys.isEmpty()) {
+            "ServicesExtension contains duplicate service keys: ${duplicateKeys.joinToString(", ")}"
+        }
+    }
+
+    private val index = services.associateBy(ServiceKey::of)
+
+    fun find(name: String) = index[ServiceKey(name)]
+
+    fun require(name: String): Service {
+        return find(name) ?: error("Service not found: ${ServiceKey(name)}")
+    }
+
+    fun all() = services
+
+    fun merge(other: ServicesExtension): ServicesExtension {
+        val existingKeys = services.mapTo(mutableSetOf(), ServiceKey::of)
+        val collisions =
+            other.services
+                .map(ServiceKey::of)
+                .filter { it in existingKeys }
+                .map(ServiceKey::toString)
+                .distinct()
+                .sorted()
+
+        require(collisions.isEmpty()) {
+            "Duplicate service keys while merging ServicesExtension: ${collisions.joinToString(", ")}"
+        }
+
+        return copy(services = services + other.services)
+    }
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesScope.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesScope.kt
@@ -1,0 +1,14 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.github.lmliam.microsmith.dsl.core.MicrosmithDsl
+
+/**
+ * Marker interface for the `services { ... }` DSL block.
+ *
+ * Feature modules extend this scope with shared service configuration
+ * entrypoints, while the core module contributes named service declarations.
+ */
+@MicrosmithDsl
+interface ServicesScope {
+    operator fun String.invoke(block: ServiceScope.() -> Unit = {})
+}

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/helpers/ServiceModelExtensions.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/helpers/ServiceModelExtensions.kt
@@ -1,0 +1,25 @@
+package io.github.lmliam.microsmith.dsl.services.helpers
+
+import io.github.lmliam.microsmith.dsl.services.core.ServiceExtension
+import io.github.lmliam.microsmith.dsl.services.core.ServiceModel
+
+/**
+ * Returns true if the model contains an extension of type [T].
+ */
+inline fun <reified T : ServiceExtension> ServiceModel.has() = get<T>() != null
+
+/**
+ * Returns the extension of type [T], or throws if not present.
+ */
+inline fun <reified T : ServiceExtension> ServiceModel.require() =
+    get<T>() ?: error("Required service extension ${T::class.simpleName} not found")
+
+/**
+ * Returns all extensions currently attached to the service model.
+ */
+fun ServiceModel.extensions() = this.keys().mapNotNull { get(it) }
+
+/**
+ * Returns the set of extension types present in the service model.
+ */
+fun ServiceModel.extensionTypes() = this.keys().map { it.java }.toSet()

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModelTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModelTests.kt
@@ -7,6 +7,10 @@ private data class TestServiceExtension(val value: String) : ServiceExtension
 
 class ServiceModelTests :
     StringSpec({
+        "empty models compare equal by value" {
+            ServiceModel.empty() shouldBe ServiceModel.empty()
+        }
+
         "get returns extension when present" {
             val extension = TestServiceExtension("hello")
             val model = ServiceModel.empty().with(TestServiceExtension::class, extension)

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModelTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModelTests.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+private data class TestServiceExtension(val value: String) : ServiceExtension
+
+class ServiceModelTests :
+    StringSpec({
+        "get returns extension when present" {
+            val extension = TestServiceExtension("hello")
+            val model = ServiceModel.empty().with(TestServiceExtension::class, extension)
+
+            model.get<TestServiceExtension>() shouldBe extension
+        }
+
+        "get returns null when extension not present" {
+            val model = ServiceModel.empty()
+
+            model.get<TestServiceExtension>() shouldBe null
+        }
+
+        "with returns new immutable snapshot" {
+            val model1 = ServiceModel.empty()
+            val model2 = model1.with(TestServiceExtension::class, TestServiceExtension("hello"))
+
+            model1.get<TestServiceExtension>() shouldBe null
+            model2.get<TestServiceExtension>() shouldBe TestServiceExtension("hello")
+        }
+    })

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesBuilderTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesBuilderTests.kt
@@ -1,0 +1,62 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+
+class ServicesBuilderTests :
+    StringSpec({
+        "register adds service to builder" {
+            val builder = ServicesBuilder()
+            val service = Service(name = "UserService", model = ServiceModel.empty())
+
+            builder.register(service)
+
+            builder.services shouldContainExactly listOf(service)
+        }
+
+        "register throws if service name is blank" {
+            val builder = ServicesBuilder()
+            val service = Service(name = " ", model = ServiceModel.empty())
+
+            shouldThrow<IllegalArgumentException> {
+                builder.register(service)
+            }
+        }
+
+        "register throws for duplicate service name" {
+            val builder = ServicesBuilder()
+            val service = Service(name = "UserService", model = ServiceModel.empty())
+
+            builder.register(service)
+
+            shouldThrow<IllegalArgumentException> {
+                builder.register(Service(name = "UserService", model = ServiceModel.empty()))
+            }
+        }
+
+        "build produces ServicesExtension with all services" {
+            val builder = ServicesBuilder()
+            val s1 = Service(name = "UserService", model = ServiceModel.empty())
+            val s2 = Service(name = "OrderService", model = ServiceModel.empty())
+
+            builder.register(s1)
+            builder.register(s2)
+
+            val ext = builder.toExtension()
+
+            ext.services shouldContainExactly listOf(s1, s2)
+        }
+
+        "ServicesExtension is immutable snapshot" {
+            val builder = ServicesBuilder()
+            val service = Service(name = "UserService", model = ServiceModel.empty())
+            builder.register(service)
+
+            val ext = builder.toExtension()
+
+            builder.register(Service(name = "OrderService", model = ServiceModel.empty()))
+
+            ext.services shouldContainExactly listOf(service)
+        }
+    })

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesBuilderTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesBuilderTests.kt
@@ -17,10 +17,9 @@ class ServicesBuilderTests :
 
         "register throws if service name is blank" {
             val builder = ServicesBuilder()
-            val service = Service(name = " ", model = ServiceModel.empty())
 
             shouldThrow<IllegalArgumentException> {
-                builder.register(service)
+                builder.register(Service(name = " ", model = ServiceModel.empty()))
             }
         }
 

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesExtensionTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesExtensionTests.kt
@@ -1,0 +1,47 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ServicesExtensionTests :
+    StringSpec({
+        "find returns service when present" {
+            val s1 = Service(name = "UserService", model = ServiceModel.empty())
+            val ext = ServicesExtension(setOf(s1))
+
+            ext.find("UserService") shouldBe s1
+        }
+
+        "find returns null when service not present" {
+            val s1 = Service(name = "UserService", model = ServiceModel.empty())
+            val ext = ServicesExtension(setOf(s1))
+
+            ext.find("OrderService") shouldBe null
+        }
+
+        "require returns service when present" {
+            val s1 = Service(name = "UserService", model = ServiceModel.empty())
+            val ext = ServicesExtension(setOf(s1))
+
+            ext.require("UserService") shouldBe s1
+        }
+
+        "require throws when service not present" {
+            val s1 = Service(name = "UserService", model = ServiceModel.empty())
+            val ext = ServicesExtension(setOf(s1))
+
+            shouldThrow<IllegalStateException> {
+                ext.require("OrderService")
+            }
+        }
+
+        "merge throws when duplicate service key exists across extensions" {
+            val left = ServicesExtension(setOf(Service(name = "UserService", model = ServiceModel.empty())))
+            val right = ServicesExtension(setOf(Service(name = "UserService", model = ServiceModel.empty())))
+
+            shouldThrow<IllegalArgumentException> {
+                left.merge(right)
+            }
+        }
+    })

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesScopeTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesScopeTests.kt
@@ -1,0 +1,77 @@
+package io.github.lmliam.microsmith.dsl.services.core
+
+import io.github.lmliam.microsmith.dsl.core.MicrosmithBuilder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+private fun ServicesScope.fake(name: String, block: ServiceScope.() -> Unit = {}) {
+    name(block)
+}
+
+class ServicesScopeTests :
+    StringSpec({
+        "services block attaches ServicesExtension to builder" {
+            val builder = MicrosmithBuilder()
+
+            builder.services {
+                fake("UserService")
+            }
+
+            val ext = builder.model.get<ServicesExtension>()
+            ext shouldBe ServicesExtension(setOf(Service(name = "UserService", model = ServiceModel.empty())))
+        }
+
+        "services block can register multiple services" {
+            val builder = MicrosmithBuilder()
+
+            builder.services {
+                fake("UserService")
+                fake("OrderService")
+            }
+
+            val ext = builder.model.get<ServicesExtension>()
+            ext shouldBe
+                ServicesExtension(
+                    setOf(
+                        Service(name = "UserService", model = ServiceModel.empty()),
+                        Service(name = "OrderService", model = ServiceModel.empty()),
+                    ),
+                )
+        }
+
+        "multiple services blocks are merged" {
+            val builder = MicrosmithBuilder()
+
+            builder.services {
+                fake("UserService")
+            }
+
+            builder.services {
+                fake("OrderService")
+            }
+
+            val ext = builder.model.get<ServicesExtension>()
+            ext shouldBe
+                ServicesExtension(
+                    setOf(
+                        Service(name = "UserService", model = ServiceModel.empty()),
+                        Service(name = "OrderService", model = ServiceModel.empty()),
+                    ),
+                )
+        }
+
+        "multiple services blocks reject duplicate service keys" {
+            val builder = MicrosmithBuilder()
+
+            builder.services {
+                fake("UserService")
+            }
+
+            shouldThrow<IllegalArgumentException> {
+                builder.services {
+                    fake("UserService")
+                }
+            }
+        }
+    })

--- a/modules/gen-services/build.gradle
+++ b/modules/gen-services/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'org.jetbrains.kotlin.kapt'
+
+dependencies {
+    implementation project(":gen")
+    api project(":dsl")
+    implementation project(":dsl-services")
+    api libs.spi.tooling.annotations
+    kapt libs.spi.tooling.processor
+    api libs.coroutines.core
+}

--- a/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServiceEmitter.kt
+++ b/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServiceEmitter.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.microsmith.gen.services
+
+import com.github.eventhorizonlab.spi.ServiceContract
+import io.github.lmliam.microsmith.dsl.services.core.Service
+import io.github.lmliam.microsmith.dsl.services.core.ServiceExtension
+import io.github.lmliam.microsmith.gen.files.FileSpace
+import io.github.lmliam.microsmith.gen.files.GeneratedFile
+import kotlin.reflect.KClass
+
+@ServiceContract
+interface ServiceEmitter<T : ServiceExtension> {
+    val type: KClass<T>
+
+    suspend fun T.emit(service: Service, space: FileSpace): List<GeneratedFile>
+}

--- a/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServiceEmitterRegistry.kt
+++ b/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServiceEmitterRegistry.kt
@@ -1,0 +1,36 @@
+package io.github.lmliam.microsmith.gen.services
+
+import io.github.lmliam.microsmith.dsl.services.core.ServiceExtension
+import java.util.ServiceLoader
+import kotlin.reflect.KClass
+
+/**
+ * Resolves service emitters by concrete service extension class and rejects ambiguous registrations.
+ */
+internal class ServiceEmitterRegistry(
+    emitters: List<ServiceEmitter<*>> = loadServiceEmitters(),
+) {
+    private val emittersByType: Map<KClass<out ServiceExtension>, ServiceEmitter<*>> = indexEmitters(emitters)
+
+    fun resolve(extension: ServiceExtension): ServiceEmitter<ServiceExtension> = emittersByType[extension::class]
+        ?.cast()
+        ?: error("No emitter found for service extension type: ${extension::class}")
+
+    private fun indexEmitters(emitters: List<ServiceEmitter<*>>): Map<KClass<out ServiceExtension>, ServiceEmitter<*>> {
+        val duplicates = emitters.groupBy(ServiceEmitter<*>::type).filterValues { it.size > 1 }
+        require(duplicates.isEmpty()) {
+            val types = duplicates.keys.map(::formatType).sorted().joinToString(", ")
+            "Duplicate service emitters registered for extension types: $types"
+        }
+
+        return emitters.associateBy(ServiceEmitter<*>::type)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ServiceEmitter<*>.cast(): ServiceEmitter<ServiceExtension> = this as ServiceEmitter<ServiceExtension>
+
+    private fun formatType(type: KClass<out ServiceExtension>): String = type.qualifiedName ?: type.toString()
+}
+
+private fun loadServiceEmitters(): List<ServiceEmitter<*>> =
+    ServiceLoader.load(ServiceEmitter::class.java).iterator().asSequence().toList()

--- a/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServicesGenerationService.kt
+++ b/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServicesGenerationService.kt
@@ -1,0 +1,17 @@
+package io.github.lmliam.microsmith.gen.services
+
+import io.github.lmliam.microsmith.dsl.services.core.ServicesExtension
+import io.github.lmliam.microsmith.dsl.services.helpers.extensions
+import io.github.lmliam.microsmith.gen.files.FileSpace
+import io.github.lmliam.microsmith.gen.files.GeneratedFile
+
+internal class ServicesGenerationService(
+    private val emitterRegistry: ServiceEmitterRegistry = ServiceEmitterRegistry(),
+) {
+    suspend fun generate(extension: ServicesExtension, space: FileSpace): List<GeneratedFile> =
+        extension.services.flatMap { service ->
+            service.model.extensions().flatMap { serviceExtension ->
+                emitterRegistry.resolve(serviceExtension).run { serviceExtension.emit(service, space) }
+            }
+        }
+}

--- a/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServicesGenerator.kt
+++ b/modules/gen-services/src/main/kotlin/io/github/lmliam/microsmith/gen/services/ServicesGenerator.kt
@@ -1,0 +1,25 @@
+package io.github.lmliam.microsmith.gen.services
+
+import com.github.eventhorizonlab.spi.ServiceProvider
+import io.github.lmliam.microsmith.dsl.services.core.ServicesExtension
+import io.github.lmliam.microsmith.gen.core.ModelGenerator
+import io.github.lmliam.microsmith.gen.files.FileSpace
+import io.github.lmliam.microsmith.gen.files.GeneratedFile
+
+@ServiceProvider(ModelGenerator::class)
+class ServicesGenerator : ModelGenerator<ServicesExtension> {
+    private val generationService: ServicesGenerationService
+
+    constructor() {
+        generationService = ServicesGenerationService()
+    }
+
+    internal constructor(generationService: ServicesGenerationService) {
+        this.generationService = generationService
+    }
+
+    override val extension get() = ServicesExtension::class
+
+    override suspend fun ServicesExtension.generate(space: FileSpace): List<GeneratedFile> =
+        generationService.generate(this, space)
+}

--- a/modules/gen-services/src/test/kotlin/io/github/lmliam/microsmith/gen/services/ServiceEmitterRegistryTests.kt
+++ b/modules/gen-services/src/test/kotlin/io/github/lmliam/microsmith/gen/services/ServiceEmitterRegistryTests.kt
@@ -1,0 +1,29 @@
+package io.github.lmliam.microsmith.gen.services
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ServiceEmitterRegistryTests :
+    StringSpec({
+        "resolve returns emitter for matching service extension class" {
+            val emitter = TestServiceEmitter()
+            val registry = ServiceEmitterRegistry(listOf(emitter))
+
+            registry.resolve(TestServiceExtension()).type shouldBe TestServiceExtension::class
+        }
+
+        "resolve rejects duplicate emitters for the same service extension class" {
+            shouldThrow<IllegalArgumentException> {
+                ServiceEmitterRegistry(listOf(TestServiceEmitter(), DuplicateTestServiceEmitter()))
+            }
+        }
+
+        "resolve rejects missing emitter" {
+            val registry = ServiceEmitterRegistry(emptyList())
+
+            shouldThrow<IllegalStateException> {
+                registry.resolve(TestServiceExtension())
+            }
+        }
+    })

--- a/modules/gen-services/src/test/kotlin/io/github/lmliam/microsmith/gen/services/ServicesGenerationServiceTests.kt
+++ b/modules/gen-services/src/test/kotlin/io/github/lmliam/microsmith/gen/services/ServicesGenerationServiceTests.kt
@@ -1,0 +1,29 @@
+package io.github.lmliam.microsmith.gen.services
+
+import io.github.lmliam.microsmith.dsl.services.core.ServiceBuilder
+import io.github.lmliam.microsmith.dsl.services.core.ServicesExtension
+import io.github.lmliam.microsmith.gen.files.DirectorySpace
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import kotlin.io.path.Path
+
+class ServicesGenerationServiceTests :
+    StringSpec({
+        "generate emits files for service extensions" {
+            val emitter = TestServiceEmitter()
+            val service =
+                ServiceBuilder("UserService").apply {
+                    put(TestServiceExtension::class, TestServiceExtension("hello"))
+                }.build()
+            val extension = ServicesExtension(setOf(service))
+            val generationService = ServicesGenerationService(ServiceEmitterRegistry(listOf(emitter)))
+            val space = DirectorySpace.from(Files.createTempDirectory("microsmith-services-gen-"))
+
+            val generated = generationService.generate(extension, space)
+
+            generated.size shouldBe 1
+            generated.single().relativePath shouldBe Path("UserService.out")
+            generated.single().contents.size shouldBe 0
+        }
+    })

--- a/modules/gen-services/src/test/kotlin/io/github/lmliam/microsmith/gen/services/TestFixtures.kt
+++ b/modules/gen-services/src/test/kotlin/io/github/lmliam/microsmith/gen/services/TestFixtures.kt
@@ -1,0 +1,26 @@
+package io.github.lmliam.microsmith.gen.services
+
+import io.github.lmliam.microsmith.dsl.services.core.Service
+import io.github.lmliam.microsmith.dsl.services.core.ServiceExtension
+import io.github.lmliam.microsmith.gen.files.FileSpace
+import io.github.lmliam.microsmith.gen.files.GeneratedFile
+import kotlin.io.path.Path
+import kotlin.reflect.KClass
+
+internal class TestServiceEmitter : ServiceEmitter<TestServiceExtension> {
+    override val type: KClass<TestServiceExtension> = TestServiceExtension::class
+
+    override suspend fun TestServiceExtension.emit(service: Service, space: FileSpace): List<GeneratedFile> =
+        listOf(GeneratedFile(Path("${service.name}.out"), byteArrayOf()))
+}
+
+internal class DuplicateTestServiceEmitter : ServiceEmitter<TestServiceExtension> {
+    override val type: KClass<TestServiceExtension> = TestServiceExtension::class
+
+    override suspend fun TestServiceExtension.emit(service: Service, space: FileSpace): List<GeneratedFile> =
+        listOf(GeneratedFile(Path("duplicate.out"), byteArrayOf()))
+}
+
+internal data class TestServiceExtension(
+    val value: String = "test",
+) : ServiceExtension

--- a/settings.gradle
+++ b/settings.gradle
@@ -60,6 +60,7 @@ rootProject.name = 'microsmith'
 
 [
     'dsl',
+    'dsl-services',
     'dsl-schemas',
     'dsl-schemas-protobuf',
     'dsl-schemas-protobuf-rpc',

--- a/settings.gradle
+++ b/settings.gradle
@@ -65,6 +65,7 @@ rootProject.name = 'microsmith'
     'dsl-schemas-protobuf',
     'dsl-schemas-protobuf-rpc',
     'gen',
+    'gen-services',
     'gen-schemas',
     'gen-schemas-protobuf',
     'gen-schemas-protobuf-rpc',


### PR DESCRIPTION
Why
- Add the core service DSL and generation foundations needed for the microservice epic.
- Keep the service surface and generator surface modular so .NET and ASP.NET layers can build on them cleanly.

What Changed
- Added `dsl-services` with the top-level `services { ... }` DSL, named service blocks, immutable snapshots, and service-scoped extension attachment.
- Added `gen-services` with a service emitter SPI, registry, and generation service that dispatches service extensions to emitters.
- Wired the new modules into the Gradle build and kept the implementation aligned with the existing DSL/gen patterns in the repo.

Validation
- `./gradlew :dsl-services:check --rerun-tasks --no-build-cache`
- `./gradlew :gen-services:check --rerun-tasks --no-build-cache`
- `./gradlew build --rerun-tasks --no-build-cache`

Closes #125
