### PR TITLE
feat(output-routing): add run-level and resource-level output routing

### DIFF
--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/GeneratedFile.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/GeneratedFile.kt
@@ -2,7 +2,11 @@ package io.github.lmliam.microsmith.gen.files
 
 import java.nio.file.Path
 
-class GeneratedFile(val relativePath: Path, contents: ByteArray) {
+class GeneratedFile(
+    val relativePath: Path,
+    contents: ByteArray,
+    val outputRoot: Path = Path.of("."),
+) {
     private val bytes = contents.copyOf()
 
     val contents: ByteArray

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputPathResolver.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputPathResolver.kt
@@ -1,11 +1,28 @@
 package io.github.lmliam.microsmith.gen.helpers
 
+import io.github.lmliam.microsmith.gen.files.DirectorySpace
 import io.github.lmliam.microsmith.gen.files.FileSpace
+import io.github.lmliam.microsmith.gen.files.GeneratedFile
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
 
 internal object GeneratedOutputPathResolver {
+    fun resolve(space: FileSpace, output: GeneratedFile): Path {
+        val normalizedRoot = space.root.toAbsolutePath().normalize()
+        ensureOutputRootIsSafe(normalizedRoot)
+
+        val routedRoot = resolveRoot(normalizedRoot, output.outputRoot)
+        val routedSpace =
+            if (routedRoot == normalizedRoot) {
+                space
+            } else {
+                DirectorySpace.from(routedRoot)
+            }
+
+        return resolve(routedSpace, output.relativePath)
+    }
+
     fun resolve(space: FileSpace, relativePath: Path): Path {
         require(!relativePath.isAbsolute) {
             "Generated output path must be relative, but was '$relativePath'."
@@ -23,6 +40,25 @@ internal object GeneratedOutputPathResolver {
         requireNoSymlinkTraversal(normalizedRoot, normalizedRelativePath)
 
         return target
+    }
+
+    fun resolveRoot(root: Path, outputRoot: Path): Path {
+        require(!outputRoot.isAbsolute) {
+            "Generated output root must be relative, but was '$outputRoot'."
+        }
+
+        val normalizedRoot = root.toAbsolutePath().normalize()
+        ensureOutputRootIsSafe(normalizedRoot)
+        val normalizedOutputRoot = outputRoot.normalize()
+        val targetRoot = normalizedRoot.resolve(normalizedOutputRoot).normalize()
+
+        require(targetRoot.startsWith(normalizedRoot)) {
+            "Generated output root '$outputRoot' escapes output root '$normalizedRoot'."
+        }
+
+        requireNoSymlinkTraversal(normalizedRoot, normalizedOutputRoot)
+
+        return targetRoot
     }
 
     private fun ensureOutputRootIsSafe(root: Path) {

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputUniquenessValidator.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputUniquenessValidator.kt
@@ -1,17 +1,38 @@
 package io.github.lmliam.microsmith.gen.helpers
 
 import io.github.lmliam.microsmith.gen.files.GeneratedFile
+import java.nio.file.Path
 
 internal object GeneratedOutputUniquenessValidator {
-    fun requireUniqueRelativePaths(outputs: List<GeneratedFile>) {
+    fun requireUniqueOutputPaths(outputs: List<GeneratedFile>) {
         val duplicates =
             outputs
-                .groupBy { it.relativePath.normalize().toString() }
+                .groupBy { outputPathKey(it) }
                 .filterValues { it.size > 1 }
 
         require(duplicates.isEmpty()) {
             val details = duplicates.keys.sorted().joinToString(", ")
             "Duplicate output file paths detected: $details"
+        }
+    }
+
+    private fun outputPathKey(output: GeneratedFile): String {
+        requireValidOutputRoot(output.outputRoot)
+
+        return output.outputRoot.normalize()
+            .resolve(output.relativePath.normalize())
+            .normalize()
+            .toString()
+    }
+
+    private fun requireValidOutputRoot(outputRoot: Path) {
+        require(!outputRoot.isAbsolute) {
+            "Generated output root must be relative, but was '$outputRoot'."
+        }
+
+        val normalizedOutputRoot = outputRoot.normalize()
+        require(!normalizedOutputRoot.startsWith(Path.of(".."))) {
+            "Generated output root '$outputRoot' escapes the run output root."
         }
     }
 }

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputWriter.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputWriter.kt
@@ -13,7 +13,7 @@ internal class GeneratedOutputWriter(
     suspend fun write(outputs: List<GeneratedFile>, space: FileSpace) {
         withContext(ioDispatcher) {
             outputs.forEach { output ->
-                val target = GeneratedOutputPathResolver.resolve(space, output.relativePath)
+                val target = GeneratedOutputPathResolver.resolve(space, output)
                 target.parent?.let(Files::createDirectories)
                 Files.write(target, output.contents)
             }

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/MicrosmithGenerationRunner.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/MicrosmithGenerationRunner.kt
@@ -20,7 +20,7 @@ internal class MicrosmithGenerationRunner(
                 // Generators still receive the final destination so any output-root-aware generator
                 // continues to see the stable repository path while staging validates write safety.
                 val generated = generatorExecutionService.generate(model, finalDir)
-                outputUniquenessValidator.requireUniqueRelativePaths(generated)
+                outputUniquenessValidator.requireUniqueOutputPaths(generated)
                 outputWriter.write(generated, tempSpace)
                 generated
             }

--- a/modules/gen/src/test/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputPathResolverTests.kt
+++ b/modules/gen/src/test/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputPathResolverTests.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.microsmith.gen.helpers
 
 import io.github.lmliam.microsmith.gen.files.DirectorySpace
+import io.github.lmliam.microsmith.gen.files.GeneratedFile
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.paths.shouldBeAbsolute
@@ -21,6 +22,23 @@ class GeneratedOutputPathResolverTests :
             Files.exists(resolved) shouldBe false
         }
 
+        "resolve routes outputs into a nested output root" {
+            val root = Files.createTempDirectory("microsmith-paths-root-")
+            val space = DirectorySpace.from(root)
+            val output =
+                GeneratedFile(
+                    relativePath = Path("UserService.cs"),
+                    contents = byteArrayOf(),
+                    outputRoot = Path("services/UserService"),
+                )
+
+            val resolved = GeneratedOutputPathResolver.resolve(space, output)
+
+            resolved.shouldBeAbsolute()
+            resolved.startsWith(space.root.resolve("services/UserService")) shouldBe true
+            Files.exists(resolved) shouldBe false
+        }
+
         "resolve rejects absolute generated output paths" {
             val root = Files.createTempDirectory("microsmith-paths-root-")
             val space = DirectorySpace.from(root)
@@ -28,6 +46,21 @@ class GeneratedOutputPathResolverTests :
 
             shouldThrow<IllegalArgumentException> {
                 GeneratedOutputPathResolver.resolve(space, absolutePath)
+            }
+        }
+
+        "resolve rejects absolute routed output roots" {
+            val root = Files.createTempDirectory("microsmith-paths-root-")
+            val space = DirectorySpace.from(root)
+            val output =
+                GeneratedFile(
+                    relativePath = Path("UserService.cs"),
+                    contents = byteArrayOf(),
+                    outputRoot = root.resolve("services").toAbsolutePath(),
+                )
+
+            shouldThrow<IllegalArgumentException> {
+                GeneratedOutputPathResolver.resolve(space, output)
             }
         }
 
@@ -41,6 +74,21 @@ class GeneratedOutputPathResolverTests :
 
             shouldThrow<IllegalArgumentException> {
                 GeneratedOutputPathResolver.resolve(space, Path("safe/../../outside.proto"))
+            }
+        }
+
+        "resolve rejects routed output roots that traverse outside the root" {
+            val root = Files.createTempDirectory("microsmith-paths-root-")
+            val space = DirectorySpace.from(root)
+            val output =
+                GeneratedFile(
+                    relativePath = Path("UserService.cs"),
+                    contents = byteArrayOf(),
+                    outputRoot = Path("../services/UserService"),
+                )
+
+            shouldThrow<IllegalArgumentException> {
+                GeneratedOutputPathResolver.resolve(space, output)
             }
         }
 

--- a/modules/gen/src/test/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputUniquenessValidatorTests.kt
+++ b/modules/gen/src/test/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputUniquenessValidatorTests.kt
@@ -1,20 +1,73 @@
 package io.github.lmliam.microsmith.gen.helpers
 
-import io.github.lmliam.microsmith.gen.files.to
+import io.github.lmliam.microsmith.gen.files.GeneratedFile
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import kotlin.io.path.Path
 
 class GeneratedOutputUniquenessValidatorTests :
     StringSpec({
-        "requireUniqueRelativePaths rejects duplicate normalized output paths" {
+        "requireUniqueOutputPaths rejects absolute output roots" {
             shouldThrow<IllegalArgumentException> {
-                GeneratedOutputUniquenessValidator.requireUniqueRelativePaths(
+                GeneratedOutputUniquenessValidator.requireUniqueOutputPaths(
                     listOf(
-                        Path("proto/User.proto") to byteArrayOf(1),
-                        Path("proto/./User.proto") to byteArrayOf(2),
+                        GeneratedFile(
+                            relativePath = Path("User.proto"),
+                            contents = byteArrayOf(1),
+                            outputRoot = Path("/tmp/proto"),
+                        ),
                     ),
                 )
             }
+        }
+
+        "requireUniqueOutputPaths rejects output roots that traverse outside the root" {
+            shouldThrow<IllegalArgumentException> {
+                GeneratedOutputUniquenessValidator.requireUniqueOutputPaths(
+                    listOf(
+                        GeneratedFile(
+                            relativePath = Path("User.proto"),
+                            contents = byteArrayOf(1),
+                            outputRoot = Path("../proto"),
+                        ),
+                    ),
+                )
+            }
+        }
+
+        "requireUniqueOutputPaths rejects duplicate normalized output paths" {
+            shouldThrow<IllegalArgumentException> {
+                GeneratedOutputUniquenessValidator.requireUniqueOutputPaths(
+                    listOf(
+                        GeneratedFile(
+                            relativePath = Path("User.proto"),
+                            contents = byteArrayOf(1),
+                            outputRoot = Path("proto"),
+                        ),
+                        GeneratedFile(
+                            relativePath = Path("./User.proto"),
+                            contents = byteArrayOf(2),
+                            outputRoot = Path("proto"),
+                        ),
+                    ),
+                )
+            }
+        }
+
+        "requireUniqueOutputPaths allows the same relative file under distinct output roots" {
+            GeneratedOutputUniquenessValidator.requireUniqueOutputPaths(
+                listOf(
+                    GeneratedFile(
+                        relativePath = Path("User.proto"),
+                        contents = byteArrayOf(1),
+                        outputRoot = Path("proto"),
+                    ),
+                    GeneratedFile(
+                        relativePath = Path("User.proto"),
+                        contents = byteArrayOf(2),
+                        outputRoot = Path("services/UserService"),
+                    ),
+                ),
+            )
         }
     })

--- a/modules/gen/src/test/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputWriterTests.kt
+++ b/modules/gen/src/test/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputWriterTests.kt
@@ -11,18 +11,19 @@ import kotlin.io.path.writeText
 
 class GeneratedOutputWriterTests :
     StringSpec({
-        "write overwrites generated files inside an existing proto directory" {
+        "write overwrites generated files inside an existing routed output directory" {
             val workspaceRoot = Files.createTempDirectory("microsmith-generated-output-writer-")
             val outputRoot = workspaceRoot.resolve("repo-root")
-            val existingProtoFile = outputRoot.resolve("proto/UserCreated.proto")
+            val existingProtoFile = outputRoot.resolve("services/UserService/UserCreated.proto")
             Files.createDirectories(existingProtoFile.parent)
             existingProtoFile.writeText("stale")
 
             GeneratedOutputWriter().write(
                 outputs = listOf(
                     GeneratedFile(
-                        relativePath = Path("proto/UserCreated.proto"),
+                        relativePath = Path("UserCreated.proto"),
                         contents = "fresh".toByteArray(),
+                        outputRoot = Path("services/UserService"),
                     ),
                 ),
                 space = DirectorySpace.from(outputRoot),


### PR DESCRIPTION
## Why
- Microsmith needs a deterministic output-routing contract that can support heterogeneous artefacts without forcing everything into one flat directory.
- The run-level CLI output root remains the default, but generated outputs need their own routed destinations when a generator/resource requires it.

## What Changed
- Added output-routing metadata to `GeneratedFile` so generators can route individual outputs under a resource-specific root.
- Updated the output path resolver and writer to honor routed output roots while still preventing traversal outside the run root.
- Tightened the output uniqueness validator so collisions are detected on resolved output paths and invalid routed roots are rejected early.
- Added tests for routed output resolution, traversal rejection, collision handling, and routed overwrite behavior.

## Validation
- `./gradlew :gen:check --rerun-tasks --no-build-cache`
- `./gradlew :build-logic:test --rerun-tasks --no-build-cache`
- `./gradlew build --rerun-tasks --no-build-cache`

Closes #126