### PR TITLE
refactor(kotlin-style): remove redundant explicit types where Kotlin inference is obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ This keeps the layering explicit:
 - Prefer immutable data, `val`, and expression-oriented control flow by default.
 - Prefer guard clauses and early returns for preconditions, invalid state handling, and fast exits when they reduce nesting and make the main path easier to read.
 - Default to the narrowest visibility that keeps the API honest. Widen visibility only when a real caller or extension point requires it.
+- Omit explicit property types when an inherited contract already fixes the type or when the initializer is unambiguous and self-describing, such as `Foo::class`, a matching concrete constructor call, or a simple literal on an implementation override.
+- Keep explicit types when they define a public contract, prevent ambiguous inference, stabilize a non-obvious declaration, or materially improve readability.
 - Use `sealed interface`, `data object`, `value class`, exhaustive `when`, and null-safety where they make state and invariants clearer.
 - Use extension functions when they improve discoverability for a well-scoped domain operation and avoid creating utility dumping grounds.
 - Use infix functions only for DSL-facing APIs when readability is clearly better than the non-infix equivalent.

--- a/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcArtifactContributor.kt
+++ b/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcArtifactContributor.kt
@@ -4,11 +4,10 @@ import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
 import io.github.lmliam.microsmith.artifact.core.ArtifactContributor
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.rpc.ResolvedProtobufRpcSchemaModel
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactContributor::class)
 class ProtobufRpcArtifactContributor : ArtifactContributor<ResolvedProtobufRpcSchemaModel> {
-    override val resolvedType: KClass<ResolvedProtobufRpcSchemaModel> = ResolvedProtobufRpcSchemaModel::class
+    override val resolvedType = ResolvedProtobufRpcSchemaModel::class
 
     override fun contribute(model: ResolvedProtobufRpcSchemaModel): List<ArtifactContribution<*>> {
         return model.schemas.map { schema ->

--- a/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcServiceArtifactAssembler.kt
+++ b/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcServiceArtifactAssembler.kt
@@ -3,11 +3,10 @@ package io.github.lmliam.microsmith.artifact.schemas.protobuf.rpc
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactAssembler
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactAssembler::class)
 class ProtobufRpcServiceArtifactAssembler : ArtifactAssembler<ProtobufRpcServiceArtifact> {
-    override val artifactType: KClass<ProtobufRpcServiceArtifact> = ProtobufRpcServiceArtifact::class
+    override val artifactType = ProtobufRpcServiceArtifact::class
 
     override fun create(first: ArtifactContribution<ProtobufRpcServiceArtifact>): ProtobufRpcServiceArtifact {
         val contribution = requireContribution(first)

--- a/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcServiceArtifactId.kt
+++ b/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcServiceArtifactId.kt
@@ -1,13 +1,12 @@
 package io.github.lmliam.microsmith.artifact.schemas.protobuf.rpc
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
-import kotlin.reflect.KClass
 
 data class ProtobufRpcServiceArtifactId(
     val packageName: String?,
     val serviceName: String,
 ) : ArtifactId<ProtobufRpcServiceArtifact> {
-    override val artifactType: KClass<ProtobufRpcServiceArtifact> = ProtobufRpcServiceArtifact::class
+    override val artifactType = ProtobufRpcServiceArtifact::class
 
     val fullyQualifiedName: String = packageName?.let { "$it.$serviceName" } ?: serviceName
 }

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoFileArtifactAssembler.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoFileArtifactAssembler.kt
@@ -3,11 +3,10 @@ package io.github.lmliam.microsmith.artifact.schemas.protobuf
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactAssembler
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactAssembler::class)
 class ProtoFileArtifactAssembler : ArtifactAssembler<ProtoFileArtifact> {
-    override val artifactType: KClass<ProtoFileArtifact> = ProtoFileArtifact::class
+    override val artifactType = ProtoFileArtifact::class
 
     override fun create(first: ArtifactContribution<ProtoFileArtifact>): ProtoFileArtifact {
         val contribution = requireContribution(first)

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoFileArtifactId.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoFileArtifactId.kt
@@ -1,13 +1,12 @@
 package io.github.lmliam.microsmith.artifact.schemas.protobuf
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
-import kotlin.reflect.KClass
 
 data class ProtoFileArtifactId(
     val packageName: String?,
     val typeName: String,
 ) : ArtifactId<ProtoFileArtifact> {
-    override val artifactType: KClass<ProtoFileArtifact> = ProtoFileArtifact::class
+    override val artifactType = ProtoFileArtifact::class
 
     val fullyQualifiedName: String = packageName?.let { "$it.$typeName" } ?: typeName
 }

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtobufArtifactContributor.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtobufArtifactContributor.kt
@@ -5,13 +5,12 @@ import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
 import io.github.lmliam.microsmith.artifact.core.ArtifactContributor
 import io.github.lmliam.microsmith.artifact.schemas.protobuf.emission.ProtobufDeclarationHandlerRegistry
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.ResolvedProtobufSchemaModel
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactContributor::class)
 class ProtobufArtifactContributor : ArtifactContributor<ResolvedProtobufSchemaModel> {
     private val declarationHandlerRegistry = ProtobufDeclarationHandlerRegistry()
 
-    override val resolvedType: KClass<ResolvedProtobufSchemaModel> = ResolvedProtobufSchemaModel::class
+    override val resolvedType = ResolvedProtobufSchemaModel::class
 
     override fun contribute(model: ResolvedProtobufSchemaModel): List<ArtifactContribution<*>> {
         return model.schemas.map { resolvedSchema ->

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/EnumDeclarationHandler.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/EnumDeclarationHandler.kt
@@ -4,10 +4,9 @@ import io.github.lmliam.microsmith.artifact.schemas.protobuf.render.ProtobufDecl
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.ProtobufSchema
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.types.Enum
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.names.QualifiedSchemaName
-import kotlin.reflect.KClass
 
 internal object EnumDeclarationHandler : ProtobufDeclarationHandler<Enum> {
-    override val type: KClass<Enum> = Enum::class
+    override val type = Enum::class
 
     override fun validate(schema: ProtobufSchema, qualifiedName: QualifiedSchemaName) {
         require(qualifiedName.typeName == schema.schema.name) {

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/MessageDeclarationHandler.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/MessageDeclarationHandler.kt
@@ -5,10 +5,9 @@ import io.github.lmliam.microsmith.artifact.schemas.protobuf.render.ProtobufDecl
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.ProtobufSchema
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.types.Message
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.names.QualifiedSchemaName
-import kotlin.reflect.KClass
 
 internal object MessageDeclarationHandler : ProtobufDeclarationHandler<Message> {
-    override val type: KClass<Message> = Message::class
+    override val type = Message::class
 
     override fun validate(schema: ProtobufSchema, qualifiedName: QualifiedSchemaName) {
         require(qualifiedName.typeName == schema.schema.name) {

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufFieldNumbers.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufFieldNumbers.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.microsmith.artifact.schemas.protobuf.emission
 internal object ProtobufFieldNumbers {
     internal const val MIN_FIELD_NUMBER = 1
     internal const val MAX_FIELD_NUMBER = 536_870_911
-    internal val FORBIDDEN_RANGE: IntRange = 19_000..19_999
+    internal val FORBIDDEN_RANGE = 19_000..19_999
 
     internal fun requireValidFieldNumber(number: Int, label: String) {
         require(number in MIN_FIELD_NUMBER..MAX_FIELD_NUMBER) {

--- a/modules/artifact-schemas-protobuf/src/test/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufDeclarationHandlerRegistryTests.kt
+++ b/modules/artifact-schemas-protobuf/src/test/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufDeclarationHandlerRegistryTests.kt
@@ -7,7 +7,6 @@ import io.github.lmliam.microsmith.resolve.schemas.protobuf.names.QualifiedSchem
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import kotlin.reflect.KClass
 
 class ProtobufDeclarationHandlerRegistryTests :
     StringSpec({
@@ -34,7 +33,7 @@ private data class TestType(
 ) : Type
 
 private object TestDeclarationHandler : ProtobufDeclarationHandler<TestType> {
-    override val type: KClass<TestType> = TestType::class
+    override val type = TestType::class
 
     override fun validate(schema: ProtobufSchema, qualifiedName: QualifiedSchemaName) = Unit
 
@@ -42,7 +41,7 @@ private object TestDeclarationHandler : ProtobufDeclarationHandler<TestType> {
 }
 
 private object DuplicateTestDeclarationHandler : ProtobufDeclarationHandler<TestType> {
-    override val type: KClass<TestType> = TestType::class
+    override val type = TestType::class
 
     override fun validate(schema: ProtobufSchema, qualifiedName: QualifiedSchemaName) = Unit
 

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageArtifactContributor.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageArtifactContributor.kt
@@ -4,11 +4,10 @@ import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
 import io.github.lmliam.microsmith.artifact.core.ArtifactContributor
 import io.github.lmliam.microsmith.resolve.services.dotnet.packages.DotnetPackageWorkspace
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactContributor::class)
 class DotnetPackageArtifactContributor : ArtifactContributor<DotnetPackageWorkspace> {
-    override val resolvedType: KClass<DotnetPackageWorkspace> = DotnetPackageWorkspace::class
+    override val resolvedType = DotnetPackageWorkspace::class
 
     override fun contribute(model: DotnetPackageWorkspace): List<ArtifactContribution<*>> {
         val solutionContributions = model.solutionsByName.values.sortedBy { it.name }.map { solution ->

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReferencesArtifactAssembler.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReferencesArtifactAssembler.kt
@@ -3,11 +3,10 @@ package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactAssembler
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactAssembler::class)
 class DotnetPackageReferencesArtifactAssembler : ArtifactAssembler<DotnetPackageReferencesArtifact> {
-    override val artifactType: KClass<DotnetPackageReferencesArtifact> = DotnetPackageReferencesArtifact::class
+    override val artifactType = DotnetPackageReferencesArtifact::class
 
     override fun create(first: ArtifactContribution<DotnetPackageReferencesArtifact>): DotnetPackageReferencesArtifact {
         val contribution = requireContribution(first)

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReferencesArtifactId.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReferencesArtifactId.kt
@@ -1,10 +1,9 @@
 package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
-import kotlin.reflect.KClass
 
 data class DotnetPackageReferencesArtifactId(
     val serviceName: String,
 ) : ArtifactId<DotnetPackageReferencesArtifact> {
-    override val artifactType: KClass<DotnetPackageReferencesArtifact> = DotnetPackageReferencesArtifact::class
+    override val artifactType = DotnetPackageReferencesArtifact::class
 }

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersionsArtifactAssembler.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersionsArtifactAssembler.kt
@@ -3,11 +3,10 @@ package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactAssembler
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactAssembler::class)
 class DotnetPackageVersionsArtifactAssembler : ArtifactAssembler<DotnetPackageVersionsArtifact> {
-    override val artifactType: KClass<DotnetPackageVersionsArtifact> = DotnetPackageVersionsArtifact::class
+    override val artifactType = DotnetPackageVersionsArtifact::class
 
     override fun create(first: ArtifactContribution<DotnetPackageVersionsArtifact>): DotnetPackageVersionsArtifact {
         val contribution = requireContribution(first)

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersionsArtifactId.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersionsArtifactId.kt
@@ -1,10 +1,9 @@
 package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
-import kotlin.reflect.KClass
 
 data class DotnetPackageVersionsArtifactId(
     val solutionName: String,
 ) : ArtifactId<DotnetPackageVersionsArtifact> {
-    override val artifactType: KClass<DotnetPackageVersionsArtifact> = DotnetPackageVersionsArtifact::class
+    override val artifactType = DotnetPackageVersionsArtifact::class
 }

--- a/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildProjectArtifactAssembler.kt
+++ b/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildProjectArtifactAssembler.kt
@@ -3,11 +3,10 @@ package io.github.lmliam.microsmith.artifact.services.dotnet.msbuild
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactAssembler
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactAssembler::class)
 class MsBuildProjectArtifactAssembler : ArtifactAssembler<MsBuildProjectArtifact> {
-    override val artifactType: KClass<MsBuildProjectArtifact> = MsBuildProjectArtifact::class
+    override val artifactType = MsBuildProjectArtifact::class
 
     override fun create(first: ArtifactContribution<MsBuildProjectArtifact>): MsBuildProjectArtifact {
         val contribution = requireContribution(first)

--- a/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildProjectArtifactId.kt
+++ b/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildProjectArtifactId.kt
@@ -1,12 +1,11 @@
 package io.github.lmliam.microsmith.artifact.services.dotnet.msbuild
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
-import kotlin.reflect.KClass
 
 data class MsBuildProjectArtifactId(
     val solutionName: String,
     val projectName: String? = null,
     val kind: MsBuildProjectKind,
 ) : ArtifactId<MsBuildProjectArtifact> {
-    override val artifactType: KClass<MsBuildProjectArtifact> = MsBuildProjectArtifact::class
+    override val artifactType = MsBuildProjectArtifact::class
 }

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactAssembler.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactAssembler.kt
@@ -3,11 +3,10 @@ package io.github.lmliam.microsmith.artifact.files
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactAssembler
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactAssembler::class)
 class BinaryFileArtifactAssembler : ArtifactAssembler<BinaryFileArtifact> {
-    override val artifactType: KClass<BinaryFileArtifact> = BinaryFileArtifact::class
+    override val artifactType = BinaryFileArtifact::class
 
     override fun create(first: ArtifactContribution<BinaryFileArtifact>): BinaryFileArtifact {
         val contribution = requireContribution(first)

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactId.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactId.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.microsmith.artifact.files
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 import java.nio.file.Path
 
-private val defaultBinaryFileOutputRoot: Path = Path.of(".")
+private val defaultBinaryFileOutputRoot = Path.of(".")
 
 data class BinaryFileArtifactId(
     val relativePath: Path,

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactId.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactId.kt
@@ -2,7 +2,6 @@ package io.github.lmliam.microsmith.artifact.files
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 import java.nio.file.Path
-import kotlin.reflect.KClass
 
 private val defaultBinaryFileOutputRoot: Path = Path.of(".")
 
@@ -10,5 +9,5 @@ data class BinaryFileArtifactId(
     val relativePath: Path,
     val outputRoot: Path = defaultBinaryFileOutputRoot,
 ) : ArtifactId<BinaryFileArtifact> {
-    override val artifactType: KClass<BinaryFileArtifact> = BinaryFileArtifact::class
+    override val artifactType = BinaryFileArtifact::class
 }

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactAssembler.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactAssembler.kt
@@ -3,11 +3,10 @@ package io.github.lmliam.microsmith.artifact.files
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.core.ArtifactAssembler
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactAssembler::class)
 class TextFileArtifactAssembler : ArtifactAssembler<TextFileArtifact> {
-    override val artifactType: KClass<TextFileArtifact> = TextFileArtifact::class
+    override val artifactType = TextFileArtifact::class
 
     override fun create(first: ArtifactContribution<TextFileArtifact>): TextFileArtifact {
         val contribution = requireContribution(first)

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactId.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactId.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.microsmith.artifact.files
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 import java.nio.file.Path
 
-private val defaultTextFileOutputRoot: Path = Path.of(".")
+private val defaultTextFileOutputRoot = Path.of(".")
 
 data class TextFileArtifactId(
     val relativePath: Path,

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactId.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactId.kt
@@ -2,7 +2,6 @@ package io.github.lmliam.microsmith.artifact.files
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 import java.nio.file.Path
-import kotlin.reflect.KClass
 
 private val defaultTextFileOutputRoot: Path = Path.of(".")
 
@@ -10,5 +9,5 @@ data class TextFileArtifactId(
     val relativePath: Path,
     val outputRoot: Path = defaultTextFileOutputRoot,
 ) : ArtifactId<TextFileArtifact> {
-    override val artifactType: KClass<TextFileArtifact> = TextFileArtifact::class
+    override val artifactType = TextFileArtifact::class
 }

--- a/modules/artifact/src/test/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblyServiceTests.kt
+++ b/modules/artifact/src/test/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblyServiceTests.kt
@@ -9,7 +9,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import java.nio.file.Path
-import kotlin.reflect.KClass
 
 private data class AlphaResolved(
     val name: String,
@@ -20,7 +19,7 @@ private data class BetaResolved(
 ) : ResolvedModel
 
 private class AlphaContributor : ArtifactContributor<AlphaResolved> {
-    override val resolvedType: KClass<AlphaResolved> = AlphaResolved::class
+    override val resolvedType = AlphaResolved::class
 
     override fun contribute(model: AlphaResolved): List<ArtifactContribution<out Artifact>> {
         return listOf(
@@ -33,7 +32,7 @@ private class AlphaContributor : ArtifactContributor<AlphaResolved> {
 }
 
 private class BetaContributor : ArtifactContributor<BetaResolved> {
-    override val resolvedType: KClass<BetaResolved> = BetaResolved::class
+    override val resolvedType = BetaResolved::class
 
     override fun contribute(model: BetaResolved): List<ArtifactContribution<out Artifact>> {
         return listOf(

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/DotnetOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/DotnetOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object DotnetOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "dotnet"
-    override val displayName: String = ".NET"
-    override val sampleMessageName: String = "DotnetUserCreated"
-    override val recommendedOutputDirectory: String = "./Generated"
+    override val id = "dotnet"
+    override val displayName = ".NET"
+    override val sampleMessageName = "DotnetUserCreated"
+    override val recommendedOutputDirectory = "./Generated"
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/GenericOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/GenericOnboardingProfile.kt
@@ -1,9 +1,9 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object GenericOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "generic"
-    override val displayName: String = "Other"
-    override val sampleMessageName: String = "UserCreated"
-    override val recommendedOutputDirectory: String? = null
-    override val bootstrapTargetDescription: String = "repository"
+    override val id = "generic"
+    override val displayName = "Other"
+    override val sampleMessageName = "UserCreated"
+    override val recommendedOutputDirectory = null
+    override val bootstrapTargetDescription = "repository"
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/GoOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/GoOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object GoOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "go"
-    override val displayName: String = "Go"
-    override val sampleMessageName: String = "GoUserCreated"
-    override val recommendedOutputDirectory: String = "./internal/gen"
+    override val id = "go"
+    override val displayName = "Go"
+    override val sampleMessageName = "GoUserCreated"
+    override val recommendedOutputDirectory = "./internal/gen"
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/JavaOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/JavaOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object JavaOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "java"
-    override val displayName: String = "Java"
-    override val sampleMessageName: String = "JavaUserCreated"
-    override val recommendedOutputDirectory: String? = null
+    override val id = "java"
+    override val displayName = "Java"
+    override val sampleMessageName = "JavaUserCreated"
+    override val recommendedOutputDirectory = null
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/KotlinOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/KotlinOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object KotlinOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "kotlin"
-    override val displayName: String = "Kotlin"
-    override val sampleMessageName: String = "KotlinUserCreated"
-    override val recommendedOutputDirectory: String? = null
+    override val id = "kotlin"
+    override val displayName = "Kotlin"
+    override val sampleMessageName = "KotlinUserCreated"
+    override val recommendedOutputDirectory = null
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/NodeOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/NodeOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object NodeOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "node"
-    override val displayName: String = "Node"
-    override val sampleMessageName: String = "NodeUserCreated"
-    override val recommendedOutputDirectory: String? = null
+    override val id = "node"
+    override val displayName = "Node"
+    override val sampleMessageName = "NodeUserCreated"
+    override val recommendedOutputDirectory = null
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/PythonOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/PythonOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object PythonOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "python"
-    override val displayName: String = "Python"
-    override val sampleMessageName: String = "PythonUserCreated"
-    override val recommendedOutputDirectory: String? = null
+    override val id = "python"
+    override val displayName = "Python"
+    override val sampleMessageName = "PythonUserCreated"
+    override val recommendedOutputDirectory = null
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/RubyOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/RubyOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object RubyOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "ruby"
-    override val displayName: String = "Ruby"
-    override val sampleMessageName: String = "RubyUserCreated"
-    override val recommendedOutputDirectory: String? = null
+    override val id = "ruby"
+    override val displayName = "Ruby"
+    override val sampleMessageName = "RubyUserCreated"
+    override val recommendedOutputDirectory = null
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/RustOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/RustOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object RustOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "rust"
-    override val displayName: String = "Rust"
-    override val sampleMessageName: String = "RustUserCreated"
-    override val recommendedOutputDirectory: String? = null
+    override val id = "rust"
+    override val displayName = "Rust"
+    override val sampleMessageName = "RustUserCreated"
+    override val recommendedOutputDirectory = null
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/ScalaOnboardingProfile.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/ScalaOnboardingProfile.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.cli.init
 
 internal data object ScalaOnboardingProfile : OnboardingProfile {
-    override val id: OnboardingProfileId = "scala"
-    override val displayName: String = "Scala"
-    override val sampleMessageName: String = "ScalaUserCreated"
-    override val recommendedOutputDirectory: String? = null
+    override val id = "scala"
+    override val displayName = "Scala"
+    override val sampleMessageName = "ScalaUserCreated"
+    override val recommendedOutputDirectory = null
 }

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
@@ -639,7 +639,7 @@ class OnboardingProfileDetectorTests :
         }
     })
 
-private val UNUSED_PROJECT_ROOT: Path = Path.of(".")
+private val UNUSED_PROJECT_ROOT = Path.of(".")
 
 private fun supportsPosixPermissions(): Boolean =
     !runningOnWindows() && FileSystems.getDefault().supportedFileAttributeViews().contains("posix")

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileDetectorTests.kt
@@ -74,10 +74,10 @@ class OnboardingProfileDetectorTests :
         "uses the configured fallback profile when no markers match" {
             val customFallback =
                 object : OnboardingProfile {
-                    override val id: OnboardingProfileId = "custom-fallback"
-                    override val displayName: String = "Custom"
-                    override val sampleMessageName: String = "CustomUserCreated"
-                    override val recommendedOutputDirectory: String? = null
+                    override val id = "custom-fallback"
+                    override val displayName = "Custom"
+                    override val sampleMessageName = "CustomUserCreated"
+                    override val recommendedOutputDirectory = null
                 }
             val detector = OnboardingProfileDetector(matchers = emptyList(), fallbackProfile = customFallback)
 
@@ -92,10 +92,10 @@ class OnboardingProfileDetectorTests :
         "formatting uses selection reason rather than generic profile identity" {
             val customFallback =
                 object : OnboardingProfile {
-                    override val id: OnboardingProfileId = "custom-fallback"
-                    override val displayName: String = "Custom"
-                    override val sampleMessageName: String = "CustomUserCreated"
-                    override val recommendedOutputDirectory: String? = null
+                    override val id = "custom-fallback"
+                    override val displayName = "Custom"
+                    override val sampleMessageName = "CustomUserCreated"
+                    override val recommendedOutputDirectory = null
                 }
             val detector =
                 OnboardingProfileDetector(
@@ -122,17 +122,17 @@ class OnboardingProfileDetectorTests :
         "rejects conflicting profile definitions that reuse the same stable id" {
             val primaryProfile =
                 object : OnboardingProfile {
-                    override val id: OnboardingProfileId = "python"
-                    override val displayName: String = "Python"
-                    override val sampleMessageName: String = "PythonUserCreated"
-                    override val recommendedOutputDirectory: String? = "./generated"
+                    override val id = "python"
+                    override val displayName = "Python"
+                    override val sampleMessageName = "PythonUserCreated"
+                    override val recommendedOutputDirectory = "./generated"
                 }
             val conflictingProfile =
                 object : OnboardingProfile {
-                    override val id: OnboardingProfileId = "python"
-                    override val displayName: String = "Python Variant"
-                    override val sampleMessageName: String = "PythonVariantUserCreated"
-                    override val recommendedOutputDirectory: String? = "./generated"
+                    override val id = "python"
+                    override val displayName = "Python Variant"
+                    override val sampleMessageName = "PythonVariantUserCreated"
+                    override val recommendedOutputDirectory = "./generated"
                 }
 
             val error =
@@ -152,17 +152,17 @@ class OnboardingProfileDetectorTests :
         "rejects fallback profile definitions that reuse a matcher stable id" {
             val primaryProfile =
                 object : OnboardingProfile {
-                    override val id: OnboardingProfileId = "python"
-                    override val displayName: String = "Python"
-                    override val sampleMessageName: String = "PythonUserCreated"
-                    override val recommendedOutputDirectory: String? = "./generated"
+                    override val id = "python"
+                    override val displayName = "Python"
+                    override val sampleMessageName = "PythonUserCreated"
+                    override val recommendedOutputDirectory = "./generated"
                 }
             val conflictingFallback =
                 object : OnboardingProfile {
-                    override val id: OnboardingProfileId = "python"
-                    override val displayName: String = "Python Fallback"
-                    override val sampleMessageName: String = "PythonFallbackUserCreated"
-                    override val recommendedOutputDirectory: String? = "./generated"
+                    override val id = "python"
+                    override val displayName = "Python Fallback"
+                    override val sampleMessageName = "PythonFallbackUserCreated"
+                    override val recommendedOutputDirectory = "./generated"
                 }
 
             val error =

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/provider/CliProviderValidatorTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/provider/CliProviderValidatorTests.kt
@@ -20,7 +20,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import kotlin.reflect.KClass
 
 class CliProviderValidatorTests :
     StringSpec({
@@ -90,35 +89,35 @@ class CliProviderValidatorTests :
     })
 
 private class ProtobufResolverStub : DomainResolver<SchemasExtension, ResolvedProtobufSchemaModel> {
-    override val authoringType: KClass<SchemasExtension> = SchemasExtension::class
-    override val resolvedType: KClass<ResolvedProtobufSchemaModel> = ResolvedProtobufSchemaModel::class
+    override val authoringType = SchemasExtension::class
+    override val resolvedType = ResolvedProtobufSchemaModel::class
 
     override fun resolve(authoring: SchemasExtension): ResolvedProtobufSchemaModel =
         ResolvedProtobufSchemaModel(emptyList())
 }
 
 private class ProtobufRpcResolverStub : DomainResolver<SchemasExtension, ResolvedProtobufRpcSchemaModel> {
-    override val authoringType: KClass<SchemasExtension> = SchemasExtension::class
-    override val resolvedType: KClass<ResolvedProtobufRpcSchemaModel> = ResolvedProtobufRpcSchemaModel::class
+    override val authoringType = SchemasExtension::class
+    override val resolvedType = ResolvedProtobufRpcSchemaModel::class
 
     override fun resolve(authoring: SchemasExtension): ResolvedProtobufRpcSchemaModel =
         ResolvedProtobufRpcSchemaModel(emptyList())
 }
 
 private class ProtobufContributorStub : ArtifactContributor<ResolvedProtobufSchemaModel> {
-    override val resolvedType: KClass<ResolvedProtobufSchemaModel> = ResolvedProtobufSchemaModel::class
+    override val resolvedType = ResolvedProtobufSchemaModel::class
 
     override fun contribute(model: ResolvedProtobufSchemaModel): List<ArtifactContribution<*>> = emptyList()
 }
 
 private class ProtobufRpcContributorStub : ArtifactContributor<ResolvedProtobufRpcSchemaModel> {
-    override val resolvedType: KClass<ResolvedProtobufRpcSchemaModel> = ResolvedProtobufRpcSchemaModel::class
+    override val resolvedType = ResolvedProtobufRpcSchemaModel::class
 
     override fun contribute(model: ResolvedProtobufRpcSchemaModel): List<ArtifactContribution<*>> = emptyList()
 }
 
 private class ProtoFileAssemblerStub : ArtifactAssembler<ProtoFileArtifact> {
-    override val artifactType: KClass<ProtoFileArtifact> = ProtoFileArtifact::class
+    override val artifactType = ProtoFileArtifact::class
 
     override fun create(first: ArtifactContribution<ProtoFileArtifact>): ProtoFileArtifact {
         val contribution = first as ProtoFileContribution
@@ -137,7 +136,7 @@ private class ProtoFileAssemblerStub : ArtifactAssembler<ProtoFileArtifact> {
 }
 
 private class ProtobufRpcAssemblerStub : ArtifactAssembler<ProtobufRpcServiceArtifact> {
-    override val artifactType: KClass<ProtobufRpcServiceArtifact> = ProtobufRpcServiceArtifact::class
+    override val artifactType = ProtobufRpcServiceArtifact::class
 
     override fun create(first: ArtifactContribution<ProtobufRpcServiceArtifact>): ProtobufRpcServiceArtifact {
         error("Not used in provider validator tests.")
@@ -150,7 +149,7 @@ private class ProtobufRpcAssemblerStub : ArtifactAssembler<ProtobufRpcServiceArt
 }
 
 private class TextFileAssemblerStub : ArtifactAssembler<TextFileArtifact> {
-    override val artifactType: KClass<TextFileArtifact> = TextFileArtifact::class
+    override val artifactType = TextFileArtifact::class
 
     override fun create(first: ArtifactContribution<TextFileArtifact>): TextFileArtifact {
         val contribution = first as TextFileArtifactContribution
@@ -167,7 +166,7 @@ private class TextFileAssemblerStub : ArtifactAssembler<TextFileArtifact> {
 }
 
 private class ProtoFileCompilerStub : ArtifactCompiler<ProtoFileArtifact> {
-    override val artifactType: KClass<ProtoFileArtifact> = ProtoFileArtifact::class
+    override val artifactType = ProtoFileArtifact::class
 
     override fun compile(artifact: ProtoFileArtifact): List<ArtifactContribution<out Artifact>> {
         return emptyList()
@@ -175,7 +174,7 @@ private class ProtoFileCompilerStub : ArtifactCompiler<ProtoFileArtifact> {
 }
 
 private class ProtobufRpcCompilerStub : ArtifactCompiler<ProtobufRpcServiceArtifact> {
-    override val artifactType: KClass<ProtobufRpcServiceArtifact> = ProtobufRpcServiceArtifact::class
+    override val artifactType = ProtobufRpcServiceArtifact::class
 
     override fun compile(artifact: ProtobufRpcServiceArtifact): List<ArtifactContribution<out Artifact>> {
         return emptyList()
@@ -183,7 +182,7 @@ private class ProtobufRpcCompilerStub : ArtifactCompiler<ProtobufRpcServiceArtif
 }
 
 private class TextFileRendererStub : ArtifactRenderer<TextFileArtifact> {
-    override val artifactType: KClass<TextFileArtifact> = TextFileArtifact::class
+    override val artifactType = TextFileArtifact::class
 
     override fun render(artifact: TextFileArtifact): GeneratedFile = GeneratedFile(
         relativePath = artifact.id.relativePath,

--- a/modules/compile-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/rpc/ProtobufRpcServiceArtifactCompiler.kt
+++ b/modules/compile-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/rpc/ProtobufRpcServiceArtifactCompiler.kt
@@ -9,11 +9,10 @@ import io.github.lmliam.microsmith.artifact.schemas.protobuf.ProtoFileContributi
 import io.github.lmliam.microsmith.artifact.schemas.protobuf.rpc.ProtobufRpcServiceArtifact
 import io.github.lmliam.microsmith.compile.core.ArtifactCompiler
 import io.github.lmliam.microsmith.compile.schemas.core.SchemasArtifactCompiler
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactCompiler::class)
 class ProtobufRpcServiceArtifactCompiler : SchemasArtifactCompiler<ProtobufRpcServiceArtifact> {
-    override val artifactType: KClass<ProtobufRpcServiceArtifact> = ProtobufRpcServiceArtifact::class
+    override val artifactType = ProtobufRpcServiceArtifact::class
 
     override fun compile(artifact: ProtobufRpcServiceArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(

--- a/modules/compile-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/ProtoFileArtifactCompiler.kt
+++ b/modules/compile-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/ProtoFileArtifactCompiler.kt
@@ -10,11 +10,10 @@ import io.github.lmliam.microsmith.compile.core.ArtifactCompiler
 import io.github.lmliam.microsmith.compile.schemas.core.SchemasArtifactCompiler
 import io.github.lmliam.microsmith.compile.schemas.protobuf.render.ProtobufFileRenderer
 import java.nio.file.Path
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactCompiler::class)
 class ProtoFileArtifactCompiler : SchemasArtifactCompiler<ProtoFileArtifact> {
-    override val artifactType: KClass<ProtoFileArtifact> = ProtoFileArtifact::class
+    override val artifactType = ProtoFileArtifact::class
 
     override fun compile(artifact: ProtoFileArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(

--- a/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageReferencesArtifactCompiler.kt
+++ b/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageReferencesArtifactCompiler.kt
@@ -12,11 +12,10 @@ import io.github.lmliam.microsmith.artifact.services.dotnet.packages.DotnetPacka
 import io.github.lmliam.microsmith.artifact.services.dotnet.packages.DotnetPackageReferencesArtifact
 import io.github.lmliam.microsmith.compile.core.ArtifactCompiler
 import io.github.lmliam.microsmith.compile.services.core.ServicesArtifactCompiler
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactCompiler::class)
 class DotnetPackageReferencesArtifactCompiler : ServicesArtifactCompiler<DotnetPackageReferencesArtifact> {
-    override val artifactType: KClass<DotnetPackageReferencesArtifact> = DotnetPackageReferencesArtifact::class
+    override val artifactType = DotnetPackageReferencesArtifact::class
 
     override fun compile(artifact: DotnetPackageReferencesArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(

--- a/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageVersionsArtifactCompiler.kt
+++ b/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageVersionsArtifactCompiler.kt
@@ -12,11 +12,10 @@ import io.github.lmliam.microsmith.artifact.services.dotnet.packages.DotnetPacka
 import io.github.lmliam.microsmith.artifact.services.dotnet.packages.DotnetPackageVersionsArtifact
 import io.github.lmliam.microsmith.compile.core.ArtifactCompiler
 import io.github.lmliam.microsmith.compile.services.core.ServicesArtifactCompiler
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactCompiler::class)
 class DotnetPackageVersionsArtifactCompiler : ServicesArtifactCompiler<DotnetPackageVersionsArtifact> {
-    override val artifactType: KClass<DotnetPackageVersionsArtifact> = DotnetPackageVersionsArtifact::class
+    override val artifactType = DotnetPackageVersionsArtifact::class
 
     override fun compile(artifact: DotnetPackageVersionsArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(

--- a/modules/compile-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/msbuild/MsBuildProjectArtifactCompiler.kt
+++ b/modules/compile-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/msbuild/MsBuildProjectArtifactCompiler.kt
@@ -10,11 +10,10 @@ import io.github.lmliam.microsmith.artifact.services.dotnet.msbuild.MsBuildProje
 import io.github.lmliam.microsmith.compile.core.ArtifactCompiler
 import io.github.lmliam.microsmith.compile.services.core.ServicesArtifactCompiler
 import java.nio.file.Path
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactCompiler::class)
 class MsBuildProjectArtifactCompiler : ServicesArtifactCompiler<MsBuildProjectArtifact> {
-    override val artifactType: KClass<MsBuildProjectArtifact> = MsBuildProjectArtifact::class
+    override val artifactType = MsBuildProjectArtifact::class
 
     override fun compile(artifact: MsBuildProjectArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(

--- a/modules/compile/src/main/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilerRegistry.kt
+++ b/modules/compile/src/main/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilerRegistry.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KClass
 internal class ArtifactCompilerRegistry(
     compilers: List<ArtifactCompiler<*>> = loadArtifactCompilers(),
 ) {
-    private val compilersByType: Map<KClass<out Artifact>, ArtifactCompiler<*>> = indexCompilers(compilers)
+    private val compilersByType = indexCompilers(compilers)
 
     fun resolveOrNull(artifact: Artifact): ArtifactCompiler<Artifact>? =
         compilersByType[artifact.id.artifactType]?.cast()

--- a/modules/compile/src/test/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilationServiceTests.kt
+++ b/modules/compile/src/test/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilationServiceTests.kt
@@ -13,7 +13,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import java.nio.file.Path
-import kotlin.reflect.KClass
 
 class ArtifactCompilationServiceTests :
     StringSpec({
@@ -76,7 +75,7 @@ private data class StageOneArtifact(
 private data class StageOneId(
     val name: String,
 ) : ArtifactId<StageOneArtifact> {
-    override val artifactType: KClass<StageOneArtifact> = StageOneArtifact::class
+    override val artifactType = StageOneArtifact::class
 }
 
 private data class StageOneContribution(
@@ -85,7 +84,7 @@ private data class StageOneContribution(
 ) : ArtifactContribution<StageOneArtifact>
 
 private class StageOneArtifactAssembler : ArtifactAssembler<StageOneArtifact> {
-    override val artifactType: KClass<StageOneArtifact> = StageOneArtifact::class
+    override val artifactType = StageOneArtifact::class
 
     override fun create(first: ArtifactContribution<StageOneArtifact>): StageOneArtifact =
         StageOneArtifact(requireContribution(first).artifactId, requireContribution(first).contents)
@@ -113,7 +112,7 @@ private data class StageTwoArtifact(
 private data class StageTwoId(
     val name: String,
 ) : ArtifactId<StageTwoArtifact> {
-    override val artifactType: KClass<StageTwoArtifact> = StageTwoArtifact::class
+    override val artifactType = StageTwoArtifact::class
 }
 
 private data class StageTwoContribution(
@@ -122,7 +121,7 @@ private data class StageTwoContribution(
 ) : ArtifactContribution<StageTwoArtifact>
 
 private class StageTwoArtifactAssembler : ArtifactAssembler<StageTwoArtifact> {
-    override val artifactType: KClass<StageTwoArtifact> = StageTwoArtifact::class
+    override val artifactType = StageTwoArtifact::class
 
     override fun create(first: ArtifactContribution<StageTwoArtifact>): StageTwoArtifact =
         StageTwoArtifact(requireContribution(first).artifactId, requireContribution(first).contents)
@@ -143,7 +142,7 @@ private class StageTwoArtifactAssembler : ArtifactAssembler<StageTwoArtifact> {
 }
 
 private class StageOneCompiler : ArtifactCompiler<StageOneArtifact> {
-    override val artifactType: KClass<StageOneArtifact> = StageOneArtifact::class
+    override val artifactType = StageOneArtifact::class
 
     override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(StageTwoContribution(StageTwoId("middle"), artifact.contents))
@@ -151,7 +150,7 @@ private class StageOneCompiler : ArtifactCompiler<StageOneArtifact> {
 }
 
 private class StageTwoCompiler : ArtifactCompiler<StageTwoArtifact> {
-    override val artifactType: KClass<StageTwoArtifact> = StageTwoArtifact::class
+    override val artifactType = StageTwoArtifact::class
 
     override fun compile(artifact: StageTwoArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(TextFileArtifactContribution(TextFileArtifactId(Path.of("result.txt")), artifact.contents))
@@ -159,7 +158,7 @@ private class StageTwoCompiler : ArtifactCompiler<StageTwoArtifact> {
 }
 
 private class SelfCyclingCompiler : ArtifactCompiler<StageOneArtifact> {
-    override val artifactType: KClass<StageOneArtifact> = StageOneArtifact::class
+    override val artifactType = StageOneArtifact::class
 
     override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(StageOneContribution(StageOneId("cycle"), artifact.contents))
@@ -167,7 +166,7 @@ private class SelfCyclingCompiler : ArtifactCompiler<StageOneArtifact> {
 }
 
 private class StageOneToStageTwoCompiler : ArtifactCompiler<StageOneArtifact> {
-    override val artifactType: KClass<StageOneArtifact> = StageOneArtifact::class
+    override val artifactType = StageOneArtifact::class
 
     override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(StageTwoContribution(StageTwoId(artifact.id.name), artifact.contents))
@@ -175,7 +174,7 @@ private class StageOneToStageTwoCompiler : ArtifactCompiler<StageOneArtifact> {
 }
 
 private class StageTwoToStageOneCompiler : ArtifactCompiler<StageTwoArtifact> {
-    override val artifactType: KClass<StageTwoArtifact> = StageTwoArtifact::class
+    override val artifactType = StageTwoArtifact::class
 
     override fun compile(artifact: StageTwoArtifact): List<ArtifactContribution<out Artifact>> {
         return listOf(StageOneContribution(StageOneId(artifact.id.name), artifact.contents))

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/core/ArtifactRendererRegistry.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/core/ArtifactRendererRegistry.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KClass
 class ArtifactRendererRegistry(
     renderers: List<ArtifactRenderer<*>> = loadArtifactRenderers(),
 ) {
-    private val renderersByType: Map<KClass<out Artifact>, ArtifactRenderer<*>> = indexRenderers(renderers)
+    private val renderersByType = indexRenderers(renderers)
 
     fun resolve(artifact: Artifact): ArtifactRenderer<Artifact> {
         return renderersByType[artifact.id.artifactType]

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/BinaryFileArtifactRenderer.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/BinaryFileArtifactRenderer.kt
@@ -4,11 +4,10 @@ import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.artifact.files.BinaryFileArtifact
 import io.github.lmliam.microsmith.gen.core.ArtifactRenderer
 import io.github.lmliam.microsmith.gen.files.GeneratedFile
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactRenderer::class)
 class BinaryFileArtifactRenderer : ArtifactRenderer<BinaryFileArtifact> {
-    override val artifactType: KClass<BinaryFileArtifact> = BinaryFileArtifact::class
+    override val artifactType = BinaryFileArtifact::class
 
     override fun render(artifact: BinaryFileArtifact): GeneratedFile {
         return GeneratedFile(

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/TextFileArtifactRenderer.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/TextFileArtifactRenderer.kt
@@ -5,11 +5,10 @@ import io.github.lmliam.microsmith.artifact.files.TextFileArtifact
 import io.github.lmliam.microsmith.gen.core.ArtifactRenderer
 import io.github.lmliam.microsmith.gen.files.GeneratedFile
 import java.nio.charset.StandardCharsets
-import kotlin.reflect.KClass
 
 @ServiceProvider(ArtifactRenderer::class)
 class TextFileArtifactRenderer : ArtifactRenderer<TextFileArtifact> {
-    override val artifactType: KClass<TextFileArtifact> = TextFileArtifact::class
+    override val artifactType = TextFileArtifact::class
 
     override fun render(artifact: TextFileArtifact): GeneratedFile {
         val renderedContents = GeneratedByMicrosmithBanner.prepend(artifact.id.relativePath, artifact.contents)

--- a/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ProtobufRpcSchemasResolver.kt
+++ b/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ProtobufRpcSchemasResolver.kt
@@ -10,12 +10,11 @@ import io.github.lmliam.microsmith.dsl.schemas.protobuf.types.Message
 import io.github.lmliam.microsmith.resolve.core.DomainResolver
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.names.ProtobufNameValidation
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.names.QualifiedSchemaName
-import kotlin.reflect.KClass
 
 @ServiceProvider(DomainResolver::class)
 class ProtobufRpcSchemasResolver : DomainResolver<SchemasExtension, ResolvedProtobufRpcSchemaModel> {
-    override val authoringType: KClass<SchemasExtension> = SchemasExtension::class
-    override val resolvedType: KClass<ResolvedProtobufRpcSchemaModel> = ResolvedProtobufRpcSchemaModel::class
+    override val authoringType = SchemasExtension::class
+    override val resolvedType = ResolvedProtobufRpcSchemaModel::class
 
     override fun resolve(authoring: SchemasExtension): ResolvedProtobufRpcSchemaModel? {
         val schemas =

--- a/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/ProtobufSchemasResolver.kt
+++ b/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/ProtobufSchemasResolver.kt
@@ -7,12 +7,11 @@ import io.github.lmliam.microsmith.dsl.schemas.protobuf.types.Enum
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.types.Message
 import io.github.lmliam.microsmith.resolve.core.DomainResolver
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.names.QualifiedSchemaName
-import kotlin.reflect.KClass
 
 @ServiceProvider(DomainResolver::class)
 class ProtobufSchemasResolver : DomainResolver<SchemasExtension, ResolvedProtobufSchemaModel> {
-    override val authoringType: KClass<SchemasExtension> = SchemasExtension::class
-    override val resolvedType: KClass<ResolvedProtobufSchemaModel> = ResolvedProtobufSchemaModel::class
+    override val authoringType = SchemasExtension::class
+    override val resolvedType = ResolvedProtobufSchemaModel::class
 
     override fun resolve(authoring: SchemasExtension): ResolvedProtobufSchemaModel? {
         val schemas =

--- a/modules/resolve-schemas/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/core/SchemasResolver.kt
+++ b/modules/resolve-schemas/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/core/SchemasResolver.kt
@@ -3,12 +3,11 @@ package io.github.lmliam.microsmith.resolve.schemas.core
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.dsl.schemas.core.SchemasExtension
 import io.github.lmliam.microsmith.resolve.core.DomainResolver
-import kotlin.reflect.KClass
 
 @ServiceProvider(DomainResolver::class)
 class SchemasResolver : DomainResolver<SchemasExtension, ResolvedSchemasModel> {
-    override val authoringType: KClass<SchemasExtension> = SchemasExtension::class
-    override val resolvedType: KClass<ResolvedSchemasModel> = ResolvedSchemasModel::class
+    override val authoringType = SchemasExtension::class
+    override val resolvedType = ResolvedSchemasModel::class
 
     override fun resolve(authoring: SchemasExtension): ResolvedSchemasModel = ResolvedSchemasModel(authoring.schemas)
 }

--- a/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/DotnetPackageWorkspaceDomainResolver.kt
+++ b/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/DotnetPackageWorkspaceDomainResolver.kt
@@ -3,14 +3,13 @@ package io.github.lmliam.microsmith.resolve.services.dotnet.packages
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.dsl.services.core.ServicesExtension
 import io.github.lmliam.microsmith.resolve.core.DomainResolver
-import kotlin.reflect.KClass
 
 @ServiceProvider(DomainResolver::class)
 class DotnetPackageWorkspaceDomainResolver(
     private val workspaceResolver: DotnetPackageWorkspaceResolver = DotnetPackageWorkspaceResolver(),
 ) : DomainResolver<ServicesExtension, DotnetPackageWorkspace> {
-    override val authoringType: KClass<ServicesExtension> = ServicesExtension::class
-    override val resolvedType: KClass<DotnetPackageWorkspace> = DotnetPackageWorkspace::class
+    override val authoringType = ServicesExtension::class
+    override val resolvedType = DotnetPackageWorkspace::class
 
     override fun resolve(authoring: ServicesExtension): DotnetPackageWorkspace? {
         val workspace = workspaceResolver.resolve(authoring)

--- a/modules/resolve-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/DotnetWorkspaceDomainResolver.kt
+++ b/modules/resolve-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/DotnetWorkspaceDomainResolver.kt
@@ -3,14 +3,13 @@ package io.github.lmliam.microsmith.resolve.services.dotnet
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.dsl.services.core.ServicesExtension
 import io.github.lmliam.microsmith.resolve.core.DomainResolver
-import kotlin.reflect.KClass
 
 @ServiceProvider(DomainResolver::class)
 class DotnetWorkspaceDomainResolver(
     private val workspaceResolver: DotnetWorkspaceResolver = DotnetWorkspaceResolver(),
 ) : DomainResolver<ServicesExtension, DotnetWorkspace> {
-    override val authoringType: KClass<ServicesExtension> = ServicesExtension::class
-    override val resolvedType: KClass<DotnetWorkspace> = DotnetWorkspace::class
+    override val authoringType = ServicesExtension::class
+    override val resolvedType = DotnetWorkspace::class
 
     override fun resolve(authoring: ServicesExtension): DotnetWorkspace? {
         val workspace = workspaceResolver.resolve(authoring)

--- a/modules/resolve-services/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/core/ServicesResolver.kt
+++ b/modules/resolve-services/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/core/ServicesResolver.kt
@@ -3,12 +3,11 @@ package io.github.lmliam.microsmith.resolve.services.core
 import com.github.eventhorizonlab.spi.ServiceProvider
 import io.github.lmliam.microsmith.dsl.services.core.ServicesExtension
 import io.github.lmliam.microsmith.resolve.core.DomainResolver
-import kotlin.reflect.KClass
 
 @ServiceProvider(DomainResolver::class)
 class ServicesResolver : DomainResolver<ServicesExtension, ResolvedServicesModel> {
-    override val authoringType: KClass<ServicesExtension> = ServicesExtension::class
-    override val resolvedType: KClass<ResolvedServicesModel> = ResolvedServicesModel::class
+    override val authoringType = ServicesExtension::class
+    override val resolvedType = ResolvedServicesModel::class
 
     override fun resolve(authoring: ServicesExtension): ResolvedServicesModel {
         return ResolvedServicesModel(authoring.services)

--- a/modules/resolve/src/test/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolutionServiceTests.kt
+++ b/modules/resolve/src/test/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolutionServiceTests.kt
@@ -5,7 +5,6 @@ import io.github.lmliam.microsmith.dsl.core.MicrosmithExtension
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import kotlin.reflect.KClass
 
 private data object AlphaExtension : MicrosmithExtension
 
@@ -20,22 +19,22 @@ private data class BetaResolvedModel(
 ) : ResolvedModel
 
 private class AlphaFirstResolver : DomainResolver<AlphaExtension, AlphaResolvedModel> {
-    override val authoringType: KClass<AlphaExtension> = AlphaExtension::class
-    override val resolvedType: KClass<AlphaResolvedModel> = AlphaResolvedModel::class
+    override val authoringType = AlphaExtension::class
+    override val resolvedType = AlphaResolvedModel::class
 
     override fun resolve(authoring: AlphaExtension) = AlphaResolvedModel("alpha")
 }
 
 private class AlphaNullResolver : DomainResolver<AlphaExtension, BetaResolvedModel> {
-    override val authoringType: KClass<AlphaExtension> = AlphaExtension::class
-    override val resolvedType: KClass<BetaResolvedModel> = BetaResolvedModel::class
+    override val authoringType = AlphaExtension::class
+    override val resolvedType = BetaResolvedModel::class
 
     override fun resolve(authoring: AlphaExtension): BetaResolvedModel? = null
 }
 
 private class BetaResolver : DomainResolver<BetaExtension, BetaResolvedModel> {
-    override val authoringType: KClass<BetaExtension> = BetaExtension::class
-    override val resolvedType: KClass<BetaResolvedModel> = BetaResolvedModel::class
+    override val authoringType = BetaExtension::class
+    override val resolvedType = BetaResolvedModel::class
 
     override fun resolve(authoring: BetaExtension) = BetaResolvedModel("beta")
 }


### PR DESCRIPTION
## Why
- Issue #140 calls for a repository-level Kotlin rule for when obvious explicit property types should be omitted versus retained.
- Microsmith had repeated low-value declarations such as `KClass<...> = ...::class` and implementation overrides whose inherited contract plus initializer already made the type obvious.
- The cleanup needed a documented boundary so future reviews can keep removing noise without erasing explicit types that still carry contract or readability value.

## What Changed
- documented the repository rule in `README.md`, including when to omit obvious implementation property types and when to keep explicit types for public contracts, ambiguity, or readability
- removed redundant explicit `KClass<...>` property types from obvious resolver, artifact, compiler, renderer, and handler implementations where the `...::class` initializer already states the type
- removed redundant explicit types from onboarding profile implementation overrides where the interface contract and simple literal initializer already fix the property type
- applied the same rule to low-risk test doubles and registry fixtures so the style is consistent across production and test code
- kept constructor-parameter properties and other contract-bearing declarations explicit, so the cleanup stays within Kotlin’s actual inference boundary instead of turning into mechanical churn

## Validation
- `./gradlew build --no-build-cache`

Closes #140
