### PR TITLE
refactor(cleanup): sweep declaration cleanup and shared helper duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1396,18 +1396,18 @@ microsmith run schema.microsmith.kts --plugin com.acme:private-emitter:1.2.3
 
 ### Environment variables
 
-| Variable                                 | Purpose                                                               |
-|------------------------------------------|-----------------------------------------------------------------------|
-| `MICROSMITH_REPOSITORY_ALLOWLIST`        | Comma-separated additional allowed repository base URIs.              |
-| `MICROSMITH_ALLOW_FILE_REPOSITORIES`     | Set to `true` to allow `file://` repositories for plugin coordinates. |
-| `MICROSMITH_REPOSITORY_CREDENTIALS_FILE` | Path to a repository credentials file.                                |
-| `MICROSMITH_REPOSITORY_USERNAME`         | Default username for authenticated repository access.                 |
-| `MICROSMITH_REPOSITORY_PASSWORD`         | Default password or token for authenticated repository access.        |
-| `MICROSMITH_GITHUB_PACKAGES_USER`        | Username for GitHub Packages repository access.                       |
-| `MICROSMITH_GITHUB_PACKAGES_TOKEN`       | Token for GitHub Packages repository access.                          |
+| Variable                                 | Purpose                                                                                                               |
+|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| `MICROSMITH_REPOSITORY_ALLOWLIST`        | Comma-separated additional allowed repository base URIs.                                                              |
+| `MICROSMITH_ALLOW_FILE_REPOSITORIES`     | Set to `true` to allow `file://` repositories for plugin coordinates.                                                 |
+| `MICROSMITH_REPOSITORY_CREDENTIALS_FILE` | Path to a repository credentials file.                                                                                |
+| `MICROSMITH_REPOSITORY_USERNAME`         | Default username for authenticated repository access.                                                                 |
+| `MICROSMITH_REPOSITORY_PASSWORD`         | Default password or token for authenticated repository access.                                                        |
+| `MICROSMITH_GITHUB_PACKAGES_USER`        | Username for GitHub Packages repository access.                                                                       |
+| `MICROSMITH_GITHUB_PACKAGES_TOKEN`       | Token for GitHub Packages repository access.                                                                          |
 | `MICROSMITH_PLUGIN_ALLOWLIST_FILE`       | Path to checksum allowlist file entries in the form `<code>&lt;kind&gt;&#124;&lt;key&gt;&#124;&lt;sha256&gt;</code>`. |
-| `MICROSMITH_SCRIPT_CACHE_DIR`            | Override the script compilation cache directory.                      |
-| `MICROSMITH_PLUGIN_CACHE_DIR`            | Override the plugin resolution cache directory.                       |
+| `MICROSMITH_SCRIPT_CACHE_DIR`            | Override the script compilation cache directory.                                                                      |
+| `MICROSMITH_PLUGIN_CACHE_DIR`            | Override the plugin resolution cache directory.                                                                       |
 
 ## CI examples
 
@@ -1559,41 +1559,41 @@ jobs:
 The repository includes fixture repositories under `examples/non-gradle/`, `examples/jvm/`, `examples/gradle/`, and `examples/maven/`.
 CLI-managed fixtures exercise `microsmith init` and direct `microsmith run` flows. Native Gradle fixtures exercise `./gradlew microsmithGenerate`. Native Maven fixtures exercise `mvn microsmith:generate`. Native sbt fixtures exercise `sbt microsmithGenerate`.
 
-| Fixture | Directory                    | Local command from fixture root                                                   | CI workflow                                                   |
-|---------|------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
-| Java (native Gradle)   | `examples/gradle/java`      | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                      | `examples/gradle/java/.github/workflows/microsmith.yml`       |
-| Kotlin (native Gradle) | `examples/gradle/kotlin`   | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                      | `examples/gradle/kotlin/.github/workflows/microsmith.yml`     |
-| Scala (native Gradle)  | `examples/gradle/scala`    | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                      | `examples/gradle/scala/.github/workflows/microsmith.yml`      |
-| Java (native Maven)    | `examples/maven/java`      | `mvn microsmith:generate -Dmicrosmith.version=<version>`                          | `examples/maven/java/.github/workflows/microsmith.yml`        |
-| Kotlin (native Maven)  | `examples/maven/kotlin`    | `mvn microsmith:generate -Dmicrosmith.version=<version>`                          | `examples/maven/kotlin/.github/workflows/microsmith.yml`      |
-| Scala (native Maven)   | `examples/maven/scala`     | `mvn microsmith:generate -Dmicrosmith.version=<version>`                          | `examples/maven/scala/.github/workflows/microsmith.yml`       |
-| Scala (native sbt)     | `examples/sbt/scala`       | `sbt -Dmicrosmith.version=<version> microsmithGenerate`                           | `examples/sbt/scala/.github/workflows/microsmith.yml`         |
-| Java    | `examples/jvm/java-maven`    | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/jvm/java-maven/.github/workflows/microsmith.yml`    |
-| Kotlin  | `examples/jvm/kotlin-gradle` | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/jvm/kotlin-gradle/.github/workflows/microsmith.yml` |
-| Scala   | `examples/jvm/scala-sbt`     | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/jvm/scala-sbt/.github/workflows/microsmith.yml`     |
-| Node    | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
-| Go      | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
-| Python  | `examples/non-gradle/python` | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/non-gradle/python/.github/workflows/microsmith.yml` |
-| Ruby    | `examples/non-gradle/ruby`   | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/non-gradle/ruby/.github/workflows/microsmith.yml`   |
-| Rust    | `examples/non-gradle/rust`   | `microsmith init` then `microsmith run build.microsmith.kts`    | `examples/non-gradle/rust/.github/workflows/microsmith.yml`   |
-| .NET    | `examples/non-gradle/dotnet` | `microsmith init` then `microsmith run build.microsmith.kts --out .\Generated`    | `examples/non-gradle/dotnet/.github/workflows/microsmith.yml` |
+| Fixture                | Directory                    | Local command from fixture root                                                | CI workflow                                                   |
+|------------------------|------------------------------|--------------------------------------------------------------------------------|---------------------------------------------------------------|
+| Java (native Gradle)   | `examples/gradle/java`       | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                   | `examples/gradle/java/.github/workflows/microsmith.yml`       |
+| Kotlin (native Gradle) | `examples/gradle/kotlin`     | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                   | `examples/gradle/kotlin/.github/workflows/microsmith.yml`     |
+| Scala (native Gradle)  | `examples/gradle/scala`      | `./gradlew microsmithGenerate -PmicrosmithVersion=<version>`                   | `examples/gradle/scala/.github/workflows/microsmith.yml`      |
+| Java (native Maven)    | `examples/maven/java`        | `mvn microsmith:generate -Dmicrosmith.version=<version>`                       | `examples/maven/java/.github/workflows/microsmith.yml`        |
+| Kotlin (native Maven)  | `examples/maven/kotlin`      | `mvn microsmith:generate -Dmicrosmith.version=<version>`                       | `examples/maven/kotlin/.github/workflows/microsmith.yml`      |
+| Scala (native Maven)   | `examples/maven/scala`       | `mvn microsmith:generate -Dmicrosmith.version=<version>`                       | `examples/maven/scala/.github/workflows/microsmith.yml`       |
+| Scala (native sbt)     | `examples/sbt/scala`         | `sbt -Dmicrosmith.version=<version> microsmithGenerate`                        | `examples/sbt/scala/.github/workflows/microsmith.yml`         |
+| Java                   | `examples/jvm/java-maven`    | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/jvm/java-maven/.github/workflows/microsmith.yml`    |
+| Kotlin                 | `examples/jvm/kotlin-gradle` | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/jvm/kotlin-gradle/.github/workflows/microsmith.yml` |
+| Scala                  | `examples/jvm/scala-sbt`     | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/jvm/scala-sbt/.github/workflows/microsmith.yml`     |
+| Node                   | `examples/non-gradle/node`   | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/non-gradle/node/.github/workflows/microsmith.yml`   |
+| Go                     | `examples/non-gradle/go`     | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/non-gradle/go/.github/workflows/microsmith.yml`     |
+| Python                 | `examples/non-gradle/python` | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/non-gradle/python/.github/workflows/microsmith.yml` |
+| Ruby                   | `examples/non-gradle/ruby`   | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/non-gradle/ruby/.github/workflows/microsmith.yml`   |
+| Rust                   | `examples/non-gradle/rust`   | `microsmith init` then `microsmith run build.microsmith.kts`                   | `examples/non-gradle/rust/.github/workflows/microsmith.yml`   |
+| .NET                   | `examples/non-gradle/dotnet` | `microsmith init` then `microsmith run build.microsmith.kts --out .\Generated` | `examples/non-gradle/dotnet/.github/workflows/microsmith.yml` |
 
 ## Validation matrix and release checklist
 
 ### Automated validation matrix
 
-| Surface                        | Coverage source                                      | Evidence                                                                                   |
-|--------------------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| CLI help and README contract   | `build-and-qodana` on Ubuntu                         | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.   |
-| CLI distribution smoke         | `cli-smoke` on Ubuntu, macOS, and Windows            | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.             |
-| Installer and bootstrap smoke  | `cli-smoke` on Ubuntu, macOS, and Windows            | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.        |
-| Native Gradle fixture smoke    | `build-and-qodana` on Ubuntu                         | Publishes required packages to `mavenLocal`, then runs `microsmithGenerate` for Java, Kotlin, and Scala Gradle fixtures. |
-| Native Maven fixture smoke     | `build-and-qodana` on Ubuntu                         | Publishes required packages to `mavenLocal`, then runs `mvn microsmith:generate` for Java, Kotlin, and Scala Maven fixtures. |
-| Native sbt fixture smoke       | `build-and-qodana` on Ubuntu                         | Publishes required packages to `mavenLocal`, then runs `sbt microsmithGenerate` for the Scala sbt fixture. |
-| Consumer fixture onboarding    | `cli-smoke` on Ubuntu and Windows                    | Ubuntu covers Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture. |
-| JetBrains helper lifecycle     | `cli-smoke` on Ubuntu and Windows                    | Ubuntu runs `ide refresh` and `ide doctor` for Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
-| Fallback artifact packaging    | `build-and-qodana` on Ubuntu                         | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`. |
-| Resolver, auth, lock, offline  | `./gradlew build` and module regression suites       | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior. |
+| Surface                       | Coverage source                                | Evidence                                                                                                                                          |
+|-------------------------------|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| CLI help and README contract  | `build-and-qodana` on Ubuntu                   | `scripts/verify_readme_cli_usage.py` compares the README usage block to built `--help`.                                                           |
+| CLI distribution smoke        | `cli-smoke` on Ubuntu, macOS, and Windows      | Dist launcher, generation, process isolation, and `doctor --diagnostics json`.                                                                    |
+| Installer and bootstrap smoke | `cli-smoke` on Ubuntu, macOS, and Windows      | Installer, `--version`, `microsmith init`, and canonical `init -> run` generation.                                                                |
+| Native Gradle fixture smoke   | `build-and-qodana` on Ubuntu                   | Publishes required packages to `mavenLocal`, then runs `microsmithGenerate` for Java, Kotlin, and Scala Gradle fixtures.                          |
+| Native Maven fixture smoke    | `build-and-qodana` on Ubuntu                   | Publishes required packages to `mavenLocal`, then runs `mvn microsmith:generate` for Java, Kotlin, and Scala Maven fixtures.                      |
+| Native sbt fixture smoke      | `build-and-qodana` on Ubuntu                   | Publishes required packages to `mavenLocal`, then runs `sbt microsmithGenerate` for the Scala sbt fixture.                                        |
+| Consumer fixture onboarding   | `cli-smoke` on Ubuntu and Windows              | Ubuntu covers Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows covers the .NET fixture.                                    |
+| JetBrains helper lifecycle    | `cli-smoke` on Ubuntu and Windows              | Ubuntu runs `ide refresh` and `ide doctor` for Java, Kotlin, Scala, Node, Go, Python, Ruby, and Rust fixtures; Windows runs the .NET helper path. |
+| Fallback artifact packaging   | `build-and-qodana` on Ubuntu                   | `:runtime-scripting:ideFallbackArtifacts` and `:runtime-scripting:generateIdeFallbackChecksums`.                                                  |
+| Resolver, auth, lock, offline | `./gradlew build` and module regression suites | `:cli:jvmKotest` covers authenticated repositories, lockfiles, cache policy, and offline behavior.                                                |
 
 Automated gates are required on every release candidate commit:
 
@@ -1614,24 +1614,24 @@ Support policy:
 
 ### Native Gradle IDE validation
 
-| Product                    | Fixture root                | Required validation path |
-|---------------------------|-----------------------------|--------------------------|
-| IntelliJ IDEA            | `examples/gradle/java`      | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
-| IntelliJ IDEA            | `examples/gradle/kotlin`    | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
-| IntelliJ IDEA + Scala plugin | `examples/gradle/scala` | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
+| Product                      | Fixture root             | Required validation path                                                                                                                                             |
+|------------------------------|--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| IntelliJ IDEA                | `examples/gradle/java`   | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
+| IntelliJ IDEA                | `examples/gradle/kotlin` | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
+| IntelliJ IDEA + Scala plugin | `examples/gradle/scala`  | Import the fixture root as a Gradle project, refresh Gradle indexing, and confirm `build.microsmith.kts` resolves Microsmith DSL symbols without the helper project. |
 
 ### Native Maven IDE validation
 
-| Product                    | Fixture root              | Required validation path |
-|---------------------------|---------------------------|--------------------------|
-| IntelliJ IDEA            | `examples/maven/java`     | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
-| IntelliJ IDEA            | `examples/maven/kotlin`   | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
-| IntelliJ IDEA + Scala plugin | `examples/maven/scala` | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
+| Product                      | Fixture root            | Required validation path                                                                                                                                                       |
+|------------------------------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| IntelliJ IDEA                | `examples/maven/java`   | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
+| IntelliJ IDEA                | `examples/maven/kotlin` | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
+| IntelliJ IDEA + Scala plugin | `examples/maven/scala`  | Import the fixture root as a Maven project, reload Maven indexing, and confirm `build.microsmith.kts` resolves the built-in Microsmith DSL symbols without the helper project. |
 
 ### Native sbt IDE validation
 
-| Product                    | Fixture root           | Required validation path |
-|---------------------------|------------------------|--------------------------|
+| Product                      | Fixture root         | Required validation path                                                                                                                                                                                                                                                                                                                                                      |
+|------------------------------|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | IntelliJ IDEA + Scala plugin | `examples/sbt/scala` | Import the fixture root as an sbt project, reload sbt indexing, and confirm the `Provided` `runtime-scripting` dependency exposes the built-in Microsmith DSL symbols in `build.microsmith.kts`. If imported sbt indexing still leaves `.microsmith.kts` unresolved, confirm the helper or fallback path restores resolution without changing the native sbt generation path. |
 
 Native Gradle checklist:
@@ -1661,17 +1661,17 @@ Native sbt checklist:
 
 ### Helper and fallback IDE validation
 
-| Product         | Fixture root                    | Required helper smoke path                              | Required fallback smoke path                             |
-|-----------------|---------------------------------|---------------------------------------------------------|----------------------------------------------------------|
-| WebStorm        | `examples/non-gradle/node`      | Run the helper checklist below against the Node fixture. | Run the fallback checklist below against the Node fixture. |
-| IntelliJ IDEA   | `examples/jvm/java-maven`       | Run the helper checklist below against the Java fixture. | Run the fallback checklist below against the Java fixture. |
-| IntelliJ IDEA   | `examples/jvm/kotlin-gradle`    | Run the helper checklist below against the Kotlin fixture. | Run the fallback checklist below against the Kotlin fixture. |
-| IntelliJ IDEA   | `examples/jvm/scala-sbt`        | Run the helper checklist below against the Scala fixture. | Run the fallback checklist below against the Scala fixture. |
-| GoLand          | `examples/non-gradle/go`        | Run the helper checklist below against the Go fixture.   | Run the fallback checklist below against the Go fixture.   |
-| PyCharm         | `examples/non-gradle/python`    | Run the helper checklist below against the Python fixture. | Run the fallback checklist below against the Python fixture. |
-| RubyMine        | `examples/non-gradle/ruby`      | Run the helper checklist below against the Ruby fixture. | Run the fallback checklist below against the Ruby fixture. |
-| RustRover       | `examples/non-gradle/rust`      | Run the helper checklist below against the Rust fixture. | Run the fallback checklist below against the Rust fixture. |
-| Rider           | `examples/non-gradle/dotnet`    | Run the helper checklist below against the .NET fixture. | Run the fallback checklist below against the .NET fixture. |
+| Product       | Fixture root                 | Required helper smoke path                                 | Required fallback smoke path                                 |
+|---------------|------------------------------|------------------------------------------------------------|--------------------------------------------------------------|
+| WebStorm      | `examples/non-gradle/node`   | Run the helper checklist below against the Node fixture.   | Run the fallback checklist below against the Node fixture.   |
+| IntelliJ IDEA | `examples/jvm/java-maven`    | Run the helper checklist below against the Java fixture.   | Run the fallback checklist below against the Java fixture.   |
+| IntelliJ IDEA | `examples/jvm/kotlin-gradle` | Run the helper checklist below against the Kotlin fixture. | Run the fallback checklist below against the Kotlin fixture. |
+| IntelliJ IDEA | `examples/jvm/scala-sbt`     | Run the helper checklist below against the Scala fixture.  | Run the fallback checklist below against the Scala fixture.  |
+| GoLand        | `examples/non-gradle/go`     | Run the helper checklist below against the Go fixture.     | Run the fallback checklist below against the Go fixture.     |
+| PyCharm       | `examples/non-gradle/python` | Run the helper checklist below against the Python fixture. | Run the fallback checklist below against the Python fixture. |
+| RubyMine      | `examples/non-gradle/ruby`   | Run the helper checklist below against the Ruby fixture.   | Run the fallback checklist below against the Ruby fixture.   |
+| RustRover     | `examples/non-gradle/rust`   | Run the helper checklist below against the Rust fixture.   | Run the fallback checklist below against the Rust fixture.   |
+| Rider         | `examples/non-gradle/dotnet` | Run the helper checklist below against the .NET fixture.   | Run the fallback checklist below against the .NET fixture.   |
 
 ### Manual IDE release checklist
 
@@ -1791,12 +1791,12 @@ The DSL surface stays the same; the execution boundary changes.
 
 ### Command mapping
 
-| Previous pattern                 | CLI replacement                                          |
-|----------------------------------|----------------------------------------------------------|
-| Gradle task invoking generation  | `microsmith run build.microsmith.kts`                      |
-| Gradle-managed plugin dependency | `--plugin group:artifact:version`                        |
-| local classpath jar wiring       | `--plugin-jar ./path/to/plugin.jar`                      |
-| Gradle offline mode              | `--offline`                                              |
+| Previous pattern                 | CLI replacement                       |
+|----------------------------------|---------------------------------------|
+| Gradle task invoking generation  | `microsmith run build.microsmith.kts` |
+| Gradle-managed plugin dependency | `--plugin group:artifact:version`     |
+| local classpath jar wiring       | `--plugin-jar ./path/to/plugin.jar`   |
+| Gradle offline mode              | `--offline`                           |
 
 ### Recommended migration sequence to the standalone CLI
 

--- a/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/cli/CliPackagingPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/cli/CliPackagingPlugin.kt
@@ -8,9 +8,9 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.ConfigurableFilePermissions
 import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSetContainer
@@ -19,7 +19,6 @@ import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.jvm.tasks.Jar
-
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.jar.JarFile
@@ -99,7 +98,10 @@ class CliPackagingPlugin : Plugin<Project> {
             project.tasks.register(CliTaskNames.GENERATE_BUNDLED_PLUGIN_CATALOG, DefaultTask::class.java) { task ->
                 task.dependsOn(bundledPluginJarTasks)
                 task.inputs.property("cliVersion", cliVersion)
-                task.inputs.property("catalogFormatVersion", CliPackagingBuildNames.BUNDLED_PLUGIN_CATALOG_FORMAT_VERSION)
+                task.inputs.property(
+                    "catalogFormatVersion",
+                    CliPackagingBuildNames.BUNDLED_PLUGIN_CATALOG_FORMAT_VERSION,
+                )
                 task.inputs.files(bundledPlugins.map { it.archiveFile })
                 task.outputs.file(bundledPluginCatalogOutput)
 
@@ -130,7 +132,7 @@ class CliPackagingPlugin : Plugin<Project> {
             task.dependsOn(generateBundledPluginCatalogTask)
             task.from(
                 bundledPluginCatalogOutput,
-                Action<CopySpec> { copySpec ->
+                Action { copySpec ->
                     copySpec.into("META-INF/microsmith")
                 },
             )
@@ -181,7 +183,9 @@ class CliPackagingPlugin : Plugin<Project> {
                     JarFile(shadedJar).use { jarFile ->
                         expectedServiceProvidersByDescriptor.forEach { (servicePath, expectedProviders) ->
                             val entry = jarFile.getJarEntry(servicePath)
-                                ?: throw GradleException("Missing merged service descriptor '$servicePath' in ${shadedJar.name}.")
+                                ?: throw GradleException(
+                                    "Missing merged service descriptor '$servicePath' in ${shadedJar.name}.",
+                                )
                             val providers =
                                 jarFile.getInputStream(entry)
                                     .bufferedReader(StandardCharsets.UTF_8)
@@ -201,13 +205,17 @@ class CliPackagingPlugin : Plugin<Project> {
                         }
 
                         val catalogEntry = jarFile.getJarEntry(bundledPluginCatalogJarEntry)
-                            ?: throw GradleException("Missing bundled plugin catalog '$bundledPluginCatalogJarEntry' in ${shadedJar.name}.")
+                            ?: throw GradleException(
+                                "Missing bundled plugin catalog '$bundledPluginCatalogJarEntry' in ${shadedJar.name}.",
+                            )
                         val actualCatalogText =
                             jarFile.getInputStream(catalogEntry)
                                 .bufferedReader(StandardCharsets.UTF_8)
                                 .use { reader -> reader.readText() }
                         if (actualCatalogText != expectedCatalogText) {
-                            throw GradleException("Bundled plugin catalog in ${shadedJar.name} does not match generated metadata.")
+                            throw GradleException(
+                                "Bundled plugin catalog in ${shadedJar.name} does not match generated metadata.",
+                            )
                         }
                         CliBundledPluginCatalogVerifier.validate(
                             actualCatalogText,
@@ -231,7 +239,7 @@ class CliPackagingPlugin : Plugin<Project> {
                 task.into(distDirectory)
                 task.from(
                     shadowJarArchive,
-                    Action<CopySpec> { copySpec ->
+                    Action { copySpec ->
                         copySpec.into("lib")
                     },
                 )
@@ -245,13 +253,13 @@ class CliPackagingPlugin : Plugin<Project> {
                 )
                 task.from(
                     project.file("src/dist/README.txt"),
-                    Action<CopySpec> { copySpec ->
+                    Action { copySpec ->
                         copySpec.into(".")
                     },
                 )
                 task.from(
                     bundledPluginCatalogOutput,
-                    Action<CopySpec> { copySpec ->
+                    Action { copySpec ->
                         copySpec.into(".")
                     },
                 )
@@ -266,7 +274,7 @@ class CliPackagingPlugin : Plugin<Project> {
                 task.destinationDirectory.set(project.layout.buildDirectory.dir("distributions"))
                 task.from(
                     distDirectory,
-                    Action<CopySpec> { copySpec ->
+                    Action { copySpec ->
                         copySpec.into(distRootName)
                     },
                 )
@@ -282,7 +290,7 @@ class CliPackagingPlugin : Plugin<Project> {
                 task.destinationDirectory.set(project.layout.buildDirectory.dir("distributions"))
                 task.from(
                     distDirectory,
-                    Action<CopySpec> { copySpec ->
+                    Action { copySpec ->
                         copySpec.into(distRootName)
                     },
                 )
@@ -303,7 +311,10 @@ class CliPackagingPlugin : Plugin<Project> {
                     val expectedCatalogText = bundledPluginCatalogOutput.get().asFile.readText(StandardCharsets.UTF_8)
                     val bundledServiceEntries = collectBundledServiceEntries()
                     val distRootDirectory = distDirectory.get().asFile
-                    val distCatalogFile = java.io.File(distRootDirectory, CliPackagingBuildNames.BUNDLED_PLUGIN_CATALOG_FILE_NAME)
+                    val distCatalogFile = java.io.File(
+                        distRootDirectory,
+                        CliPackagingBuildNames.BUNDLED_PLUGIN_CATALOG_FILE_NAME,
+                    )
                     if (!distCatalogFile.isFile) {
                         throw GradleException(
                             "Distribution directory is missing '${CliPackagingBuildNames.BUNDLED_PLUGIN_CATALOG_FILE_NAME}' at ${distCatalogFile.path}.",
@@ -333,20 +344,24 @@ class CliPackagingPlugin : Plugin<Project> {
                         }
                         val launcherText = launcher.readText(StandardCharsets.UTF_8)
                         if (launcherText.contains("@CLI_JAR@")) {
-                            throw GradleException("Launcher '${launcher.path}' still contains unresolved @CLI_JAR@ token.")
+                            throw GradleException(
+                                "Launcher '${launcher.path}' still contains unresolved @CLI_JAR@ token.",
+                            )
                         }
                         if (!launcherText.contains(shadowJarArchiveName)) {
-                            throw GradleException("Launcher '${launcher.path}' does not reference '${shadowJarArchiveName}'.")
+                            throw GradleException(
+                                "Launcher '${launcher.path}' does not reference '$shadowJarArchiveName'.",
+                            )
                         }
                     }
 
                     val expectedEntries =
                         setOf(
-                            "${distRootName}/${CliPackagingBuildNames.BUNDLED_PLUGIN_CATALOG_FILE_NAME}",
-                            "${distRootName}/README.txt",
-                            "${distRootName}/bin/microsmith",
-                            "${distRootName}/bin/microsmith.bat",
-                            "${distRootName}/lib/$shadowJarArchiveName",
+                            "$distRootName/${CliPackagingBuildNames.BUNDLED_PLUGIN_CATALOG_FILE_NAME}",
+                            "$distRootName/README.txt",
+                            "$distRootName/bin/microsmith",
+                            "$distRootName/bin/microsmith.bat",
+                            "$distRootName/lib/$shadowJarArchiveName",
                         )
 
                     mapOf(
@@ -356,7 +371,9 @@ class CliPackagingPlugin : Plugin<Project> {
                         val missingEntries = expectedEntries.filterNot(entries::contains)
                         if (missingEntries.isNotEmpty()) {
                             throw GradleException(
-                                "Archive $archiveName is missing expected distribution entries: ${missingEntries.joinToString(", ")}",
+                                "Archive $archiveName is missing expected distribution entries: ${missingEntries.joinToString(
+                                    ", ",
+                                )}",
                             )
                         }
                     }
@@ -376,7 +393,7 @@ class CliPackagingPlugin : Plugin<Project> {
                 )
                 task.from(
                     project.file("src/install/microsmith-install.ps1"),
-                    Action<CopySpec> { copySpec ->
+                    Action { copySpec ->
                         copySpec.into(".")
                     },
                 )
@@ -399,12 +416,17 @@ class CliPackagingPlugin : Plugin<Project> {
                         ?.sortedBy { file -> file.name }
                         .orEmpty()
                 if (sourceFiles.isEmpty()) {
-                    throw GradleException("Release assets directory '${releaseDir.path}' did not contain files to checksum.")
+                    throw GradleException(
+                        "Release assets directory '${releaseDir.path}' did not contain files to checksum.",
+                    )
                 }
 
                 sourceFiles.forEach { file ->
                     val checksum = MessageDigest.getInstance("SHA-256").digest(file.readBytes()).encodeHex()
-                    java.io.File(releaseDir, "${file.name}.sha256").writeText("$checksum  ${file.name}\n", StandardCharsets.UTF_8)
+                    java.io.File(
+                        releaseDir,
+                        "${file.name}.sha256",
+                    ).writeText("$checksum  ${file.name}\n", StandardCharsets.UTF_8)
                 }
             }
         }
@@ -427,33 +449,34 @@ private object CliTaskNames {
     const val RELEASE_ARTIFACTS = "releaseArtifacts"
 }
 
-private fun launcherCopySpec(shadowJarArchiveName: String): Action<CopySpec> =
-    Action { copySpec ->
-        copySpec.into("bin")
-        copySpec.filter(
-            mapOf("tokens" to mapOf("CLI_JAR" to shadowJarArchiveName)),
-            ReplaceTokens::class.java,
-        )
-        copySpec.filePermissions(Action<ConfigurableFilePermissions> { permissions ->
+private fun launcherCopySpec(shadowJarArchiveName: String): Action<CopySpec> = Action { copySpec ->
+    copySpec.into("bin")
+    copySpec.filter(
+        mapOf("tokens" to mapOf("CLI_JAR" to shadowJarArchiveName)),
+        ReplaceTokens::class.java,
+    )
+    copySpec.filePermissions(
+        Action<ConfigurableFilePermissions> { permissions ->
             permissions.unix("rwxr-xr-x")
-        })
-    }
+        },
+    )
+}
 
-private fun windowsLauncherCopySpec(shadowJarArchiveName: String): Action<CopySpec> =
-    Action { copySpec ->
-        copySpec.into("bin")
-        copySpec.filter(
-            mapOf("tokens" to mapOf("CLI_JAR" to shadowJarArchiveName)),
-            ReplaceTokens::class.java,
-        )
-    }
+private fun windowsLauncherCopySpec(shadowJarArchiveName: String): Action<CopySpec> = Action { copySpec ->
+    copySpec.into("bin")
+    copySpec.filter(
+        mapOf("tokens" to mapOf("CLI_JAR" to shadowJarArchiveName)),
+        ReplaceTokens::class.java,
+    )
+}
 
-private fun executableFileCopySpec(): Action<CopySpec> =
-    Action { copySpec ->
-        copySpec.into(".")
-        copySpec.filePermissions(Action<ConfigurableFilePermissions> { permissions ->
+private fun executableFileCopySpec(): Action<CopySpec> = Action { copySpec ->
+    copySpec.into(".")
+    copySpec.filePermissions(
+        Action<ConfigurableFilePermissions> { permissions ->
             permissions.unix("rwxr-xr-x")
-        })
-    }
+        },
+    )
+}
 
 private fun ByteArray.encodeHex(): String = joinToString(separator = "") { byte -> "%02x".format(byte) }

--- a/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/maven/MavenPluginDescriptorWriter.kt
+++ b/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/maven/MavenPluginDescriptorWriter.kt
@@ -1,7 +1,6 @@
 package io.github.lmliam.microsmith.build.maven
 
 import org.gradle.api.artifacts.Configuration
-
 import java.io.File
 import java.nio.charset.StandardCharsets
 
@@ -102,41 +101,41 @@ internal object MavenPluginDescriptorWriter {
                                     4,
                                     "projectBaseDirectory",
                                     implementation = "java.io.File",
-                                    defaultValue = "\${project.basedir}",
-                                    value = "\${project.basedir}",
+                                    defaultValue = $$"${project.basedir}",
+                                    value = $$"${project.basedir}",
                                 )
                                 appendConfigurationElement(
                                     4,
                                     "scriptFile",
                                     implementation = "java.io.File",
-                                    defaultValue = "\${project.basedir}/build.microsmith.kts",
-                                    value = "\${microsmith.scriptFile}",
+                                    defaultValue = $$"${project.basedir}/build.microsmith.kts",
+                                    value = $$"${microsmith.scriptFile}",
                                 )
                                 appendConfigurationElement(
                                     4,
                                     "outputDirectory",
                                     implementation = "java.io.File",
-                                    defaultValue = "\${project.build.directory}/generated/microsmith",
-                                    value = "\${microsmith.outputDirectory}",
+                                    defaultValue = $$"${project.build.directory}/generated/microsmith",
+                                    value = $$"${microsmith.outputDirectory}",
                                 )
                                 appendConfigurationElement(
                                     4,
                                     "cacheDirectory",
                                     implementation = "java.io.File",
-                                    defaultValue = "\${project.build.directory}/tmp/microsmith/cache",
-                                    value = "\${microsmith.cacheDirectory}",
+                                    defaultValue = $$"${project.build.directory}/tmp/microsmith/cache",
+                                    value = $$"${microsmith.cacheDirectory}",
                                 )
                                 appendConfigurationElement(
                                     4,
                                     "variables",
                                     implementation = "java.util.Properties",
-                                    value = "\${microsmith.variables}",
+                                    value = $$"${microsmith.variables}",
                                 )
                                 appendConfigurationElement(
                                     4,
                                     "flags",
                                     implementation = "java.util.List",
-                                    value = "\${microsmith.flags}",
+                                    value = $$"${microsmith.flags}",
                                 )
                             }
                         }
@@ -234,16 +233,15 @@ private fun StringBuilder.appendIndent(level: Int) {
     }
 }
 
-private fun escapeXml(value: String): String =
-    buildString(value.length) {
-        value.forEach { char ->
-            when (char) {
-                '&' -> append("&amp;")
-                '<' -> append("&lt;")
-                '>' -> append("&gt;")
-                '"' -> append("&quot;")
-                '\'' -> append("&apos;")
-                else -> append(char)
-            }
+private fun escapeXml(value: String): String = buildString(value.length) {
+    value.forEach { char ->
+        when (char) {
+            '&' -> append("&amp;")
+            '<' -> append("&lt;")
+            '>' -> append("&gt;")
+            '"' -> append("&quot;")
+            '\'' -> append("&apos;")
+            else -> append(char)
         }
     }
+}

--- a/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/quality/KotlinSourceScanning.kt
+++ b/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/quality/KotlinSourceScanning.kt
@@ -1,0 +1,18 @@
+package io.github.lmliam.microsmith.build.quality
+
+internal const val KOTLIN_TRIPLE_QUOTE = "\"\"\""
+
+internal fun String.consumeQuotedLiteral(startIndex: Int, quote: Char): Int? {
+    var index = startIndex + 1
+    while (index < length) {
+        if (this[index] == '\\') {
+            index += 2
+            continue
+        }
+        if (this[index] == quote) {
+            return index + 1
+        }
+        index += 1
+    }
+    return null
+}

--- a/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/quality/ProductionKotlinLine.kt
+++ b/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/quality/ProductionKotlinLine.kt
@@ -95,7 +95,7 @@ private fun String.consumeBalancedParentheses(startIndex: Int): Int? {
     var depth = 0
     while (index < length) {
         when {
-            startsWith(TRIPLE_QUOTE, index) -> {
+            startsWith(KOTLIN_TRIPLE_QUOTE, index) -> {
                 index = consumeTripleQuotedString(index) ?: return null
                 continue
             }
@@ -124,23 +124,8 @@ private fun String.consumeBalancedParentheses(startIndex: Int): Int? {
 }
 
 private fun String.consumeTripleQuotedString(startIndex: Int): Int? {
-    val closingIndex = indexOf(TRIPLE_QUOTE, startIndex + TRIPLE_QUOTE.length)
-    return closingIndex.takeIf { it >= 0 }?.plus(TRIPLE_QUOTE.length)
-}
-
-private fun String.consumeQuotedLiteral(startIndex: Int, quote: Char): Int? {
-    var index = startIndex + 1
-    while (index < length) {
-        if (this[index] == '\\') {
-            index += 2
-            continue
-        }
-        if (this[index] == quote) {
-            return index + 1
-        }
-        index += 1
-    }
-    return null
+    val closingIndex = indexOf(KOTLIN_TRIPLE_QUOTE, startIndex + KOTLIN_TRIPLE_QUOTE.length)
+    return closingIndex.takeIf { it >= 0 }?.plus(KOTLIN_TRIPLE_QUOTE.length)
 }
 
 private val PACKAGE_DECLARATION_PATTERN = Regex("^package\\s+([A-Za-z0-9_.]+)$")
@@ -149,15 +134,14 @@ private const val DECLARATION_MODIFIER_PATTERN =
 private val TOP_LEVEL_TYPE_DECLARATION_PATTERN = Regex(
     "^$DECLARATION_MODIFIER_PATTERN(?:class|interface|object)\\b",
 )
-private val TOP_LEVEL_FUN_INTERFACE_PATTERN = Regex("^$DECLARATION_MODIFIER_PATTERN(?:fun\\s+interface)\\b")
-private val TOP_LEVEL_TYPE_ALIAS_PATTERN = Regex("^$DECLARATION_MODIFIER_PATTERN(?:typealias)\\b")
+private val TOP_LEVEL_FUN_INTERFACE_PATTERN = Regex("^${DECLARATION_MODIFIER_PATTERN}fun\\s+interface\\b")
+private val TOP_LEVEL_TYPE_ALIAS_PATTERN = Regex("^${DECLARATION_MODIFIER_PATTERN}typealias\\b")
 private val TOP_LEVEL_TYPE_DECLARATION_NAME_PATTERN = Regex(
     "^$DECLARATION_MODIFIER_PATTERN(?:class|interface|object)\\s+([A-Za-z_][A-Za-z0-9_]*)\\b",
 )
 private val TOP_LEVEL_FUN_INTERFACE_NAME_PATTERN = Regex(
-    "^$DECLARATION_MODIFIER_PATTERN(?:fun\\s+interface)\\s+([A-Za-z_][A-Za-z0-9_]*)\\b",
+    "^${DECLARATION_MODIFIER_PATTERN}fun\\s+interface\\s+([A-Za-z_][A-Za-z0-9_]*)\\b",
 )
 private val TOP_LEVEL_TYPE_ALIAS_NAME_PATTERN = Regex(
-    "^$DECLARATION_MODIFIER_PATTERN(?:typealias)\\s+([A-Za-z_][A-Za-z0-9_]*)\\b",
+    "^${DECLARATION_MODIFIER_PATTERN}typealias\\s+([A-Za-z_][A-Za-z0-9_]*)\\b",
 )
-private const val TRIPLE_QUOTE = "\"\"\""

--- a/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/quality/TopLevelKotlinLineScanner.kt
+++ b/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/quality/TopLevelKotlinLineScanner.kt
@@ -35,7 +35,7 @@ internal object TopLevelKotlinLineScanner {
                     }
 
                     currentTripleQuotedString -> {
-                        val tripleQuoteEnd = line.indexOf(TRIPLE_QUOTE, index)
+                        val tripleQuoteEnd = line.indexOf(KOTLIN_TRIPLE_QUOTE, index)
                         if (tripleQuoteEnd == -1) {
                             return copy(
                                 braceDepth = currentBraceDepth,
@@ -44,7 +44,7 @@ internal object TopLevelKotlinLineScanner {
                             )
                         }
                         currentTripleQuotedString = false
-                        index = tripleQuoteEnd + TRIPLE_QUOTE.length
+                        index = tripleQuoteEnd + KOTLIN_TRIPLE_QUOTE.length
                     }
 
                     line.startsWith(LINE_COMMENT_MARKER, index) -> break
@@ -53,9 +53,9 @@ internal object TopLevelKotlinLineScanner {
                         index += BLOCK_COMMENT_START_MARKER.length
                     }
 
-                    line.startsWith(TRIPLE_QUOTE, index) -> {
+                    line.startsWith(KOTLIN_TRIPLE_QUOTE, index) -> {
                         currentTripleQuotedString = true
-                        index += TRIPLE_QUOTE.length
+                        index += KOTLIN_TRIPLE_QUOTE.length
                     }
 
                     line[index] == '"' -> {
@@ -88,23 +88,7 @@ internal object TopLevelKotlinLineScanner {
         }
     }
 
-    private fun String.consumeQuotedLiteral(startIndex: Int, quote: Char): Int? {
-        var index = startIndex + 1
-        while (index < length) {
-            if (this[index] == '\\') {
-                index += 2
-                continue
-            }
-            if (this[index] == quote) {
-                return index + 1
-            }
-            index += 1
-        }
-        return null
-    }
-
     private const val LINE_COMMENT_MARKER = "//"
     private const val BLOCK_COMMENT_START_MARKER = "/*"
     private const val BLOCK_COMMENT_END_MARKER = "*/"
-    private const val TRIPLE_QUOTE = "\"\"\""
 }

--- a/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/runtime/RuntimeScriptingSourceFiles.kt
+++ b/build-logic/src/main/kotlin/io/github/lmliam/microsmith/build/runtime/RuntimeScriptingSourceFiles.kt
@@ -2,7 +2,6 @@ package io.github.lmliam.microsmith.build.runtime
 
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-
 import java.io.File
 import java.nio.charset.StandardCharsets
 
@@ -27,9 +26,8 @@ internal object RuntimeScriptingSourceFiles {
     private const val COMPILATION_CONFIGURATION_MARKER = "compilationConfiguration ="
     private const val IMPLICIT_RECEIVER_MARKER = "implicitReceivers("
 
-    fun annotatedKotlinScriptSourceFile(project: Project, fileExtension: String): File {
-        return annotatedKotlinScriptSourceFile(sourceRoot(project), fileExtension)
-    }
+    fun annotatedKotlinScriptSourceFile(project: Project, fileExtension: String): File =
+        annotatedKotlinScriptSourceFile(sourceRoot(project), fileExtension)
 
     fun annotatedKotlinScriptSourceFile(sourceRoot: File, fileExtension: String): File {
         val sourceFiles =
@@ -44,16 +42,17 @@ internal object RuntimeScriptingSourceFiles {
 
         if (sourceFiles.size != 1) {
             throw GradleException(
-                "Expected exactly one Kotlin script template source for extension '$fileExtension' but found ${sourceFiles.map { it.path }}",
+                "Expected exactly one Kotlin script template source for extension '$fileExtension' but found ${sourceFiles.map {
+                    it.path
+                }}",
             )
         }
 
         return sourceFiles.single()
     }
 
-    fun sourceFileByTopLevelDeclaration(project: Project, declarationName: String): File {
-        return sourceFileByTopLevelDeclaration(sourceRoot(project), declarationName)
-    }
+    fun sourceFileByTopLevelDeclaration(project: Project, declarationName: String): File =
+        sourceFileByTopLevelDeclaration(sourceRoot(project), declarationName)
 
     fun sourceFileByTopLevelDeclaration(sourceRoot: File, declarationName: String): File {
         val sourceFiles = sourceRoot
@@ -64,7 +63,9 @@ internal object RuntimeScriptingSourceFiles {
 
         if (sourceFiles.size != 1) {
             throw GradleException(
-                "Expected exactly one source file declaring '$declarationName' but found ${sourceFiles.map { it.path }}",
+                "Expected exactly one source file declaring '$declarationName' but found ${sourceFiles.map {
+                    it.path
+                }}",
             )
         }
 
@@ -85,27 +86,17 @@ internal object RuntimeScriptingSourceFiles {
         } ?: throw GradleException("Source file '${sourceFile.path}' did not declare a package.")
     }
 
-    fun topLevelDeclarationNameFromSourceFile(sourceFile: File): String {
-        return topLevelDeclarationNameOrNull(sourceFile)
-            ?: throw GradleException("Source file '${sourceFile.path}' did not declare a top level class or object.")
-    }
+    fun topLevelDeclarationNameFromSourceFile(sourceFile: File): String = topLevelDeclarationNameOrNull(sourceFile)
+        ?: throw GradleException("Source file '${sourceFile.path}' did not declare a top level class or object.")
 
-    fun fqcnFromSourceFile(sourceFile: File): String {
-        return "${packageNameFromSourceFile(sourceFile)}.${topLevelDeclarationNameFromSourceFile(sourceFile)}"
-    }
+    fun fqcnFromSourceFile(sourceFile: File): String =
+        "${packageNameFromSourceFile(sourceFile)}.${topLevelDeclarationNameFromSourceFile(sourceFile)}"
 
-    fun compilationConfigurationSourceFileFromScriptTemplateSourceFile(
-        project: Project,
-        sourceFile: File,
-    ): File {
-        return compilationConfigurationSourceFileFromScriptTemplateSourceFile(sourceRoot(project), sourceFile)
-    }
+    fun compilationConfigurationSourceFileFromScriptTemplateSourceFile(project: Project, sourceFile: File): File =
+        compilationConfigurationSourceFileFromScriptTemplateSourceFile(sourceRoot(project), sourceFile)
 
-    fun compilationConfigurationSourceFileFromScriptTemplateSourceFile(
-        sourceRoot: File,
-        sourceFile: File,
-    ): File {
-        return sourceFileByTopLevelDeclaration(
+    fun compilationConfigurationSourceFileFromScriptTemplateSourceFile(sourceRoot: File, sourceFile: File): File =
+        sourceFileByTopLevelDeclaration(
             sourceRoot,
             referencedTypeSimpleNameFromSourceFile(
                 sourceFile,
@@ -113,20 +104,12 @@ internal object RuntimeScriptingSourceFiles {
                 "compilation configuration",
             ),
         )
-    }
 
-    fun contextSourceFileFromCompilationConfigurationSourceFile(
-        project: Project,
-        sourceFile: File,
-    ): File {
-        return contextSourceFileFromCompilationConfigurationSourceFile(sourceRoot(project), sourceFile)
-    }
+    fun contextSourceFileFromCompilationConfigurationSourceFile(project: Project, sourceFile: File): File =
+        contextSourceFileFromCompilationConfigurationSourceFile(sourceRoot(project), sourceFile)
 
-    fun contextSourceFileFromCompilationConfigurationSourceFile(
-        sourceRoot: File,
-        sourceFile: File,
-    ): File {
-        return sourceFileByTopLevelDeclaration(
+    fun contextSourceFileFromCompilationConfigurationSourceFile(sourceRoot: File, sourceFile: File): File =
+        sourceFileByTopLevelDeclaration(
             sourceRoot,
             referencedTypeSimpleNameFromSourceFile(
                 sourceFile,
@@ -134,12 +117,13 @@ internal object RuntimeScriptingSourceFiles {
                 "script context",
             ),
         )
-    }
 
     private fun topLevelDeclarationNameOrNull(sourceFile: File): String? {
         return firstMatchingLine(sourceFile) { line ->
             val trimmedLine = line.trimStart()
-            if (trimmedLine.isBlank() || trimmedLine.startsWith("//") || trimmedLine.startsWith("/*") || trimmedLine.startsWith("*")) {
+            if (trimmedLine.isBlank() || trimmedLine.startsWith("//") || trimmedLine.startsWith("/*") ||
+                trimmedLine.startsWith("*")
+            ) {
                 return@firstMatchingLine null
             }
             if (trimmedLine.startsWith("@")) {
@@ -150,18 +134,16 @@ internal object RuntimeScriptingSourceFiles {
             when {
                 declarationLine.startsWith(CLASS_DECLARATION_PREFIX) ->
                     extractDeclarationName(declarationLine, CLASS_DECLARATION_PREFIX)
+
                 declarationLine.startsWith(OBJECT_DECLARATION_PREFIX) ->
                     extractDeclarationName(declarationLine, OBJECT_DECLARATION_PREFIX)
+
                 else -> null
             }
         }
     }
 
-    private fun referencedTypeSimpleNameFromSourceFile(
-        sourceFile: File,
-        marker: String,
-        description: String,
-    ): String {
+    private fun referencedTypeSimpleNameFromSourceFile(sourceFile: File, marker: String, description: String): String {
         val sourceText = sourceFile.readText(StandardCharsets.UTF_8)
         val markerIndex = sourceText.indexOf(marker)
         if (markerIndex < 0) {
@@ -177,7 +159,10 @@ internal object RuntimeScriptingSourceFiles {
             .substring(markerIndex + marker.length, classIndex)
             .trim()
             .trimEnd(',', ')')
-        val simpleName = referencedType.substringAfterLast('.').takeWhile { char -> char.isLetterOrDigit() || char == '_' }
+        val simpleName = referencedType.substringAfterLast('.').takeWhile { char ->
+            char.isLetterOrDigit() ||
+                char == '_'
+        }
         if (simpleName.isBlank()) {
             throw GradleException("Source file '${sourceFile.path}' did not reference a valid $description type.")
         }
@@ -187,7 +172,7 @@ internal object RuntimeScriptingSourceFiles {
 
     private fun firstMatchingLine(sourceFile: File, matcher: (String) -> String?): String? {
         val sourceText = sourceFile.readText(StandardCharsets.UTF_8)
-        return sourceText.lineSequence().mapNotNull(matcher).firstOrNull()
+        return sourceText.lineSequence().firstNotNullOfOrNull(matcher)
     }
 
     private fun removeLeadingDeclarationModifiers(line: String): String {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 25 17:31:46 BST 2025
+#Mon Apr 06 11:38:00 BST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcArtifactContributor.kt
+++ b/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcArtifactContributor.kt
@@ -9,8 +9,8 @@ import io.github.lmliam.microsmith.resolve.schemas.protobuf.rpc.ResolvedProtobuf
 class ProtobufRpcArtifactContributor : ArtifactContributor<ResolvedProtobufRpcSchemaModel> {
     override val resolvedType = ResolvedProtobufRpcSchemaModel::class
 
-    override fun contribute(model: ResolvedProtobufRpcSchemaModel): List<ArtifactContribution<*>> {
-        return model.schemas.map { schema ->
+    override fun contribute(model: ResolvedProtobufRpcSchemaModel): List<ArtifactContribution<*>> =
+        model.schemas.map { schema ->
             ProtobufRpcServiceContribution(
                 artifactId = ProtobufRpcServiceArtifactId(
                     packageName = schema.qualifiedName.packageName,
@@ -32,5 +32,4 @@ class ProtobufRpcArtifactContributor : ArtifactContributor<ResolvedProtobufRpcSc
                 },
             )
         }
-    }
 }

--- a/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcEndpoint.kt
+++ b/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcEndpoint.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.artifact.schemas.protobuf.rpc
 
-data class ProtobufRpcEndpoint(
-    val typeName: String,
-    val streaming: Boolean,
-)
+data class ProtobufRpcEndpoint(val typeName: String, val streaming: Boolean)

--- a/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcOperation.kt
+++ b/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcOperation.kt
@@ -1,7 +1,3 @@
 package io.github.lmliam.microsmith.artifact.schemas.protobuf.rpc
 
-data class ProtobufRpcOperation(
-    val name: String,
-    val request: ProtobufRpcEndpoint,
-    val response: ProtobufRpcEndpoint,
-)
+data class ProtobufRpcOperation(val name: String, val request: ProtobufRpcEndpoint, val response: ProtobufRpcEndpoint)

--- a/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcServiceArtifactId.kt
+++ b/modules/artifact-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/rpc/ProtobufRpcServiceArtifactId.kt
@@ -2,10 +2,8 @@ package io.github.lmliam.microsmith.artifact.schemas.protobuf.rpc
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 
-data class ProtobufRpcServiceArtifactId(
-    val packageName: String?,
-    val serviceName: String,
-) : ArtifactId<ProtobufRpcServiceArtifact> {
+data class ProtobufRpcServiceArtifactId(val packageName: String?, val serviceName: String) :
+    ArtifactId<ProtobufRpcServiceArtifact> {
     override val artifactType = ProtobufRpcServiceArtifact::class
 
     val fullyQualifiedName: String = packageName?.let { "$it.$serviceName" } ?: serviceName

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoDeclaration.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoDeclaration.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.artifact.schemas.protobuf
 
-data class ProtoDeclaration(
-    val name: String,
-    val contents: String,
-)
+data class ProtoDeclaration(val name: String, val contents: String)

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoFileArtifactId.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtoFileArtifactId.kt
@@ -2,10 +2,7 @@ package io.github.lmliam.microsmith.artifact.schemas.protobuf
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 
-data class ProtoFileArtifactId(
-    val packageName: String?,
-    val typeName: String,
-) : ArtifactId<ProtoFileArtifact> {
+data class ProtoFileArtifactId(val packageName: String?, val typeName: String) : ArtifactId<ProtoFileArtifact> {
     override val artifactType = ProtoFileArtifact::class
 
     val fullyQualifiedName: String = packageName?.let { "$it.$typeName" } ?: typeName

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtobufArtifactContributor.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/ProtobufArtifactContributor.kt
@@ -12,8 +12,8 @@ class ProtobufArtifactContributor : ArtifactContributor<ResolvedProtobufSchemaMo
 
     override val resolvedType = ResolvedProtobufSchemaModel::class
 
-    override fun contribute(model: ResolvedProtobufSchemaModel): List<ArtifactContribution<*>> {
-        return model.schemas.map { resolvedSchema ->
+    override fun contribute(model: ResolvedProtobufSchemaModel): List<ArtifactContribution<*>> =
+        model.schemas.map { resolvedSchema ->
             val declarationHandler = declarationHandlerRegistry.resolve(resolvedSchema.schema.schema)
             declarationHandler.validate(resolvedSchema.schema, resolvedSchema.qualifiedName)
 
@@ -32,5 +32,4 @@ class ProtobufArtifactContributor : ArtifactContributor<ResolvedProtobufSchemaMo
                 ),
             )
         }
-    }
 }

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/MessageEmissionValidator.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/MessageEmissionValidator.kt
@@ -18,39 +18,19 @@ internal object MessageEmissionValidator {
     }
 
     private fun requireUniqueFieldNames(message: Message) {
-        val duplicates =
-            collectFieldNameUsages(message)
-                .groupBy(keySelector = Pair<String, String>::first, valueTransform = Pair<String, String>::second)
-                .filterValues { it.size > 1 }
-
-        require(duplicates.isEmpty()) {
-            val details =
-                duplicates
-                    .toSortedMap()
-                    .entries
-                    .joinToString("; ") { (duplicateName, locations) ->
-                        "$duplicateName (${locations.joinToString()})"
-                    }
-            "Duplicate field names in message '${message.name}': $details"
-        }
+        requireUniqueUsages(
+            messageName = message.name,
+            label = "field names",
+            usages = collectFieldNameUsages(message),
+        )
     }
 
     private fun requireUniqueFieldNumbers(message: Message) {
-        val duplicates =
-            collectFieldNumberUsages(message)
-                .groupBy(keySelector = Pair<Int, String>::first, valueTransform = Pair<Int, String>::second)
-                .filterValues { it.size > 1 }
-
-        require(duplicates.isEmpty()) {
-            val details =
-                duplicates
-                    .toSortedMap()
-                    .entries
-                    .joinToString("; ") { (duplicateNumber, locations) ->
-                        "$duplicateNumber (${locations.joinToString()})"
-                    }
-            "Duplicate field numbers in message '${message.name}': $details"
-        }
+        requireUniqueUsages(
+            messageName = message.name,
+            label = "field numbers",
+            usages = collectFieldNumberUsages(message),
+        )
     }
 
     private fun requireUniqueOneofNames(message: Message) {
@@ -76,6 +56,28 @@ internal object MessageEmissionValidator {
             oneof.fields.forEach { field ->
                 add(field.index to "oneof '${oneof.name}' field '${field.name}'")
             }
+        }
+    }
+
+    private fun <Key : Comparable<Key>> requireUniqueUsages(
+        messageName: String,
+        label: String,
+        usages: List<Pair<Key, String>>,
+    ) {
+        val duplicates =
+            usages
+                .groupBy(keySelector = Pair<Key, String>::first, valueTransform = Pair<Key, String>::second)
+                .filterValues { it.size > 1 }
+
+        require(duplicates.isEmpty()) {
+            val details =
+                duplicates
+                    .toSortedMap()
+                    .entries
+                    .joinToString("; ") { (duplicateKey, locations) ->
+                        "$duplicateKey (${locations.joinToString()})"
+                    }
+            "Duplicate $label in message '$messageName': $details"
         }
     }
 }

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufDeclarationHandlerRegistry.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufDeclarationHandlerRegistry.kt
@@ -3,15 +3,11 @@ package io.github.lmliam.microsmith.artifact.schemas.protobuf.emission
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.types.Type
 import kotlin.reflect.KClass
 
-internal class ProtobufDeclarationHandlerRegistry(
-    handlers: List<ProtobufDeclarationHandler<*>> = defaultHandlers,
-) {
+internal class ProtobufDeclarationHandlerRegistry(handlers: List<ProtobufDeclarationHandler<*>> = defaultHandlers) {
     private val handlersByType = indexHandlers(handlers)
 
-    fun resolve(type: Type): ProtobufDeclarationHandler<Type> {
-        return handlersByType[type::class]?.cast()
-            ?: error("No protobuf declaration support registered for ${type::class.qualifiedName}.")
-    }
+    fun resolve(type: Type): ProtobufDeclarationHandler<Type> = handlersByType[type::class]?.cast()
+        ?: error("No protobuf declaration support registered for ${type::class.qualifiedName}.")
 
     private fun indexHandlers(
         handlers: List<ProtobufDeclarationHandler<*>>,
@@ -26,9 +22,8 @@ internal class ProtobufDeclarationHandlerRegistry(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun ProtobufDeclarationHandler<*>.cast(): ProtobufDeclarationHandler<Type> {
-        return this as ProtobufDeclarationHandler<Type>
-    }
+    private fun ProtobufDeclarationHandler<*>.cast(): ProtobufDeclarationHandler<Type> =
+        this as ProtobufDeclarationHandler<Type>
 
     private companion object {
         val defaultHandlers = listOf(MessageDeclarationHandler, EnumDeclarationHandler)

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ReservedSpan.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ReservedSpan.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.artifact.schemas.protobuf.emission
 
-internal data class ReservedSpan(
-    val description: String,
-    val range: IntRange,
-)
+internal data class ReservedSpan(val description: String, val range: IntRange)

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ReservedUsageCollisionValidator.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ReservedUsageCollisionValidator.kt
@@ -86,14 +86,17 @@ internal object ReservedUsageCollisionValidator {
             description = reserved.index.toString(),
             range = reserved.index..reserved.index,
         )
+
         is ReservedRange -> ReservedSpan(
             description = "${reserved.indexRange.first} to ${reserved.indexRange.last}",
             range = reserved.indexRange,
         )
+
         is ReservedToMax -> ReservedSpan(
             description = "${reserved.from} to max",
             range = reserved.from..ProtobufFieldNumbers.MAX_FIELD_NUMBER,
         )
+
         is ReservedName -> error("Reserved names do not produce numeric spans.")
     }
 }

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ReservedUsageOwner.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ReservedUsageOwner.kt
@@ -1,15 +1,10 @@
 package io.github.lmliam.microsmith.artifact.schemas.protobuf.emission
 
-internal data class ReservedUsageOwner(
-    val kind: Kind,
-    val name: String,
-) {
+internal data class ReservedUsageOwner(val kind: Kind, val name: String) {
     val displayName: String
         get() = kind.displayName
 
-    enum class Kind(
-        val displayName: String,
-    ) {
+    enum class Kind(val displayName: String) {
         MESSAGE("Message"),
         ENUM("Enum"),
     }

--- a/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/render/ProtobufFieldRenderer.kt
+++ b/modules/artifact-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/render/ProtobufFieldRenderer.kt
@@ -19,8 +19,11 @@ internal object ProtobufFieldRenderer {
             is ScalarField -> append(
                 "${ProtobufValueTypeRenderer.render(field.primitive)} ${field.name} = ${field.index};",
             )
+
             is ReferenceField -> append("${field.reference.name} ${field.name} = ${field.index};")
+
             is MapField -> append("${ProtobufValueTypeRenderer.render(field.type)} ${field.name} = ${field.index};")
+
             is OneofField -> invalidTopLevelOneofField(field.name)
         }
     }

--- a/modules/artifact-schemas-protobuf/src/test/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufDeclarationHandlerRegistryTests.kt
+++ b/modules/artifact-schemas-protobuf/src/test/kotlin/io/github/lmliam/microsmith/artifact/schemas/protobuf/emission/ProtobufDeclarationHandlerRegistryTests.kt
@@ -28,9 +28,7 @@ class ProtobufDeclarationHandlerRegistryTests :
         }
     })
 
-private data class TestType(
-    override val name: String = "Test",
-) : Type
+private data class TestType(override val name: String = "Test") : Type
 
 private object TestDeclarationHandler : ProtobufDeclarationHandler<TestType> {
     override val type = TestType::class

--- a/modules/artifact-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/asp/DotnetAspArtifactContributor.kt
+++ b/modules/artifact-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/asp/DotnetAspArtifactContributor.kt
@@ -9,8 +9,10 @@ import io.github.lmliam.microsmith.resolve.services.dotnet.asp.DotnetAspWorkspac
 class DotnetAspArtifactContributor : ArtifactContributor<DotnetAspWorkspace> {
     override val resolvedType = DotnetAspWorkspace::class
 
-    override fun contribute(model: DotnetAspWorkspace): List<ArtifactContribution<*>> {
-        return model.servicesByName.values.sortedBy { it.name }.mapIndexed { index, service ->
+    override fun contribute(model: DotnetAspWorkspace): List<ArtifactContribution<*>> =
+        model.servicesByName.values.sortedBy {
+            it.name
+        }.mapIndexed { index, service ->
             val httpPort = BASE_HTTP_PORT + (index * PORT_STRIDE)
             DotnetAspServiceContribution(
                 artifactId = DotnetAspServiceArtifactId(service.solutionName, service.projectName),
@@ -21,7 +23,6 @@ class DotnetAspArtifactContributor : ArtifactContributor<DotnetAspWorkspace> {
                 httpsPort = httpPort + 1,
             )
         }
-    }
 
     private companion object {
         const val BASE_HTTP_PORT = 5000

--- a/modules/artifact-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/asp/DotnetAspServiceArtifactId.kt
+++ b/modules/artifact-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/asp/DotnetAspServiceArtifactId.kt
@@ -2,9 +2,7 @@ package io.github.lmliam.microsmith.artifact.services.dotnet.asp
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 
-data class DotnetAspServiceArtifactId(
-    val solutionName: String,
-    val projectName: String,
-) : ArtifactId<DotnetAspServiceArtifact> {
+data class DotnetAspServiceArtifactId(val solutionName: String, val projectName: String) :
+    ArtifactId<DotnetAspServiceArtifact> {
     override val artifactType = DotnetAspServiceArtifact::class
 }

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReference.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReference.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 
-data class DotnetPackageReference(
-    val name: String,
-    val version: String?,
-)
+data class DotnetPackageReference(val name: String, val version: String?)

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReferencesArtifactId.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageReferencesArtifactId.kt
@@ -2,8 +2,6 @@ package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 
-data class DotnetPackageReferencesArtifactId(
-    val serviceName: String,
-) : ArtifactId<DotnetPackageReferencesArtifact> {
+data class DotnetPackageReferencesArtifactId(val serviceName: String) : ArtifactId<DotnetPackageReferencesArtifact> {
     override val artifactType = DotnetPackageReferencesArtifact::class
 }

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersion.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersion.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 
-data class DotnetPackageVersion(
-    val name: String,
-    val version: String,
-)
+data class DotnetPackageVersion(val name: String, val version: String)

--- a/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersionsArtifactId.kt
+++ b/modules/artifact-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/packages/DotnetPackageVersionsArtifactId.kt
@@ -2,8 +2,6 @@ package io.github.lmliam.microsmith.artifact.services.dotnet.packages
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactId
 
-data class DotnetPackageVersionsArtifactId(
-    val solutionName: String,
-) : ArtifactId<DotnetPackageVersionsArtifact> {
+data class DotnetPackageVersionsArtifactId(val solutionName: String) : ArtifactId<DotnetPackageVersionsArtifact> {
     override val artifactType = DotnetPackageVersionsArtifact::class
 }

--- a/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildItem.kt
+++ b/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildItem.kt
@@ -1,10 +1,6 @@
 package io.github.lmliam.microsmith.artifact.services.dotnet.msbuild
 
-class MsBuildItem(
-    val itemName: String,
-    val include: String,
-    attributes: Map<String, String> = emptyMap(),
-) {
+class MsBuildItem(val itemName: String, val include: String, attributes: Map<String, String> = emptyMap()) {
     val attributes: Map<String, String> = attributes.toMap()
 
     init {
@@ -12,12 +8,10 @@ class MsBuildItem(
         this.attributes.keys.forEach(MsBuildNames::requireAttributeName)
     }
 
-    override fun equals(other: Any?): Boolean {
-        return other is MsBuildItem &&
-            itemName == other.itemName &&
-            include == other.include &&
-            attributes == other.attributes
-    }
+    override fun equals(other: Any?): Boolean = other is MsBuildItem &&
+        itemName == other.itemName &&
+        include == other.include &&
+        attributes == other.attributes
 
     override fun hashCode(): Int {
         var result = itemName.hashCode()
@@ -26,7 +20,5 @@ class MsBuildItem(
         return result
     }
 
-    override fun toString(): String {
-        return "MsBuildItem(itemName=$itemName, include=$include, attributes=$attributes)"
-    }
+    override fun toString(): String = "MsBuildItem(itemName=$itemName, include=$include, attributes=$attributes)"
 }

--- a/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildProjectArtifactAssembler.kt
+++ b/modules/artifact-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/artifact/services/dotnet/msbuild/MsBuildProjectArtifactAssembler.kt
@@ -76,7 +76,4 @@ class MsBuildProjectArtifactAssembler : ArtifactAssembler<MsBuildProjectArtifact
     }
 }
 
-private data class MsBuildItemIdentity(
-    val itemName: String,
-    val include: String,
-)
+private data class MsBuildItemIdentity(val itemName: String, val include: String)

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblerRegistry.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblerRegistry.kt
@@ -3,18 +3,15 @@ package io.github.lmliam.microsmith.artifact.core
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
-internal class ArtifactAssemblerRegistry(
-    assemblers: List<ArtifactAssembler<*>> = loadArtifactAssemblers(),
-) {
+internal class ArtifactAssemblerRegistry(assemblers: List<ArtifactAssembler<*>> = loadArtifactAssemblers()) {
     private val assemblersByType = indexAssemblers(assemblers)
 
-    fun resolve(artifactId: ArtifactId<out Artifact>): ArtifactAssembler<Artifact> {
-        return assemblersByType[artifactId.artifactType]
+    fun resolve(artifactId: ArtifactId<out Artifact>): ArtifactAssembler<Artifact> =
+        assemblersByType[artifactId.artifactType]
             ?.cast()
             ?: error(
                 "No artifact assembler found for artifact type: ${artifactId.artifactType}",
             )
-    }
 
     private fun indexAssemblers(
         assemblers: List<ArtifactAssembler<*>>,
@@ -32,9 +29,7 @@ internal class ArtifactAssemblerRegistry(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun ArtifactAssembler<*>.cast(): ArtifactAssembler<Artifact> {
-        return this as ArtifactAssembler<Artifact>
-    }
+    private fun ArtifactAssembler<*>.cast(): ArtifactAssembler<Artifact> = this as ArtifactAssembler<Artifact>
 
     private fun formatType(type: KClass<out Artifact>): String = type.qualifiedName ?: type.toString()
 }

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblyService.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblyService.kt
@@ -15,9 +15,8 @@ class ArtifactAssemblyService {
         this.assemblerRegistry = assemblerRegistry
     }
 
-    fun assemble(contributions: List<ArtifactContribution<out Artifact>>): ArtifactAssembly {
-        return assembleRetaining(emptyList(), contributions)
-    }
+    fun assemble(contributions: List<ArtifactContribution<out Artifact>>): ArtifactAssembly =
+        assembleRetaining(emptyList(), contributions)
 
     fun assembleRetaining(
         retainedArtifacts: List<Artifact>,
@@ -49,7 +48,6 @@ class ArtifactAssemblyService {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun ArtifactContribution<out Artifact>.cast(): ArtifactContribution<Artifact> {
-        return this as ArtifactContribution<Artifact>
-    }
+    private fun ArtifactContribution<out Artifact>.cast(): ArtifactContribution<Artifact> =
+        this as ArtifactContribution<Artifact>
 }

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactContributionService.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactContributionService.kt
@@ -13,20 +13,16 @@ class ArtifactContributionService {
         this.contributorRegistry = contributorRegistry
     }
 
-    fun contribute(models: List<ResolvedModel>): List<ArtifactContribution<out Artifact>> {
-        return models
-            .sortedBy { it::class.qualifiedName ?: it::class.toString() }
-            .flatMap { model ->
-                contributorRegistry.resolve(model).flatMap { contributor ->
-                    contributor.contributeUnchecked(model)
-                }
+    fun contribute(models: List<ResolvedModel>): List<ArtifactContribution<out Artifact>> = models
+        .sortedBy { it::class.qualifiedName ?: it::class.toString() }
+        .flatMap { model ->
+            contributorRegistry.resolve(model).flatMap { contributor ->
+                contributor.contributeUnchecked(model)
             }
-    }
+        }
 }
 
 @Suppress("UNCHECKED_CAST")
 private fun ArtifactContributor<ResolvedModel>.contributeUnchecked(
     model: ResolvedModel,
-): List<ArtifactContribution<out Artifact>> {
-    return (this as ArtifactContributor<ResolvedModel>).contribute(model)
-}
+): List<ArtifactContribution<out Artifact>> = (this as ArtifactContributor<ResolvedModel>).contribute(model)

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactContributorRegistry.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactContributorRegistry.kt
@@ -4,16 +4,13 @@ import io.github.lmliam.microsmith.resolve.core.ResolvedModel
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
-internal class ArtifactContributorRegistry(
-    contributors: List<ArtifactContributor<*>> = loadArtifactContributors(),
-) {
+internal class ArtifactContributorRegistry(contributors: List<ArtifactContributor<*>> = loadArtifactContributors()) {
     private val contributorsByResolvedType = indexContributors(contributors)
 
-    fun resolve(model: ResolvedModel): List<ArtifactContributor<ResolvedModel>> {
-        return contributorsByResolvedType[model::class]
+    fun resolve(model: ResolvedModel): List<ArtifactContributor<ResolvedModel>> =
+        contributorsByResolvedType[model::class]
             ?.map { it.cast() }
             .orEmpty()
-    }
 
     private fun indexContributors(
         contributors: List<ArtifactContributor<*>>,
@@ -40,9 +37,8 @@ internal class ArtifactContributorRegistry(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun ArtifactContributor<*>.cast(): ArtifactContributor<ResolvedModel> {
-        return this as ArtifactContributor<ResolvedModel>
-    }
+    private fun ArtifactContributor<*>.cast(): ArtifactContributor<ResolvedModel> =
+        this as ArtifactContributor<ResolvedModel>
 
     private fun formatType(type: KClass<out ResolvedModel>): String = type.qualifiedName ?: type.toString()
 }

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifact.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifact.kt
@@ -2,10 +2,7 @@ package io.github.lmliam.microsmith.artifact.files
 
 import io.github.lmliam.microsmith.artifact.core.Artifact
 
-class BinaryFileArtifact(
-    override val id: BinaryFileArtifactId,
-    contents: ByteArray,
-) : Artifact {
+class BinaryFileArtifact(override val id: BinaryFileArtifactId, contents: ByteArray) : Artifact {
     private val bytes = contents.copyOf()
 
     val copiedContents: ByteArray

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactContribution.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactContribution.kt
@@ -2,10 +2,8 @@ package io.github.lmliam.microsmith.artifact.files
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
 
-class BinaryFileArtifactContribution(
-    override val artifactId: BinaryFileArtifactId,
-    contents: ByteArray,
-) : ArtifactContribution<BinaryFileArtifact> {
+class BinaryFileArtifactContribution(override val artifactId: BinaryFileArtifactId, contents: ByteArray) :
+    ArtifactContribution<BinaryFileArtifact> {
     private val bytes = contents.copyOf()
 
     val copiedContents: ByteArray

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactId.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/BinaryFileArtifactId.kt
@@ -5,9 +5,7 @@ import java.nio.file.Path
 
 private val defaultBinaryFileOutputRoot = Path.of(".")
 
-data class BinaryFileArtifactId(
-    val relativePath: Path,
-    val outputRoot: Path = defaultBinaryFileOutputRoot,
-) : ArtifactId<BinaryFileArtifact> {
+data class BinaryFileArtifactId(val relativePath: Path, val outputRoot: Path = defaultBinaryFileOutputRoot) :
+    ArtifactId<BinaryFileArtifact> {
     override val artifactType = BinaryFileArtifact::class
 }

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifact.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifact.kt
@@ -2,7 +2,4 @@ package io.github.lmliam.microsmith.artifact.files
 
 import io.github.lmliam.microsmith.artifact.core.Artifact
 
-data class TextFileArtifact(
-    override val id: TextFileArtifactId,
-    val contents: String,
-) : Artifact
+data class TextFileArtifact(override val id: TextFileArtifactId, val contents: String) : Artifact

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactContribution.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactContribution.kt
@@ -2,7 +2,5 @@ package io.github.lmliam.microsmith.artifact.files
 
 import io.github.lmliam.microsmith.artifact.core.ArtifactContribution
 
-data class TextFileArtifactContribution(
-    override val artifactId: TextFileArtifactId,
-    val contents: String,
-) : ArtifactContribution<TextFileArtifact>
+data class TextFileArtifactContribution(override val artifactId: TextFileArtifactId, val contents: String) :
+    ArtifactContribution<TextFileArtifact>

--- a/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactId.kt
+++ b/modules/artifact/src/main/kotlin/io/github/lmliam/microsmith/artifact/files/TextFileArtifactId.kt
@@ -5,9 +5,7 @@ import java.nio.file.Path
 
 private val defaultTextFileOutputRoot = Path.of(".")
 
-data class TextFileArtifactId(
-    val relativePath: Path,
-    val outputRoot: Path = defaultTextFileOutputRoot,
-) : ArtifactId<TextFileArtifact> {
+data class TextFileArtifactId(val relativePath: Path, val outputRoot: Path = defaultTextFileOutputRoot) :
+    ArtifactId<TextFileArtifact> {
     override val artifactType = TextFileArtifact::class
 }

--- a/modules/artifact/src/test/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblyServiceTests.kt
+++ b/modules/artifact/src/test/kotlin/io/github/lmliam/microsmith/artifact/core/ArtifactAssemblyServiceTests.kt
@@ -10,38 +10,30 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import java.nio.file.Path
 
-private data class AlphaResolved(
-    val name: String,
-) : ResolvedModel
+private data class AlphaResolved(val name: String) : ResolvedModel
 
-private data class BetaResolved(
-    val name: String,
-) : ResolvedModel
+private data class BetaResolved(val name: String) : ResolvedModel
 
 private class AlphaContributor : ArtifactContributor<AlphaResolved> {
     override val resolvedType = AlphaResolved::class
 
-    override fun contribute(model: AlphaResolved): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            TextFileArtifactContribution(
-                artifactId = TextFileArtifactId(relativePath = Path.of("alpha.txt")),
-                contents = model.name,
-            ),
-        )
-    }
+    override fun contribute(model: AlphaResolved): List<ArtifactContribution<out Artifact>> = listOf(
+        TextFileArtifactContribution(
+            artifactId = TextFileArtifactId(relativePath = Path.of("alpha.txt")),
+            contents = model.name,
+        ),
+    )
 }
 
 private class BetaContributor : ArtifactContributor<BetaResolved> {
     override val resolvedType = BetaResolved::class
 
-    override fun contribute(model: BetaResolved): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            TextFileArtifactContribution(
-                artifactId = TextFileArtifactId(relativePath = Path.of("beta.txt")),
-                contents = model.name,
-            ),
-        )
-    }
+    override fun contribute(model: BetaResolved): List<ArtifactContribution<out Artifact>> = listOf(
+        TextFileArtifactContribution(
+            artifactId = TextFileArtifactId(relativePath = Path.of("beta.txt")),
+            contents = model.name,
+        ),
+    )
 }
 
 class ArtifactAssemblyServiceTests :

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/MicrosmithCli.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/MicrosmithCli.kt
@@ -98,15 +98,20 @@ internal class MicrosmithCli(
         }
 
         is ErrorCommand -> usageErrorHandler.execute(parsed)
+
         is RunCommand -> runCommandHandler.execute(parsed)
+
         is DoctorCommand -> doctorCommandHandler.execute(parsed)
+
         is VersionCommand -> {
             stdout("microsmith ${versionProvider()}")
             0
         }
 
         is InitCommand -> initCommandHandler.execute(parsed)
+
         is IdeRefreshCommand -> ideRefreshCommandHandler.execute(parsed)
+
         is IdeDoctorCommand -> ideDoctorCommandHandler.execute(parsed)
     }
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/diagnostics/JsonValueRenderer.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/diagnostics/JsonValueRenderer.kt
@@ -2,9 +2,13 @@ package io.github.lmliam.microsmith.cli.diagnostics
 
 internal fun toJsonValue(value: Any?): String = when (value) {
     null -> "null"
+
     is String -> "\"${value.escapeJson()}\""
+
     is Number -> value.toString()
+
     is Boolean -> value.toString()
+
     is Map<*, *> ->
         value.entries.joinToString(
             prefix = "{",
@@ -15,6 +19,7 @@ internal fun toJsonValue(value: Any?): String = when (value) {
         }
 
     is Iterable<*> -> value.joinToString(prefix = "[", postfix = "]", separator = ",") { entry -> toJsonValue(entry) }
+
     else -> "\"${value.toString().escapeJson()}\""
 }
 
@@ -23,12 +28,19 @@ private fun String.escapeJson(): String {
     for (char in this) {
         when (char) {
             '\\' -> builder.append("\\\\")
+
             '"' -> builder.append("\\\"")
+
             '\b' -> builder.append("\\b")
+
             '\u000C' -> builder.append("\\f")
+
             '\n' -> builder.append("\\n")
+
             '\r' -> builder.append("\\r")
+
             '\t' -> builder.append("\\t")
+
             else -> {
                 if (char.code <= MAX_JSON_CONTROL_CHAR_CODE) {
                     builder.append("\\u%04x".format(char.code))

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/doctor/DoctorBootstrapStateCheck.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/doctor/DoctorBootstrapStateCheck.kt
@@ -129,12 +129,14 @@ internal object DoctorBootstrapStateCheck {
         .map(Path::toString)
         .sorted()
 
-    private fun invalidManagedFiles(projectRoot: Path, managedFiles: List<Path>): List<String> = managedFiles
-        .filter(::managedPathExists)
-        .filterNot(::isManagedRegularFile)
-        .map(projectRoot::relativize)
-        .map(Path::toString)
-        .sorted()
+    private fun invalidManagedFiles(projectRoot: Path, managedFiles: List<Path>): List<String> =
+        managedFiles.asSequence()
+            .filter(::managedPathExists)
+            .filterNot(::isManagedRegularFile)
+            .map(projectRoot::relativize)
+            .map(Path::toString)
+            .sorted()
+            .toList()
 
     private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
 

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/doctor/DoctorEnvironmentChecks.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/doctor/DoctorEnvironmentChecks.kt
@@ -27,31 +27,29 @@ internal object DoctorEnvironmentChecks {
         )
     }
 
-    fun checkProviderDiscovery(providerValidator: () -> List<String>): DoctorCheckResult {
-        return try {
-            val errors = providerValidator()
-            if (errors.isEmpty()) {
-                DoctorCheckResult(
-                    id = "provider-discovery",
-                    status = DoctorCheckStatus.PASS,
-                    message = "Required built-in service providers are available.",
-                )
-            } else {
-                DoctorCheckResult(
-                    id = "provider-discovery",
-                    status = DoctorCheckStatus.FAIL,
-                    message = "Required built-in service providers are missing.",
-                    details = mapOf("errors" to errors.joinToString(" | ")),
-                )
-            }
-        } catch (error: ServiceConfigurationError) {
+    fun checkProviderDiscovery(providerValidator: () -> List<String>): DoctorCheckResult = try {
+        val errors = providerValidator()
+        if (errors.isEmpty()) {
+            DoctorCheckResult(
+                id = "provider-discovery",
+                status = DoctorCheckStatus.PASS,
+                message = "Required built-in service providers are available.",
+            )
+        } else {
             DoctorCheckResult(
                 id = "provider-discovery",
                 status = DoctorCheckStatus.FAIL,
-                message = "Service provider loading failed.",
-                details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
+                message = "Required built-in service providers are missing.",
+                details = mapOf("errors" to errors.joinToString(" | ")),
             )
         }
+    } catch (error: ServiceConfigurationError) {
+        DoctorCheckResult(
+            id = "provider-discovery",
+            status = DoctorCheckStatus.FAIL,
+            message = "Service provider loading failed.",
+            details = mapOf("error" to (error.message ?: error::class.simpleName.orEmpty())),
+        )
     }
 
     fun checkDirectoryWritable(id: String, directory: Path): DoctorCheckResult = runCatching {

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/eventlog/EventLogWriter.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/eventlog/EventLogWriter.kt
@@ -1,10 +1,10 @@
 package io.github.lmliam.microsmith.cli.eventlog
 
 import io.github.lmliam.microsmith.cli.diagnostics.toJsonValue
+import io.github.lmliam.microsmith.cli.support.sha256IfRegularFile
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
-import java.security.MessageDigest
 import java.time.Instant
 
 internal object EventLogWriter {
@@ -16,7 +16,7 @@ internal object EventLogWriter {
                 "status" to event.status.wireValue,
                 "exitCode" to event.exitCode,
                 "scriptPath" to event.scriptPath.toAbsolutePath().normalize().toString(),
-                "scriptSha256" to sha256IfPresent(event.scriptPath),
+                "scriptSha256" to sha256IfRegularFile(event.scriptPath),
                 "outputPath" to event.outputPath.toAbsolutePath().normalize().toString(),
                 "pluginCoordinates" to event.pluginCoordinates.toList().sorted(),
                 "pluginJars" to event.pluginJars.map { it.toAbsolutePath().normalize().toString() }.sorted(),
@@ -38,25 +38,5 @@ internal object EventLogWriter {
             StandardOpenOption.APPEND,
             StandardOpenOption.WRITE,
         )
-    }
-
-    private fun sha256IfPresent(path: Path): String? {
-        val normalized = path.toAbsolutePath().normalize()
-        if (!Files.exists(normalized) || !Files.isRegularFile(normalized)) {
-            return null
-        }
-
-        val digest = MessageDigest.getInstance("SHA-256")
-        Files.newInputStream(normalized).use { input ->
-            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-            while (true) {
-                val read = input.read(buffer)
-                if (read == -1) {
-                    break
-                }
-                digest.update(buffer, 0, read)
-            }
-        }
-        return digest.digest().joinToString(separator = "") { "%02x".format(it) }
     }
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/execution/InitSummaryEmitter.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/execution/InitSummaryEmitter.kt
@@ -86,11 +86,13 @@ internal object InitSummaryEmitter {
                     "IDE support: apply plugin id '$GRADLE_PLUGIN_ID', configure 'microsmith { ... }', " +
                     "and run './gradlew microsmithGenerate'.",
             )
+
             JvmNativeBuildSystem.MAVEN -> emitter.info(
                 "Maven repository detected. Prefer the native Maven plugin path when you want imported-project " +
                     "IDE support: add '$MICROSMITH_RUNTIME_SCRIPTING_COORDINATE' as a provided dependency, " +
                     "configure '$MICROSMITH_MAVEN_PLUGIN_COORDINATE', and run 'mvn microsmith:generate'.",
             )
+
             JvmNativeBuildSystem.SBT -> emitter.info(
                 "sbt repository detected. Prefer the native sbt plugin path when you want build-aligned " +
                     "generation: add '$MICROSMITH_GROUP' % '$MICROSMITH_SBT_PLUGIN_ARTIFACT' in project/plugins.sbt, " +

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/execution/RunCompletionReporter.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/execution/RunCompletionReporter.kt
@@ -10,9 +10,7 @@ import io.github.lmliam.microsmith.runtime.scripting.model.ScriptRunResult
 import io.github.lmliam.microsmith.runtime.scripting.model.ScriptRunSuccess
 import java.nio.file.Path
 
-internal class RunCompletionReporter(
-    private val eventLogWriter: (Path, RunEventLogEntry) -> Unit,
-) {
+internal class RunCompletionReporter(private val eventLogWriter: (Path, RunEventLogEntry) -> Unit) {
     fun complete(
         command: RunCommand,
         emitter: CliDiagnosticEmitter,

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/ide/ManagedIdeHelperFileWriter.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/ide/ManagedIdeHelperFileWriter.kt
@@ -10,6 +10,7 @@ internal class ManagedIdeHelperFileWriter {
     fun ensureManagedDirectory(path: Path) {
         when {
             managedPathExists(path) && isManagedDirectory(path) -> return
+
             managedPathExists(path) ->
                 throw IdeHelperConflictException("IDE helper directory '$path' exists but is not a directory.")
 
@@ -32,18 +33,16 @@ internal class ManagedIdeHelperFileWriter {
 
     private fun managedPathExists(path: Path): Boolean = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
 
-    private fun managedFileContentMatches(path: Path, normalizedContent: String): Boolean {
-        return try {
-            if (!isManagedRegularFile(path)) {
-                false
-            } else {
-                Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n") == normalizedContent
-            }
-        } catch (_: IOException) {
+    private fun managedFileContentMatches(path: Path, normalizedContent: String): Boolean = try {
+        if (!isManagedRegularFile(path)) {
             false
-        } catch (_: SecurityException) {
-            false
+        } else {
+            Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n") == normalizedContent
         }
+    } catch (_: IOException) {
+        false
+    } catch (_: SecurityException) {
+        false
     }
 
     private fun isManagedDirectory(path: Path): Boolean = Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/BuiltInOnboardingProfileMatchers.kt
@@ -8,77 +8,66 @@ import kotlin.io.path.isRegularFile
 internal object BuiltInOnboardingProfileMatchers {
     fun all(
         dotnetMarkerFinder: (Path) -> String? = DotnetOnboardingMarkerFinder::find,
-    ): List<OnboardingProfileMatcher> {
-        return listOf(
-            rootMarkerMatcher(NodeOnboardingProfile, "package.json"),
-            rootMarkerMatcher(GoOnboardingProfile, "go.mod"),
-            javaMatcher(),
-            kotlinMatcher(),
-            scalaMatcher(),
-            rootMarkerMatcher(
-                PythonOnboardingProfile,
-                "pyproject.toml",
-                "requirements.txt",
-                "setup.py",
-                "setup.cfg",
-            ),
-            rootMarkerMatcher(RubyOnboardingProfile, "Gemfile", "gems.rb"),
-            rubyGemspecMatcher(),
-            rootMarkerMatcher(RustOnboardingProfile, "Cargo.toml"),
-            dotnetMatcher(dotnetMarkerFinder),
-        )
-    }
+    ): List<OnboardingProfileMatcher> = listOf(
+        rootMarkerMatcher(NodeOnboardingProfile, "package.json"),
+        rootMarkerMatcher(GoOnboardingProfile, "go.mod"),
+        javaMatcher(),
+        kotlinMatcher(),
+        scalaMatcher(),
+        rootMarkerMatcher(
+            PythonOnboardingProfile,
+            "pyproject.toml",
+            "requirements.txt",
+            "setup.py",
+            "setup.cfg",
+        ),
+        rootMarkerMatcher(RubyOnboardingProfile, "Gemfile", "gems.rb"),
+        rubyGemspecMatcher(),
+        rootMarkerMatcher(RustOnboardingProfile, "Cargo.toml"),
+        dotnetMatcher(dotnetMarkerFinder),
+    )
 
-    private fun dotnetMatcher(dotnetMarkerFinder: (Path) -> String?): OnboardingProfileMatcher {
-        return OnboardingProfileMatcher(DotnetOnboardingProfile) { projectRoot ->
+    private fun dotnetMatcher(dotnetMarkerFinder: (Path) -> String?): OnboardingProfileMatcher =
+        OnboardingProfileMatcher(DotnetOnboardingProfile) { projectRoot ->
             findDotnetMarkers(projectRoot, dotnetMarkerFinder)
         }
-    }
 
     private fun rootMarkerMatcher(
         profile: OnboardingProfile,
         vararg markerFileNames: String,
-    ): OnboardingProfileMatcher {
-        return OnboardingProfileMatcher(profile) { projectRoot ->
-            markerFileNames.filter { markerFileName ->
-                projectRoot.resolve(markerFileName).isRegularFile()
-            }
+    ): OnboardingProfileMatcher = OnboardingProfileMatcher(profile) { projectRoot ->
+        markerFileNames.filter { markerFileName ->
+            projectRoot.resolve(markerFileName).isRegularFile()
         }
     }
 
-    private fun rubyGemspecMatcher(): OnboardingProfileMatcher {
-        return OnboardingProfileMatcher(RubyOnboardingProfile) { projectRoot ->
+    private fun rubyGemspecMatcher(): OnboardingProfileMatcher =
+        OnboardingProfileMatcher(RubyOnboardingProfile) { projectRoot ->
             RubyOnboardingMarkerFinder.find(projectRoot)
         }
-    }
 
-    private fun javaMatcher(): OnboardingProfileMatcher {
-        return OnboardingProfileMatcher(JavaOnboardingProfile) { projectRoot ->
+    private fun javaMatcher(): OnboardingProfileMatcher =
+        OnboardingProfileMatcher(JavaOnboardingProfile) { projectRoot ->
             JavaOnboardingMarkerFinder.find(projectRoot)
         }
-    }
 
-    private fun kotlinMatcher(): OnboardingProfileMatcher {
-        return OnboardingProfileMatcher(KotlinOnboardingProfile) { projectRoot ->
+    private fun kotlinMatcher(): OnboardingProfileMatcher =
+        OnboardingProfileMatcher(KotlinOnboardingProfile) { projectRoot ->
             KotlinOnboardingMarkerFinder.find(projectRoot)
         }
-    }
 
-    private fun scalaMatcher(): OnboardingProfileMatcher {
-        return OnboardingProfileMatcher(ScalaOnboardingProfile) { projectRoot ->
+    private fun scalaMatcher(): OnboardingProfileMatcher =
+        OnboardingProfileMatcher(ScalaOnboardingProfile) { projectRoot ->
             ScalaOnboardingMarkerFinder.find(projectRoot)
         }
-    }
 
-    private fun findDotnetMarkers(projectRoot: Path, dotnetMarkerFinder: (Path) -> String?): List<String> {
-        return try {
-            dotnetMarkerFinder(projectRoot)?.let(::listOf).orEmpty()
-        } catch (_: IOException) {
-            emptyList()
-        } catch (_: UncheckedIOException) {
-            emptyList()
-        } catch (_: SecurityException) {
-            emptyList()
-        }
+    private fun findDotnetMarkers(projectRoot: Path, dotnetMarkerFinder: (Path) -> String?): List<String> = try {
+        dotnetMarkerFinder(projectRoot)?.let(::listOf).orEmpty()
+    } catch (_: IOException) {
+        emptyList()
+    } catch (_: UncheckedIOException) {
+        emptyList()
+    } catch (_: SecurityException) {
+        emptyList()
     }
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/JvmOnboardingMarkerFinder.kt
@@ -10,40 +10,38 @@ import java.nio.file.attribute.BasicFileAttributes
 import kotlin.io.path.isRegularFile
 
 internal object JvmOnboardingMarkerFinder {
-    fun find(projectRoot: Path, buildMarkers: List<Path>, sourceRootMatcher: (Path) -> Boolean): List<String> {
-        return try {
-            val matchedBuildMarkers =
-                buildMarkers
-                    .filter { markerPath ->
-                        projectRoot.resolve(markerPath).isRegularFile()
-                    }.map(Path::toString)
-            val rootSourceMarkers = findRootSourceMarkers(projectRoot, sourceRootMatcher)
+    fun find(projectRoot: Path, buildMarkers: List<Path>, sourceRootMatcher: (Path) -> Boolean): List<String> = try {
+        val matchedBuildMarkers =
+            buildMarkers
+                .filter { markerPath ->
+                    projectRoot.resolve(markerPath).isRegularFile()
+                }.map(Path::toString)
+        val rootSourceMarkers = findRootSourceMarkers(projectRoot, sourceRootMatcher)
 
-            when {
-                rootSourceMarkers.isNotEmpty() -> {
-                    (matchedBuildMarkers + rootSourceMarkers).sorted()
-                }
+        when {
+            rootSourceMarkers.isNotEmpty() -> {
+                (matchedBuildMarkers + rootSourceMarkers).sorted()
+            }
 
-                matchedBuildMarkers.isEmpty() -> {
+            matchedBuildMarkers.isEmpty() -> {
+                emptyList()
+            }
+
+            else -> {
+                val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot, sourceRootMatcher)
+                if (matchedModuleSourceMarkers.isEmpty()) {
                     emptyList()
-                }
-
-                else -> {
-                    val matchedModuleSourceMarkers = findModuleSourceMarkers(projectRoot, sourceRootMatcher)
-                    if (matchedModuleSourceMarkers.isEmpty()) {
-                        emptyList()
-                    } else {
-                        (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
-                    }
+                } else {
+                    (matchedBuildMarkers + matchedModuleSourceMarkers).sorted()
                 }
             }
-        } catch (_: IOException) {
-            emptyList()
-        } catch (_: UncheckedIOException) {
-            emptyList()
-        } catch (_: SecurityException) {
-            emptyList()
         }
+    } catch (_: IOException) {
+        emptyList()
+    } catch (_: UncheckedIOException) {
+        emptyList()
+    } catch (_: SecurityException) {
+        emptyList()
     }
 
     private fun findRootSourceMarkers(projectRoot: Path, sourceRootMatcher: (Path) -> Boolean): List<String> {
@@ -108,16 +106,14 @@ internal object JvmOnboardingMarkerFinder {
         return matchedMarkers.sorted()
     }
 
-    private fun isRootSourceMarker(relativeDirectory: Path, sourceRootMatcher: (Path) -> Boolean): Boolean {
-        return relativeDirectory.nameCount == ROOT_SOURCE_MARKER_DEPTH &&
+    private fun isRootSourceMarker(relativeDirectory: Path, sourceRootMatcher: (Path) -> Boolean): Boolean =
+        relativeDirectory.nameCount == ROOT_SOURCE_MARKER_DEPTH &&
             relativeDirectory.getName(0).toString() == SOURCE_ROOT_DIRECTORY_NAME &&
             sourceRootMatcher(relativeDirectory)
-    }
 
-    private fun isIgnoredNestedScanRootDirectory(relativeDirectory: Path): Boolean {
-        return relativeDirectory.nameCount == INFRASTRUCTURE_DIRECTORY_DEPTH &&
+    private fun isIgnoredNestedScanRootDirectory(relativeDirectory: Path): Boolean =
+        relativeDirectory.nameCount == INFRASTRUCTURE_DIRECTORY_DEPTH &&
             relativeDirectory.getName(0).toString() in IGNORED_NESTED_SCAN_ROOT_DIRECTORIES
-    }
 }
 
 private const val MODULE_SOURCE_SEARCH_DEPTH = 6

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileConflictValidator.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileConflictValidator.kt
@@ -12,13 +12,11 @@ internal object OnboardingProfileConflictValidator {
     private fun conflictingProfileIds(
         matchers: List<OnboardingProfileMatcher>,
         fallbackProfile: OnboardingProfile,
-    ): List<OnboardingProfileId> {
-        return matchers
-            .map(OnboardingProfileMatcher::profile)
-            .plus(fallbackProfile)
-            .groupBy(OnboardingProfile::id)
-            .filterValues { groupedProfiles -> groupedProfiles.distinct().size > 1 }
-            .keys
-            .sorted()
-    }
+    ): List<OnboardingProfileId> = matchers
+        .map(OnboardingProfileMatcher::profile)
+        .plus(fallbackProfile)
+        .groupBy(OnboardingProfile::id)
+        .filterValues { groupedProfiles -> groupedProfiles.distinct().size > 1 }
+        .keys
+        .sorted()
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileDetection.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileDetection.kt
@@ -10,8 +10,10 @@ internal fun OnboardingProfileDetection.describeForComment(): String = buildStri
     append("Detected repository profile: ${profile.displayName}")
     when (selectionReason) {
         OnboardingProfileSelectionReason.NO_MARKERS_MATCHED -> append(" (no repo markers matched)")
+
         OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS ->
             append(" (multiple repository markers matched: ${matchedMarkers.joinToString(separator = ", ")})")
+
         OnboardingProfileSelectionReason.MATCHED_PROFILE ->
             append(" via ${matchedMarkers.joinToString(separator = ", ")}")
     }
@@ -21,8 +23,10 @@ internal fun OnboardingProfileDetection.describeForSummary(): String = buildStri
     append(profile.displayName)
     when (selectionReason) {
         OnboardingProfileSelectionReason.NO_MARKERS_MATCHED -> Unit
+
         OnboardingProfileSelectionReason.AMBIGUOUS_MARKERS ->
             append(" (multiple markers matched: ${matchedMarkers.joinToString(separator = ", ")})")
+
         OnboardingProfileSelectionReason.MATCHED_PROFILE ->
             append(" (matched ${matchedMarkers.joinToString(separator = ", ")})")
     }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileMatch.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileMatch.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.cli.init
 
-internal data class OnboardingProfileMatch(
-    val profile: OnboardingProfile,
-    val matchedMarkers: List<String>,
-)
+internal data class OnboardingProfileMatch(val profile: OnboardingProfile, val matchedMarkers: List<String>)

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileMatcher.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/OnboardingProfileMatcher.kt
@@ -2,7 +2,4 @@ package io.github.lmliam.microsmith.cli.init
 
 import java.nio.file.Path
 
-internal data class OnboardingProfileMatcher(
-    val profile: OnboardingProfile,
-    val detect: (Path) -> List<String>,
-)
+internal data class OnboardingProfileMatcher(val profile: OnboardingProfile, val detect: (Path) -> List<String>)

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/RubyOnboardingMarkerFinder.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/init/RubyOnboardingMarkerFinder.kt
@@ -16,15 +16,13 @@ internal object RubyOnboardingMarkerFinder {
         emptyList()
     }
 
-    private fun findRootGemspecs(projectRoot: Path): List<String> {
-        return Files.newDirectoryStream(projectRoot) { candidate ->
-            Files.isRegularFile(candidate) && candidate.fileName.toString().endsWith(".gemspec")
-        }.use { directoryStream ->
-            directoryStream
-                .map(Path::getFileName)
-                .map(Path::toString)
-                .sorted()
-                .toList()
-        }
+    private fun findRootGemspecs(projectRoot: Path): List<String> = Files.newDirectoryStream(projectRoot) { candidate ->
+        Files.isRegularFile(candidate) && candidate.fileName.toString().endsWith(".gemspec")
+    }.use { directoryStream ->
+        directoryStream
+            .map(Path::getFileName)
+            .map(Path::toString)
+            .sorted()
+            .toList()
     }
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/parsing/DoctorCommandParser.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/parsing/DoctorCommandParser.kt
@@ -21,7 +21,9 @@ private fun parseDoctorOptions(args: List<String>, startIndex: Int): ParsedDocto
         val consumed =
             when (val token = args[index]) {
                 DIAGNOSTICS_OPTION -> state.consumeDiagnostics(args = args, index = index)
+
                 VERBOSE_OPTION -> state.consumeVerbose()
+
                 else -> {
                     state.consumeUnknownOption(token)
                     0

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/parsing/InitCommandParser.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/parsing/InitCommandParser.kt
@@ -32,10 +32,12 @@ private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOpt
                 DIAGNOSTICS_OPTION -> ParsedToken(
                     index + diagnosticOptions.consumeDiagnostics(args = args, index = index),
                 )
+
                 VERBOSE_OPTION ->
                     ParsedToken(
                         index + diagnosticOptions.consumeVerbose(),
                     )
+
                 REPO_ROOT_OPTION ->
                     parseRepoRootOption(
                         args = args,
@@ -45,6 +47,7 @@ private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOpt
                         projectRoot = parsedProjectRoot
                         projectRootSpecified = true
                     }
+
                 FORCE_OPTION ->
                     parseSingleOccurrenceFlag(
                         index = index,
@@ -53,6 +56,7 @@ private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOpt
                     ) {
                         force = true
                     }
+
                 SKIP_IDE_HELPER_OPTION ->
                     parseSingleOccurrenceFlag(
                         index = index,
@@ -61,6 +65,7 @@ private fun parseInitOptions(args: List<String>, startIndex: Int): ParsedInitOpt
                     ) {
                         skipIdeHelper = true
                     }
+
                 else -> ParsedToken(nextIndex = index, error = "Unknown option '$token'.")
             }
         if (parsedToken.error != null) {

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/AetherRemoteRepositoryFactory.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/AetherRemoteRepositoryFactory.kt
@@ -18,7 +18,6 @@ internal class AetherRemoteRepositoryFactory {
     }
 }
 
-@Suppress("UsePropertyAccessSyntax")
 private fun RemoteRepository.Builder.applyAuthentication(credentials: RepositoryCredentials) {
     /*
      * Kotlin property syntax is not usable here: the Java type exposes a package-private field and

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/LocalPluginResolver.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/LocalPluginResolver.kt
@@ -3,9 +3,7 @@ package io.github.lmliam.microsmith.cli.plugins
 import java.nio.file.Files
 import java.nio.file.Path
 
-internal class LocalPluginResolver(
-    private val checksumCalculator: (Path) -> String = ::sha256,
-) {
+internal class LocalPluginResolver(private val checksumCalculator: (Path) -> String = ::sha256) {
     fun resolveValidated(pluginJars: Set<Path>): List<LocalPluginJar> {
         val localPluginJars =
             pluginJars

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/MavenDependencyGraph.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/MavenDependencyGraph.kt
@@ -3,7 +3,4 @@ package io.github.lmliam.microsmith.cli.plugins
 import org.eclipse.aether.graph.DependencyNode
 import org.eclipse.aether.resolution.ArtifactResult
 
-internal data class MavenDependencyGraph(
-    val root: DependencyNode?,
-    val artifactResults: List<ArtifactResult>,
-)
+internal data class MavenDependencyGraph(val root: DependencyNode?, val artifactResults: List<ArtifactResult>)

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolutionChecksums.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolutionChecksums.kt
@@ -1,26 +1,10 @@
 package io.github.lmliam.microsmith.cli.plugins
 
-import java.nio.file.Files
 import java.nio.file.Path
-import java.security.MessageDigest
+import io.github.lmliam.microsmith.cli.support.sha256 as fileSha256
 
 private const val HEX_SHA256_LENGTH = 64
 
-internal fun sha256(path: Path): String {
-    val digest = MessageDigest.getInstance("SHA-256")
-    Files.newInputStream(path).use { input ->
-        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        while (true) {
-            val read = input.read(buffer)
-            if (read == -1) {
-                break
-            }
-            digest.update(buffer, 0, read)
-        }
-    }
-    return digest.digest().toHexString()
-}
+internal fun sha256(path: Path): String = fileSha256(path)
 
 internal fun isSha256(value: String): Boolean = value.length == HEX_SHA256_LENGTH && value.matches(Regex("^[a-f0-9]+$"))
-
-private fun ByteArray.toHexString(): String = joinToString(separator = "") { "%02x".format(it) }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolutionPaths.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolutionPaths.kt
@@ -18,9 +18,6 @@ internal fun defaultLockfilePath(scriptPath: Path): Path {
     val normalizedScriptPath = scriptPath.toAbsolutePath().normalize()
     val lockfileBaseName = normalizedScriptPath.fileName.toString().removeSuffix(".kts")
     val lockfileName = "$lockfileBaseName.plugins.lock"
-    val parent = normalizedScriptPath.parent
-    if (parent == null) {
-        return Path.of(lockfileName)
-    }
+    val parent = normalizedScriptPath.parent ?: return Path.of(lockfileName)
     return parent.resolve(lockfileName)
 }

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/RemotePluginResolutionAccumulator.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/plugins/RemotePluginResolutionAccumulator.kt
@@ -2,9 +2,7 @@ package io.github.lmliam.microsmith.cli.plugins
 
 import java.nio.file.Path
 
-internal class RemotePluginResolutionAccumulator(
-    private val checksumCalculator: (Path) -> String = ::sha256,
-) {
+internal class RemotePluginResolutionAccumulator(private val checksumCalculator: (Path) -> String = ::sha256) {
     fun resolve(
         coordinates: List<Coordinate>,
         offline: Boolean,

--- a/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/support/Sha256Files.kt
+++ b/modules/cli/src/main/kotlin/io/github/lmliam/microsmith/cli/support/Sha256Files.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.microsmith.cli.support
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+internal fun sha256(path: Path): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    Files.newInputStream(path).use { input ->
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = input.read(buffer)
+            if (read == -1) {
+                break
+            }
+            digest.update(buffer, 0, read)
+        }
+    }
+    return digest.digest().toHexString()
+}
+
+internal fun sha256IfRegularFile(path: Path): String? {
+    val normalized = path.toAbsolutePath().normalize()
+    if (!Files.isRegularFile(normalized)) {
+        return null
+    }
+    return sha256(normalized)
+}
+
+private fun ByteArray.toHexString(): String = joinToString(separator = "") { "%02x".format(it) }

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
@@ -115,7 +115,7 @@ class IdeHelperGeneratorTests :
 
         "escapes dollar signs in generated classpath literals" {
             val repoRoot = createTempDirectory("microsmith-ide-helper-path-escaping")
-            val runtimeJar = repoRoot.resolve($$"runtime/dollar$name.jar")
+            val runtimeJar = repoRoot.resolve("runtime/dollar\$name.jar")
             runtimeJar.parent.createDirectories()
             runtimeJar.writeText("jar-binary-placeholder")
 
@@ -126,7 +126,7 @@ class IdeHelperGeneratorTests :
                 )
 
                 val buildFile = repoRoot.resolve(".microsmith/ide/build.gradle.kts")
-                buildFile.readText().shouldContain($$"dollar\\$name.jar")
+                buildFile.readText().shouldContain("dollar\\\$name.jar")
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
             }

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/ide/IdeHelperGeneratorTests.kt
@@ -115,7 +115,7 @@ class IdeHelperGeneratorTests :
 
         "escapes dollar signs in generated classpath literals" {
             val repoRoot = createTempDirectory("microsmith-ide-helper-path-escaping")
-            val runtimeJar = repoRoot.resolve("runtime/dollar\$name.jar")
+            val runtimeJar = repoRoot.resolve($$"runtime/dollar$name.jar")
             runtimeJar.parent.createDirectories()
             runtimeJar.writeText("jar-binary-placeholder")
 
@@ -126,7 +126,7 @@ class IdeHelperGeneratorTests :
                 )
 
                 val buildFile = repoRoot.resolve(".microsmith/ide/build.gradle.kts")
-                buildFile.readText().shouldContain("dollar\\\$name.jar")
+                buildFile.readText().shouldContain($$"dollar\\$name.jar")
             } finally {
                 runCatching { repoRoot.deleteRecursively() }
             }

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/init/InitBootstrapTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/init/InitBootstrapTests.kt
@@ -5,7 +5,6 @@ import io.github.lmliam.microsmith.cli.ide.IdeHelperConflictException
 import io.github.lmliam.microsmith.cli.ide.IdeHelperRefreshResult
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolverGuardrailTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolverGuardrailTests.kt
@@ -106,9 +106,8 @@ class PluginResolverGuardrailTests :
                                 error("resolve() should not be called when sensitive value initialization fails.")
                             }
 
-                            override fun sensitiveValues(): Set<String> {
+                            override fun sensitiveValues(): Set<String> =
                                 throw IllegalArgumentException("Repository credentials file is invalid.")
-                            }
                         },
                     )
 
@@ -140,11 +139,9 @@ class PluginResolverGuardrailTests :
                                 error("resolve() should not be called when sensitive value initialization fails.")
                             }
 
-                            override fun sensitiveValues(): Set<String> {
-                                throw UncheckedIOException(
-                                    IOException("Repository credentials file could not be read."),
-                                )
-                            }
+                            override fun sensitiveValues(): Set<String> = throw UncheckedIOException(
+                                IOException("Repository credentials file could not be read."),
+                            )
                         },
                     )
 

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolverValidationTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/plugins/PluginResolverValidationTests.kt
@@ -78,9 +78,8 @@ class PluginResolverValidationTests :
                         ),
                         repositoryCredentialsResolver =
                         object : RepositoryCredentialsResolver {
-                            override fun resolve(repositoryUri: String): RepositoryCredentials? {
+                            override fun resolve(repositoryUri: String): RepositoryCredentials? =
                                 throw IllegalArgumentException("Repository credentials are invalid.")
-                            }
                         },
                         remotePluginResolver =
                         object : RemotePluginResolver {

--- a/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/provider/CliProviderValidatorTests.kt
+++ b/modules/cli/src/test/kotlin/io/github/lmliam/microsmith/cli/provider/CliProviderValidatorTests.kt
@@ -168,17 +168,13 @@ private class TextFileAssemblerStub : ArtifactAssembler<TextFileArtifact> {
 private class ProtoFileCompilerStub : ArtifactCompiler<ProtoFileArtifact> {
     override val artifactType = ProtoFileArtifact::class
 
-    override fun compile(artifact: ProtoFileArtifact): List<ArtifactContribution<out Artifact>> {
-        return emptyList()
-    }
+    override fun compile(artifact: ProtoFileArtifact): List<ArtifactContribution<out Artifact>> = emptyList()
 }
 
 private class ProtobufRpcCompilerStub : ArtifactCompiler<ProtobufRpcServiceArtifact> {
     override val artifactType = ProtobufRpcServiceArtifact::class
 
-    override fun compile(artifact: ProtobufRpcServiceArtifact): List<ArtifactContribution<out Artifact>> {
-        return emptyList()
-    }
+    override fun compile(artifact: ProtobufRpcServiceArtifact): List<ArtifactContribution<out Artifact>> = emptyList()
 }
 
 private class TextFileRendererStub : ArtifactRenderer<TextFileArtifact> {

--- a/modules/compile-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/rpc/ProtobufRpcServiceArtifactCompiler.kt
+++ b/modules/compile-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/rpc/ProtobufRpcServiceArtifactCompiler.kt
@@ -14,22 +14,20 @@ import io.github.lmliam.microsmith.compile.schemas.core.SchemasArtifactCompiler
 class ProtobufRpcServiceArtifactCompiler : SchemasArtifactCompiler<ProtobufRpcServiceArtifact> {
     override val artifactType = ProtobufRpcServiceArtifact::class
 
-    override fun compile(artifact: ProtobufRpcServiceArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            ProtoFileContribution(
-                artifactId = ProtoFileArtifactId(
-                    packageName = artifact.id.packageName,
-                    typeName = artifact.id.serviceName,
-                ),
+    override fun compile(artifact: ProtobufRpcServiceArtifact): List<ArtifactContribution<out Artifact>> = listOf(
+        ProtoFileContribution(
+            artifactId = ProtoFileArtifactId(
                 packageName = artifact.id.packageName,
-                imports = artifact.imports,
-                declarations = listOf(
-                    ProtoDeclaration(
-                        name = artifact.id.serviceName,
-                        contents = ProtobufServiceRenderer.render(artifact),
-                    ),
+                typeName = artifact.id.serviceName,
+            ),
+            packageName = artifact.id.packageName,
+            imports = artifact.imports,
+            declarations = listOf(
+                ProtoDeclaration(
+                    name = artifact.id.serviceName,
+                    contents = ProtobufServiceRenderer.render(artifact),
                 ),
             ),
-        )
-    }
+        ),
+    )
 }

--- a/modules/compile-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/ProtoFileArtifactCompiler.kt
+++ b/modules/compile-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/compile/schemas/protobuf/ProtoFileArtifactCompiler.kt
@@ -15,14 +15,12 @@ import java.nio.file.Path
 class ProtoFileArtifactCompiler : SchemasArtifactCompiler<ProtoFileArtifact> {
     override val artifactType = ProtoFileArtifact::class
 
-    override fun compile(artifact: ProtoFileArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            TextFileArtifactContribution(
-                artifactId = TextFileArtifactId(relativePath = artifact.relativePath()),
-                contents = ProtobufFileRenderer.render(artifact),
-            ),
-        )
-    }
+    override fun compile(artifact: ProtoFileArtifact): List<ArtifactContribution<out Artifact>> = listOf(
+        TextFileArtifactContribution(
+            artifactId = TextFileArtifactId(relativePath = artifact.relativePath()),
+            contents = ProtobufFileRenderer.render(artifact),
+        ),
+    )
 
     private fun ProtoFileArtifact.relativePath(): Path {
         val packagePath = id.packageName?.replace('.', '/')

--- a/modules/compile-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/asp/DotnetAspServiceArtifactCompiler.kt
+++ b/modules/compile-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/asp/DotnetAspServiceArtifactCompiler.kt
@@ -82,15 +82,15 @@ class DotnetAspServiceArtifactCompiler : ServicesArtifactCompiler<DotnetAspServi
         }
     """.trimIndent()
 
-    private fun renderLaunchSettingsFile(artifact: DotnetAspServiceArtifact): String = $$"""
+    private fun renderLaunchSettingsFile(artifact: DotnetAspServiceArtifact): String = """
         {
-          "$schema": "http://json.schemastore.org/launchsettings.json",
+          "${'$'}schema": "http://json.schemastore.org/launchsettings.json",
           "profiles": {
-            "$${artifact.id.projectName}": {
+            "${artifact.id.projectName}": {
               "commandName": "Project",
               "dotnetRunMessages": true,
               "launchBrowser": false,
-              "applicationUrl": "http://localhost:$${artifact.httpPort};https://localhost:$${artifact.httpsPort}",
+              "applicationUrl": "http://localhost:${artifact.httpPort};https://localhost:${artifact.httpsPort}",
               "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
               }

--- a/modules/compile-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/asp/DotnetAspServiceArtifactCompiler.kt
+++ b/modules/compile-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/asp/DotnetAspServiceArtifactCompiler.kt
@@ -22,40 +22,36 @@ class DotnetAspServiceArtifactCompiler : ServicesArtifactCompiler<DotnetAspServi
 
     override val artifactType = DotnetAspServiceArtifact::class
 
-    override fun compile(artifact: DotnetAspServiceArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            MsBuildProjectContribution(
-                artifactId = MsBuildProjectArtifactId(
-                    solutionName = artifact.id.solutionName,
-                    projectName = artifact.id.projectName,
-                    kind = MsBuildProjectKind.Project,
-                ),
-                projectAttributes = mapOf(MsBuildNames.SDK_ATTRIBUTE to "Microsoft.NET.Sdk.Web"),
-                properties = mapOf(
-                    MsBuildNames.IMPLICIT_USINGS_PROPERTY to "enable",
-                    MsBuildNames.NULLABLE_PROPERTY to "enable",
-                    MsBuildNames.TARGET_FRAMEWORK_PROPERTY to artifact.targetFrameworkMoniker,
-                ),
+    override fun compile(artifact: DotnetAspServiceArtifact): List<ArtifactContribution<out Artifact>> = listOf(
+        MsBuildProjectContribution(
+            artifactId = MsBuildProjectArtifactId(
+                solutionName = artifact.id.solutionName,
+                projectName = artifact.id.projectName,
+                kind = MsBuildProjectKind.Project,
             ),
-            textContribution(artifact, "Program.cs", renderProgramFile()),
-            textContribution(artifact, "appsettings.json", renderAppSettingsFile(artifact)),
-            textContribution(artifact, "Properties/launchSettings.json", renderLaunchSettingsFile(artifact)),
-        )
-    }
+            projectAttributes = mapOf(MsBuildNames.SDK_ATTRIBUTE to "Microsoft.NET.Sdk.Web"),
+            properties = mapOf(
+                MsBuildNames.IMPLICIT_USINGS_PROPERTY to "enable",
+                MsBuildNames.NULLABLE_PROPERTY to "enable",
+                MsBuildNames.TARGET_FRAMEWORK_PROPERTY to artifact.targetFrameworkMoniker,
+            ),
+        ),
+        textContribution(artifact, "Program.cs", renderProgramFile()),
+        textContribution(artifact, "appsettings.json", renderAppSettingsFile(artifact)),
+        textContribution(artifact, "Properties/launchSettings.json", renderLaunchSettingsFile(artifact)),
+    )
 
     private fun textContribution(
         artifact: DotnetAspServiceArtifact,
         relativePath: String,
         contents: String,
-    ): TextFileArtifactContribution {
-        return TextFileArtifactContribution(
-            artifactId = TextFileArtifactId(
-                relativePath = Path.of(relativePath),
-                outputRoot = artifact.outputRoot,
-            ),
-            contents = contents,
-        )
-    }
+    ): TextFileArtifactContribution = TextFileArtifactContribution(
+        artifactId = TextFileArtifactId(
+            relativePath = Path.of(relativePath),
+            outputRoot = artifact.outputRoot,
+        ),
+        contents = contents,
+    )
 
     private fun renderProgramFile(): String = """
         var builder = WebApplication.CreateBuilder(args);
@@ -86,15 +82,15 @@ class DotnetAspServiceArtifactCompiler : ServicesArtifactCompiler<DotnetAspServi
         }
     """.trimIndent()
 
-    private fun renderLaunchSettingsFile(artifact: DotnetAspServiceArtifact): String = """
+    private fun renderLaunchSettingsFile(artifact: DotnetAspServiceArtifact): String = $$"""
         {
-          "${'$'}schema": "http://json.schemastore.org/launchsettings.json",
+          "$schema": "http://json.schemastore.org/launchsettings.json",
           "profiles": {
-            "${artifact.id.projectName}": {
+            "$${artifact.id.projectName}": {
               "commandName": "Project",
               "dotnetRunMessages": true,
               "launchBrowser": false,
-              "applicationUrl": "http://localhost:${artifact.httpPort};https://localhost:${artifact.httpsPort}",
+              "applicationUrl": "http://localhost:$${artifact.httpPort};https://localhost:$${artifact.httpsPort}",
               "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
               }
@@ -108,12 +104,19 @@ class DotnetAspServiceArtifactCompiler : ServicesArtifactCompiler<DotnetAspServi
         value.forEach { char ->
             when (char) {
                 '\\' -> escaped.append("\\\\")
+
                 '"' -> escaped.append("\\\"")
+
                 '\b' -> escaped.append("\\b")
+
                 '\u000C' -> escaped.append("\\f")
+
                 '\n' -> escaped.append("\\n")
+
                 '\r' -> escaped.append("\\r")
+
                 '\t' -> escaped.append("\\t")
+
                 else -> {
                     if (char.code < FIRST_NON_PRINTABLE_ASCII_CODE_POINT) {
                         escaped.append("\\u%04x".format(char.code))

--- a/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageReferencesArtifactCompiler.kt
+++ b/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageReferencesArtifactCompiler.kt
@@ -17,24 +17,22 @@ import io.github.lmliam.microsmith.compile.services.core.ServicesArtifactCompile
 class DotnetPackageReferencesArtifactCompiler : ServicesArtifactCompiler<DotnetPackageReferencesArtifact> {
     override val artifactType = DotnetPackageReferencesArtifact::class
 
-    override fun compile(artifact: DotnetPackageReferencesArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            MsBuildProjectContribution(
-                artifactId = MsBuildProjectArtifactId(
-                    solutionName = artifact.solutionName,
-                    projectName = artifact.projectName,
-                    kind = MsBuildProjectKind.DirectoryBuildProps,
-                ),
-                items = artifact.packages.sortedBy(DotnetPackageReference::name).map { packageReference ->
-                    MsBuildItem(
-                        itemName = MsBuildNames.PACKAGE_REFERENCE_ITEM,
-                        include = packageReference.name,
-                        attributes = packageReference.version
-                            ?.let { mapOf(MsBuildNames.VERSION_ATTRIBUTE to it) }
-                            .orEmpty(),
-                    )
-                },
+    override fun compile(artifact: DotnetPackageReferencesArtifact): List<ArtifactContribution<out Artifact>> = listOf(
+        MsBuildProjectContribution(
+            artifactId = MsBuildProjectArtifactId(
+                solutionName = artifact.solutionName,
+                projectName = artifact.projectName,
+                kind = MsBuildProjectKind.DirectoryBuildProps,
             ),
-        )
-    }
+            items = artifact.packages.sortedBy(DotnetPackageReference::name).map { packageReference ->
+                MsBuildItem(
+                    itemName = MsBuildNames.PACKAGE_REFERENCE_ITEM,
+                    include = packageReference.name,
+                    attributes = packageReference.version
+                        ?.let { mapOf(MsBuildNames.VERSION_ATTRIBUTE to it) }
+                        .orEmpty(),
+                )
+            },
+        ),
+    )
 }

--- a/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageVersionsArtifactCompiler.kt
+++ b/modules/compile-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/packages/DotnetPackageVersionsArtifactCompiler.kt
@@ -17,22 +17,20 @@ import io.github.lmliam.microsmith.compile.services.core.ServicesArtifactCompile
 class DotnetPackageVersionsArtifactCompiler : ServicesArtifactCompiler<DotnetPackageVersionsArtifact> {
     override val artifactType = DotnetPackageVersionsArtifact::class
 
-    override fun compile(artifact: DotnetPackageVersionsArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            MsBuildProjectContribution(
-                artifactId = MsBuildProjectArtifactId(
-                    solutionName = artifact.id.solutionName,
-                    kind = MsBuildProjectKind.DirectoryPackagesProps,
-                ),
-                properties = mapOf(MsBuildNames.MANAGE_PACKAGE_VERSIONS_CENTRALLY_PROPERTY to "true"),
-                items = artifact.packages.sortedBy(DotnetPackageVersion::name).map { packageVersion ->
-                    MsBuildItem(
-                        itemName = MsBuildNames.PACKAGE_VERSION_ITEM,
-                        include = packageVersion.name,
-                        attributes = mapOf(MsBuildNames.VERSION_ATTRIBUTE to packageVersion.version),
-                    )
-                },
+    override fun compile(artifact: DotnetPackageVersionsArtifact): List<ArtifactContribution<out Artifact>> = listOf(
+        MsBuildProjectContribution(
+            artifactId = MsBuildProjectArtifactId(
+                solutionName = artifact.id.solutionName,
+                kind = MsBuildProjectKind.DirectoryPackagesProps,
             ),
-        )
-    }
+            properties = mapOf(MsBuildNames.MANAGE_PACKAGE_VERSIONS_CENTRALLY_PROPERTY to "true"),
+            items = artifact.packages.sortedBy(DotnetPackageVersion::name).map { packageVersion ->
+                MsBuildItem(
+                    itemName = MsBuildNames.PACKAGE_VERSION_ITEM,
+                    include = packageVersion.name,
+                    attributes = mapOf(MsBuildNames.VERSION_ATTRIBUTE to packageVersion.version),
+                )
+            },
+        ),
+    )
 }

--- a/modules/compile-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/msbuild/MsBuildProjectArtifactCompiler.kt
+++ b/modules/compile-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/compile/services/dotnet/msbuild/MsBuildProjectArtifactCompiler.kt
@@ -15,24 +15,24 @@ import java.nio.file.Path
 class MsBuildProjectArtifactCompiler : ServicesArtifactCompiler<MsBuildProjectArtifact> {
     override val artifactType = MsBuildProjectArtifact::class
 
-    override fun compile(artifact: MsBuildProjectArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(
-            TextFileArtifactContribution(
-                artifactId = TextFileArtifactId(
-                    relativePath = projectRelativePath(artifact),
-                    outputRoot = artifact.outputRoot(),
-                ),
-                contents = MsBuildProjectXmlRenderer.render(artifact),
+    override fun compile(artifact: MsBuildProjectArtifact): List<ArtifactContribution<out Artifact>> = listOf(
+        TextFileArtifactContribution(
+            artifactId = TextFileArtifactId(
+                relativePath = projectRelativePath(artifact),
+                outputRoot = artifact.outputRoot(),
             ),
-        )
-    }
+            contents = MsBuildProjectXmlRenderer.render(artifact),
+        ),
+    )
 
     private fun MsBuildProjectArtifact.outputRoot(): Path = when (id.kind) {
         MsBuildProjectKind.DirectoryPackagesProps -> dotnetOutputRoot.resolve(id.solutionName)
+
         MsBuildProjectKind.DirectoryBuildProps ->
             dotnetOutputRoot
                 .resolve(id.solutionName)
                 .resolve(requireNotNull(id.projectName))
+
         MsBuildProjectKind.Project ->
             dotnetOutputRoot
                 .resolve(id.solutionName)

--- a/modules/compile/src/main/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilerRegistry.kt
+++ b/modules/compile/src/main/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilerRegistry.kt
@@ -4,9 +4,7 @@ import io.github.lmliam.microsmith.artifact.core.Artifact
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
-internal class ArtifactCompilerRegistry(
-    compilers: List<ArtifactCompiler<*>> = loadArtifactCompilers(),
-) {
+internal class ArtifactCompilerRegistry(compilers: List<ArtifactCompiler<*>> = loadArtifactCompilers()) {
     private val compilersByType = indexCompilers(compilers)
 
     fun resolveOrNull(artifact: Artifact): ArtifactCompiler<Artifact>? =

--- a/modules/compile/src/test/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilationServiceTests.kt
+++ b/modules/compile/src/test/kotlin/io/github/lmliam/microsmith/compile/core/ArtifactCompilationServiceTests.kt
@@ -67,21 +67,14 @@ class ArtifactCompilationServiceTests :
         }
     })
 
-private data class StageOneArtifact(
-    override val id: StageOneId,
-    val contents: String,
-) : Artifact
+private data class StageOneArtifact(override val id: StageOneId, val contents: String) : Artifact
 
-private data class StageOneId(
-    val name: String,
-) : ArtifactId<StageOneArtifact> {
+private data class StageOneId(val name: String) : ArtifactId<StageOneArtifact> {
     override val artifactType = StageOneArtifact::class
 }
 
-private data class StageOneContribution(
-    override val artifactId: StageOneId,
-    val contents: String,
-) : ArtifactContribution<StageOneArtifact>
+private data class StageOneContribution(override val artifactId: StageOneId, val contents: String) :
+    ArtifactContribution<StageOneArtifact>
 
 private class StageOneArtifactAssembler : ArtifactAssembler<StageOneArtifact> {
     override val artifactType = StageOneArtifact::class
@@ -104,21 +97,14 @@ private class StageOneArtifactAssembler : ArtifactAssembler<StageOneArtifact> {
     }
 }
 
-private data class StageTwoArtifact(
-    override val id: StageTwoId,
-    val contents: String,
-) : Artifact
+private data class StageTwoArtifact(override val id: StageTwoId, val contents: String) : Artifact
 
-private data class StageTwoId(
-    val name: String,
-) : ArtifactId<StageTwoArtifact> {
+private data class StageTwoId(val name: String) : ArtifactId<StageTwoArtifact> {
     override val artifactType = StageTwoArtifact::class
 }
 
-private data class StageTwoContribution(
-    override val artifactId: StageTwoId,
-    val contents: String,
-) : ArtifactContribution<StageTwoArtifact>
+private data class StageTwoContribution(override val artifactId: StageTwoId, val contents: String) :
+    ArtifactContribution<StageTwoArtifact>
 
 private class StageTwoArtifactAssembler : ArtifactAssembler<StageTwoArtifact> {
     override val artifactType = StageTwoArtifact::class
@@ -144,39 +130,34 @@ private class StageTwoArtifactAssembler : ArtifactAssembler<StageTwoArtifact> {
 private class StageOneCompiler : ArtifactCompiler<StageOneArtifact> {
     override val artifactType = StageOneArtifact::class
 
-    override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(StageTwoContribution(StageTwoId("middle"), artifact.contents))
-    }
+    override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> =
+        listOf(StageTwoContribution(StageTwoId("middle"), artifact.contents))
 }
 
 private class StageTwoCompiler : ArtifactCompiler<StageTwoArtifact> {
     override val artifactType = StageTwoArtifact::class
 
-    override fun compile(artifact: StageTwoArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(TextFileArtifactContribution(TextFileArtifactId(Path.of("result.txt")), artifact.contents))
-    }
+    override fun compile(artifact: StageTwoArtifact): List<ArtifactContribution<out Artifact>> =
+        listOf(TextFileArtifactContribution(TextFileArtifactId(Path.of("result.txt")), artifact.contents))
 }
 
 private class SelfCyclingCompiler : ArtifactCompiler<StageOneArtifact> {
     override val artifactType = StageOneArtifact::class
 
-    override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(StageOneContribution(StageOneId("cycle"), artifact.contents))
-    }
+    override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> =
+        listOf(StageOneContribution(StageOneId("cycle"), artifact.contents))
 }
 
 private class StageOneToStageTwoCompiler : ArtifactCompiler<StageOneArtifact> {
     override val artifactType = StageOneArtifact::class
 
-    override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(StageTwoContribution(StageTwoId(artifact.id.name), artifact.contents))
-    }
+    override fun compile(artifact: StageOneArtifact): List<ArtifactContribution<out Artifact>> =
+        listOf(StageTwoContribution(StageTwoId(artifact.id.name), artifact.contents))
 }
 
 private class StageTwoToStageOneCompiler : ArtifactCompiler<StageTwoArtifact> {
     override val artifactType = StageTwoArtifact::class
 
-    override fun compile(artifact: StageTwoArtifact): List<ArtifactContribution<out Artifact>> {
-        return listOf(StageOneContribution(StageOneId(artifact.id.name), artifact.contents))
-    }
+    override fun compile(artifact: StageTwoArtifact): List<ArtifactContribution<out Artifact>> =
+        listOf(StageOneContribution(StageOneId(artifact.id.name), artifact.contents))
 }

--- a/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/Rpc.kt
+++ b/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/Rpc.kt
@@ -1,7 +1,3 @@
 package io.github.lmliam.microsmith.dsl.schemas.protobuf.rpc
 
-data class Rpc(
-    val name: String,
-    val request: RpcEndpoint,
-    val response: RpcEndpoint,
-)
+data class Rpc(val name: String, val request: RpcEndpoint, val response: RpcEndpoint)

--- a/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/RpcEndpointMarker.kt
+++ b/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/RpcEndpointMarker.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.dsl.schemas.protobuf.rpc
 
-class RpcEndpointMarker(
-    val target: String,
-    val streaming: Boolean = false,
-)
+class RpcEndpointMarker(val target: String, val streaming: Boolean = false)

--- a/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/Service.kt
+++ b/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/Service.kt
@@ -4,10 +4,9 @@ import io.github.lmliam.microsmith.dsl.schemas.protobuf.support.ProtobufReferenc
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.support.ProtobufReferenceResolver
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.types.Type
 
-data class Service(
-    override val name: String,
-    val rpcs: List<Rpc>,
-) : Type, ProtobufReferenceResolvableType {
+data class Service(override val name: String, val rpcs: List<Rpc>) :
+    Type,
+    ProtobufReferenceResolvableType {
     override fun resolveReferences(resolver: ProtobufReferenceResolver): Type = copy(
         rpcs = rpcs.map { rpc -> rpc.resolveReferences(resolver, name) },
     )

--- a/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/ServiceBuilder.kt
+++ b/modules/dsl-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/rpc/ServiceBuilder.kt
@@ -3,10 +3,8 @@ package io.github.lmliam.microsmith.dsl.schemas.protobuf.rpc
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.ProtobufDeclarationContext
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.field.Reference
 
-internal class ServiceBuilder(
-    private val name: String,
-    private val declarationContext: ProtobufDeclarationContext,
-) : ServiceScope {
+internal class ServiceBuilder(private val name: String, private val declarationContext: ProtobufDeclarationContext) :
+    ServiceScope {
     private val routeNames = mutableSetOf<String>()
     private val rpcs = mutableListOf<Rpc>()
 
@@ -21,10 +19,8 @@ internal class ServiceBuilder(
     fun build(): Service = Service(name = name, rpcs = rpcs.toList())
 }
 
-private class RpcBuilder(
-    private val name: String,
-    private val declarationContext: ProtobufDeclarationContext,
-) : RpcScope {
+private class RpcBuilder(private val name: String, private val declarationContext: ProtobufDeclarationContext) :
+    RpcScope {
     private var request: RpcEndpoint? = null
     private var response: RpcEndpoint? = null
     private var declarationStyle: RpcDeclarationStyle? = null

--- a/modules/dsl-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/support/ReferenceResolutionContext.kt
+++ b/modules/dsl-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/support/ReferenceResolutionContext.kt
@@ -15,13 +15,10 @@ internal class ReferenceResolutionContext(schemas: Set<ProtobufSchema>) : Protob
     private val schemasByName = schemas.associateBy(ProtobufSchema::name)
     private val errors = mutableListOf<String>()
 
-    fun resolve(schema: ProtobufSchema): ProtobufSchema {
-        val schemaType = schema.schema
-        return when (schemaType) {
-            is Message -> schema.copy(schema = schemaType.resolveMessage())
-            is ProtobufReferenceResolvableType -> schema.copy(schema = schemaType.resolveReferences(this))
-            else -> schema
-        }
+    fun resolve(schema: ProtobufSchema): ProtobufSchema = when (val schemaType = schema.schema) {
+        is Message -> schema.copy(schema = schemaType.resolveMessage())
+        is ProtobufReferenceResolvableType -> schema.copy(schema = schemaType.resolveReferences(this))
+        else -> schema
     }
 
     fun failOnUnresolvedReferences() {

--- a/modules/dsl-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/types/Enum.kt
+++ b/modules/dsl-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/types/Enum.kt
@@ -6,7 +6,8 @@ data class Enum(
     override val name: String,
     val values: List<EnumValue>,
     override val reserved: List<Reserved> = emptyList(),
-) : Type, ReservedDeclarationOwner {
+) : Type,
+    ReservedDeclarationOwner {
     companion object {
         internal const val UNSPECIFIED = "UNSPECIFIED"
     }

--- a/modules/dsl-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/types/Message.kt
+++ b/modules/dsl-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/protobuf/types/Message.kt
@@ -9,4 +9,5 @@ data class Message(
     val fields: List<Field> = emptyList(),
     val oneofs: List<Oneof> = emptyList(),
     override val reserved: List<Reserved> = emptyList(),
-) : Type, ReservedDeclarationOwner
+) : Type,
+    ReservedDeclarationOwner

--- a/modules/dsl-schemas/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/core/SchemasExtension.kt
+++ b/modules/dsl-schemas/src/main/kotlin/io/github/lmliam/microsmith/dsl/schemas/core/SchemasExtension.kt
@@ -46,13 +46,13 @@ data class SchemasExtension(val schemas: Set<Schema>) : MicrosmithExtension {
 
     fun merge(other: SchemasExtension): SchemasExtension {
         val existingKeys = schemas.mapTo(mutableSetOf(), Schema::schemaKey)
-        val collisions =
-            other.schemas
-                .map(Schema::schemaKey)
-                .filter { it in existingKeys }
-                .map { (type, name) -> schemaDisplayKey(type, name) }
-                .distinct()
-                .sorted()
+        val collisions = other.schemas.asSequence()
+            .map(Schema::schemaKey)
+            .filter { it in existingKeys }
+            .map { (type, name) -> schemaDisplayKey(type, name) }
+            .distinct()
+            .sorted()
+            .toList()
 
         require(collisions.isEmpty()) {
             "Duplicate schema keys while merging SchemasExtension: ${collisions.joinToString(", ")}"

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/model/InlineDotnetModelBuilder.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/model/InlineDotnetModelBuilder.kt
@@ -5,14 +5,13 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.core.model.DotnetModel
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.model.DotnetModelScope
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-internal class InlineDotnetModelBuilder(
-    private val modelName: String,
-) : DotnetFieldSetBuilder(
-    fieldNameLabel = "ASP.NET inline model field name",
-    duplicateFieldMessage = { fieldName ->
-        "Duplicate ASP.NET inline model field '$fieldName' in model '$modelName'."
-    },
-),
+internal class InlineDotnetModelBuilder(private val modelName: String) :
+    DotnetFieldSetBuilder(
+        fieldNameLabel = "ASP.NET inline model field name",
+        duplicateFieldMessage = { fieldName ->
+            "Duplicate ASP.NET inline model field '$fieldName' in model '$modelName'."
+        },
+    ),
     DotnetModelScope {
     fun build() = DotnetModel(
         name = validateDotnetIdentifier(modelName, "ASP.NET inline model name"),

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspHeaderField.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspHeaderField.kt
@@ -2,10 +2,7 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.request
 
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-data class DotnetAspHeaderField(
-    val name: String,
-    val headerName: String,
-) {
+data class DotnetAspHeaderField(val name: String, val headerName: String) {
     init {
         validateDotnetIdentifier(name, "ASP.NET header field name")
         require(headerName.isNotBlank()) {

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspHeadersBinding.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspHeadersBinding.kt
@@ -2,10 +2,7 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.request
 
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-data class DotnetAspHeadersBinding(
-    val name: String,
-    val headers: List<DotnetAspHeaderField>,
-) {
+data class DotnetAspHeadersBinding(val name: String, val headers: List<DotnetAspHeaderField>) {
     init {
         require(headers.isNotEmpty()) {
             "ASP.NET headers binding '$name' must declare at least one header."

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspHeadersBindingBuilder.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspHeadersBindingBuilder.kt
@@ -1,8 +1,6 @@
 package io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.request
 
-internal class DotnetAspHeadersBindingBuilder(
-    private val name: String,
-) : DotnetAspHeadersBindingScope {
+internal class DotnetAspHeadersBindingBuilder(private val name: String) : DotnetAspHeadersBindingScope {
     private val headers = mutableListOf<DotnetAspHeaderField>()
 
     override fun header(name: String): DotnetAspHeaderField {
@@ -32,9 +30,7 @@ internal class DotnetAspHeadersBindingBuilder(
                     }
                 }.joinToString("")
 
-        return if (candidate.isNotBlank()) {
-            candidate
-        } else {
+        return candidate.ifBlank {
             error("Unable to derive an ASP.NET header field name from '$headerName'.")
         }
     }

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspRequestBinding.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspRequestBinding.kt
@@ -2,10 +2,7 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.request
 
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-data class DotnetAspRequestBinding(
-    val name: String,
-    val fields: List<DotnetAspRequestField>,
-) {
+data class DotnetAspRequestBinding(val name: String, val fields: List<DotnetAspRequestField>) {
     init {
         require(fields.isNotEmpty()) {
             "ASP.NET request binding '$name' must declare at least one field."

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspRequestBindingBuilder.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspRequestBindingBuilder.kt
@@ -1,8 +1,8 @@
 package io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.request
 
-internal class DotnetAspRequestBindingBuilder(
-    private val name: String,
-) : DotnetAspRequestFieldSetBuilder("binding '$name'"), DotnetAspRequestBindingScope {
+internal class DotnetAspRequestBindingBuilder(private val name: String) :
+    DotnetAspRequestFieldSetBuilder("binding '$name'"),
+    DotnetAspRequestBindingScope {
 
     fun build() = DotnetAspRequestBinding(name = name, fields = buildFields())
 }

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspRequestFieldSetBuilder.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/request/DotnetAspRequestFieldSetBuilder.kt
@@ -4,9 +4,8 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.core.model.DotnetConfigur
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.model.DotnetFieldType
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-internal open class DotnetAspRequestFieldSetBuilder(
-    private val fieldContainerLabel: String,
-) : DotnetConfigurableTypedFieldScope<DotnetAspRequestField, DotnetAspRequestFieldScope> {
+internal open class DotnetAspRequestFieldSetBuilder(private val fieldContainerLabel: String) :
+    DotnetConfigurableTypedFieldScope<DotnetAspRequestField, DotnetAspRequestFieldScope> {
     private val fieldsByName = linkedMapOf<String, DotnetAspRequestField>()
 
     override fun string(name: String, block: DotnetAspRequestFieldScope.() -> Unit) =

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/response/DotnetAspResponseBuilder.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/response/DotnetAspResponseBuilder.kt
@@ -5,9 +5,7 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.model.Inlin
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.model.DotnetModel
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.model.DotnetModelScope
 
-internal class DotnetAspResponseBuilder(
-    private val modelName: String,
-) : DotnetAspResponseScope {
+internal class DotnetAspResponseBuilder(private val modelName: String) : DotnetAspResponseScope {
     private var inlineModel: DotnetModel? = null
     private var headers: List<DotnetAspResponseHeader> = emptyList()
 

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/response/DotnetAspResponseHeader.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/response/DotnetAspResponseHeader.kt
@@ -1,8 +1,6 @@
 package io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.response
 
-data class DotnetAspResponseHeader(
-    val name: String,
-) {
+data class DotnetAspResponseHeader(val name: String) {
     init {
         require(name.isNotBlank()) {
             "ASP.NET response header name cannot be blank."

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/service/DotnetAspRouteGroupBuilder.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/rest/service/DotnetAspRouteGroupBuilder.kt
@@ -7,9 +7,7 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.endpoint.Do
 import io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.route.DotnetAspRouteGroup
 import io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.route.DotnetAspRouteScope
 
-internal class DotnetAspRouteGroupBuilder(
-    private val path: String,
-) : DotnetAspRouteScope {
+internal class DotnetAspRouteGroupBuilder(private val path: String) : DotnetAspRouteScope {
     private val groups = mutableListOf<DotnetAspRouteGroup>()
     private val endpoints = mutableListOf<DotnetAspEndpoint>()
 

--- a/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/service/DotnetAspServiceExtension.kt
+++ b/modules/dsl-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/asp/core/service/DotnetAspServiceExtension.kt
@@ -8,9 +8,9 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.asp.core.rest.service.mer
 /**
  * Per-service ASP.NET scaffold opt-in declared under `asp { ... }`.
  */
-data class DotnetAspServiceExtension(
-    val rest: DotnetAspRest? = null,
-) : ServiceExtension, MergeableExtension<DotnetAspServiceExtension> {
+data class DotnetAspServiceExtension(val rest: DotnetAspRest? = null) :
+    ServiceExtension,
+    MergeableExtension<DotnetAspServiceExtension> {
     override fun merge(other: DotnetAspServiceExtension) = DotnetAspServiceExtension(
         rest =
         when {

--- a/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/service/DotnetPackageReferenceDeclaration.kt
+++ b/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/service/DotnetPackageReferenceDeclaration.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.dsl.services.dotnet.packages.service
 
-data class DotnetPackageReferenceDeclaration(
-    val name: String,
-    val version: String?,
-)
+data class DotnetPackageReferenceDeclaration(val name: String, val version: String?)

--- a/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/service/DotnetPackageReferencesBuilder.kt
+++ b/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/service/DotnetPackageReferencesBuilder.kt
@@ -3,9 +3,8 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.packages.service
 import io.github.lmliam.microsmith.dsl.services.dotnet.packages.support.normalizeDotnetPackagePath
 import io.github.lmliam.microsmith.dsl.services.dotnet.packages.support.validateDotnetPackageVersion
 
-internal class DotnetPackageReferencesBuilder(
-    private val pathSegments: List<String> = emptyList(),
-) : DotnetPackageReferencesScope {
+internal class DotnetPackageReferencesBuilder(private val pathSegments: List<String> = emptyList()) :
+    DotnetPackageReferencesScope {
     private var version: String? = null
     private val children = linkedMapOf<String, DotnetPackageReferencesBuilder>()
 

--- a/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/service/DotnetPackageReferencesExtension.kt
+++ b/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/service/DotnetPackageReferencesExtension.kt
@@ -8,12 +8,12 @@ import io.github.lmliam.microsmith.dsl.services.core.ServiceExtension
  * A null value means the package reference is versionless at the service level and must be
  * satisfied by central package ownership during resolution.
  */
-data class DotnetPackageReferencesExtension(
-    val packages: List<DotnetPackageReferenceDeclaration> = emptyList(),
-) : ServiceExtension, MergeableExtension<DotnetPackageReferencesExtension> {
+data class DotnetPackageReferencesExtension(val packages: List<DotnetPackageReferenceDeclaration> = emptyList()) :
+    ServiceExtension,
+    MergeableExtension<DotnetPackageReferencesExtension> {
     fun findPackage(name: String): String? = packages.find { it.name == name }?.version
 
-    fun requirePackage(name: String): String? {
+    fun requirePackage(name: String): String {
         require(name.isNotBlank()) { "Package name cannot be blank." }
         return findPackage(name) ?: error("Dotnet package not found: $name")
     }

--- a/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/solution/DotnetPackageVersionDeclaration.kt
+++ b/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/solution/DotnetPackageVersionDeclaration.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.dsl.services.dotnet.packages.solution
 
-data class DotnetPackageVersionDeclaration(
-    val name: String,
-    val version: String,
-)
+data class DotnetPackageVersionDeclaration(val name: String, val version: String)

--- a/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/solution/DotnetPackageVersionsBuilder.kt
+++ b/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/solution/DotnetPackageVersionsBuilder.kt
@@ -3,9 +3,8 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.packages.solution
 import io.github.lmliam.microsmith.dsl.services.dotnet.packages.support.normalizeDotnetPackagePath
 import io.github.lmliam.microsmith.dsl.services.dotnet.packages.support.validateDotnetPackageVersion
 
-internal class DotnetPackageVersionsBuilder(
-    private val pathSegments: List<String> = emptyList(),
-) : DotnetPackageVersionScope {
+internal class DotnetPackageVersionsBuilder(private val pathSegments: List<String> = emptyList()) :
+    DotnetPackageVersionScope {
     private var version: String? = null
     private val children = linkedMapOf<String, DotnetPackageVersionsBuilder>()
 

--- a/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/solution/DotnetPackageVersionsExtension.kt
+++ b/modules/dsl-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/packages/solution/DotnetPackageVersionsExtension.kt
@@ -6,9 +6,9 @@ import io.github.lmliam.microsmith.dsl.core.MicrosmithExtension
 /**
  * Central package versions declared under `solutions { "Name" { packages { ... } } }`.
  */
-data class DotnetPackageVersionsExtension(
-    val packages: List<DotnetPackageVersionDeclaration> = emptyList(),
-) : MicrosmithExtension, MergeableExtension<DotnetPackageVersionsExtension> {
+data class DotnetPackageVersionsExtension(val packages: List<DotnetPackageVersionDeclaration> = emptyList()) :
+    MicrosmithExtension,
+    MergeableExtension<DotnetPackageVersionsExtension> {
     fun findVersion(name: String): String? = packages.find { it.name == name }?.version
 
     fun requireVersion(name: String): String {

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/DotnetTarget.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/DotnetTarget.kt
@@ -4,9 +4,7 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.core
  * Validated .NET target framework monikers for the DSL.
  */
 @JvmInline
-value class DotnetTarget(
-    val moniker: String,
-) {
+value class DotnetTarget(val moniker: String) {
     init {
         require(moniker in supportedMonikers) {
             "Unsupported .NET target framework moniker: '$moniker'."

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/DotnetTargetAliases.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/DotnetTargetAliases.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.core
 /**
  * User-facing target aliases exposed directly on .NET DSL scopes.
  */
-@Suppress("VariableNaming")
+@Suppress("VariableNaming", "PropertyName")
 interface DotnetTargetAliases {
     val NET5: DotnetTarget
         get() = DotnetTarget.NET5

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/defaults/DotnetDefaultsExtension.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/defaults/DotnetDefaultsExtension.kt
@@ -14,7 +14,8 @@ data class DotnetDefaultsExtension(
     val target: DotnetTarget? = null,
     val solutions: Map<String, DotnetSolution> = emptyMap(),
     val model: DotnetDefaultsModel = DotnetDefaultsModel.empty(),
-) : MicrosmithExtension, MergeableExtension<DotnetDefaultsExtension> {
+) : MicrosmithExtension,
+    MergeableExtension<DotnetDefaultsExtension> {
     fun findSolution(name: String) = solutions[name]
 
     fun requireSolution(name: String): DotnetSolution {

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/defaults/DotnetDefaultsModel.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/defaults/DotnetDefaultsModel.kt
@@ -29,9 +29,7 @@ class DotnetDefaultsModel internal constructor(
 
     fun keys() = extensions.keys
 
-    override fun equals(other: Any?): Boolean {
-        return other is DotnetDefaultsModel && extensions == other.extensions
-    }
+    override fun equals(other: Any?): Boolean = other is DotnetDefaultsModel && extensions == other.extensions
 
     override fun hashCode(): Int = extensions.hashCode()
 

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/model/DotnetField.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/model/DotnetField.kt
@@ -5,10 +5,7 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotn
 /**
  * A single .NET model field.
  */
-data class DotnetField(
-    val name: String,
-    val type: DotnetFieldType,
-) {
+data class DotnetField(val name: String, val type: DotnetFieldType) {
     init {
         validateDotnetIdentifier(name, "Field name")
     }

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/model/DotnetModel.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/model/DotnetModel.kt
@@ -5,10 +5,7 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotn
 /**
  * Canonical .NET service-local model declaration.
  */
-data class DotnetModel(
-    val name: String,
-    val fields: List<DotnetField>,
-) {
+data class DotnetModel(val name: String, val fields: List<DotnetField>) {
     init {
         validateDotnetIdentifier(name, "Model name")
     }

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/model/DotnetModelBuilder.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/model/DotnetModelBuilder.kt
@@ -2,14 +2,12 @@ package io.github.lmliam.microsmith.dsl.services.dotnet.core.model
 
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-internal class DotnetModelBuilder(
-    private val name: String,
-) : DotnetFieldSetBuilder(), DotnetModelScope {
+internal class DotnetModelBuilder(private val name: String) :
+    DotnetFieldSetBuilder(),
+    DotnetModelScope {
 
-    fun build(): DotnetModel {
-        return DotnetModel(
-            name = validateDotnetIdentifier(name, "Model name"),
-            fields = buildFields(),
-        )
-    }
+    fun build(): DotnetModel = DotnetModel(
+        name = validateDotnetIdentifier(name, "Model name"),
+        fields = buildFields(),
+    )
 }

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/service/DotnetServiceExtension.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/service/DotnetServiceExtension.kt
@@ -16,7 +16,8 @@ data class DotnetServiceExtension(
     val project: String? = null,
     val models: Map<String, DotnetModel> = emptyMap(),
     val model: DotnetServiceModel = DotnetServiceModel.empty(),
-) : ServiceExtension, MergeableExtension<DotnetServiceExtension> {
+) : ServiceExtension,
+    MergeableExtension<DotnetServiceExtension> {
     fun findModel(name: String) = models[name]
 
     fun requireModel(name: String): DotnetModel {

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/service/DotnetServiceModel.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/service/DotnetServiceModel.kt
@@ -29,9 +29,7 @@ class DotnetServiceModel internal constructor(
 
     fun keys() = extensions.keys
 
-    override fun equals(other: Any?): Boolean {
-        return other is DotnetServiceModel && extensions == other.extensions
-    }
+    override fun equals(other: Any?): Boolean = other is DotnetServiceModel && extensions == other.extensions
 
     override fun hashCode(): Int = extensions.hashCode()
 
@@ -43,7 +41,9 @@ class DotnetServiceModel internal constructor(
 @Suppress("UNCHECKED_CAST")
 private fun <T : ServiceExtension> mergeServiceExtension(existing: T?, incoming: T): T = when {
     existing == null -> incoming
+
     existing::class == incoming::class && existing is MergeableExtension<*> ->
         (existing as MergeableExtension<T>).merge(incoming)
+
     else -> incoming
 }

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/solution/DotnetSolution.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/solution/DotnetSolution.kt
@@ -7,10 +7,7 @@ import kotlin.reflect.KClass
 /**
  * A named .NET solution declared in the services-level dotnet defaults scope.
  */
-data class DotnetSolution(
-    val name: String,
-    val model: DotnetSolutionModel = DotnetSolutionModel.empty(),
-) {
+data class DotnetSolution(val name: String, val model: DotnetSolutionModel = DotnetSolutionModel.empty()) {
     init {
         validateDotnetQualifiedIdentifier(name, "Solution name")
     }

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/solution/DotnetSolutionBuilder.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/solution/DotnetSolutionBuilder.kt
@@ -4,9 +4,7 @@ import io.github.lmliam.microsmith.dsl.core.MicrosmithExtension
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetQualifiedIdentifier
 import kotlin.reflect.KClass
 
-internal class DotnetSolutionBuilder(
-    private val name: String,
-) : DotnetSolutionContext {
+internal class DotnetSolutionBuilder(private val name: String) : DotnetSolutionContext {
     private var model = DotnetSolutionModel.empty()
 
     override fun <T : MicrosmithExtension> put(type: KClass<T>, ext: T) {

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/solution/DotnetSolutionModel.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/solution/DotnetSolutionModel.kt
@@ -29,9 +29,7 @@ class DotnetSolutionModel internal constructor(
 
     fun keys() = extensions.keys
 
-    override fun equals(other: Any?): Boolean {
-        return other is DotnetSolutionModel && extensions == other.extensions
-    }
+    override fun equals(other: Any?): Boolean = other is DotnetSolutionModel && extensions == other.extensions
 
     override fun hashCode(): Int = extensions.hashCode()
 

--- a/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/support/DotnetNameValidation.kt
+++ b/modules/dsl-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/support/DotnetNameValidation.kt
@@ -20,9 +20,7 @@ fun validateDotnetQualifiedIdentifier(value: String, label: String): String {
     return normalized
 }
 
-private fun isDotnetQualifiedIdentifier(value: String): Boolean {
-    return value.split('.').all(::isDotnetIdentifier)
-}
+private fun isDotnetQualifiedIdentifier(value: String): Boolean = value.split('.').all(::isDotnetIdentifier)
 
 private fun isDotnetIdentifier(value: String): Boolean {
     val candidate = value.removePrefix("@")
@@ -38,9 +36,7 @@ private fun isDotnetIdentifier(value: String): Boolean {
     return candidate.asCodePoints().drop(1).all(Int::isDotnetIdentifierPart)
 }
 
-private fun String.firstCodePoint(): Int {
-    return codePointAt(0)
-}
+private fun String.firstCodePoint(): Int = codePointAt(0)
 
 private fun String.asCodePoints(): Sequence<Int> = sequence {
     var index = 0
@@ -51,22 +47,18 @@ private fun String.asCodePoints(): Sequence<Int> = sequence {
     }
 }
 
-private fun Int.isDotnetIdentifierStart(): Boolean {
-    return this == '_'.code ||
-        Character.isLetter(this) ||
-        Character.getType(this).toInt() == Character.LETTER_NUMBER.toInt()
-}
+private fun Int.isDotnetIdentifierStart(): Boolean = this == '_'.code ||
+    Character.isLetter(this) ||
+    Character.getType(this).toInt() == Character.LETTER_NUMBER.toInt()
 
-private fun Int.isDotnetIdentifierPart(): Boolean {
-    return isDotnetIdentifierStart() ||
-        when (Character.getType(this).toInt()) {
-            Character.NON_SPACING_MARK.toInt(),
-            Character.COMBINING_SPACING_MARK.toInt(),
-            Character.DECIMAL_DIGIT_NUMBER.toInt(),
-            Character.CONNECTOR_PUNCTUATION.toInt(),
-            Character.FORMAT.toInt(),
-            -> true
+private fun Int.isDotnetIdentifierPart(): Boolean = isDotnetIdentifierStart() ||
+    when (Character.getType(this).toInt()) {
+        Character.NON_SPACING_MARK.toInt(),
+        Character.COMBINING_SPACING_MARK.toInt(),
+        Character.DECIMAL_DIGIT_NUMBER.toInt(),
+        Character.CONNECTOR_PUNCTUATION.toInt(),
+        Character.FORMAT.toInt(),
+        -> true
 
-            else -> false
-        }
-}
+        else -> false
+    }

--- a/modules/dsl-services-dotnet/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/DotnetDslTests.kt
+++ b/modules/dsl-services-dotnet/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/dotnet/core/DotnetDslTests.kt
@@ -19,9 +19,9 @@ import io.kotest.matchers.shouldBe
 private fun MicrosmithBuilder.requireServicesExtension(): ServicesExtension =
     requireNotNull(model.get<ServicesExtension>())
 
-private data class TestSolutionExtension(
-    val values: List<String>,
-) : MicrosmithExtension, MergeableExtension<TestSolutionExtension> {
+private data class TestSolutionExtension(val values: List<String>) :
+    MicrosmithExtension,
+    MergeableExtension<TestSolutionExtension> {
     override fun merge(other: TestSolutionExtension) = TestSolutionExtension(values + other.values)
 }
 

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/Service.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/Service.kt
@@ -3,10 +3,7 @@ package io.github.lmliam.microsmith.dsl.services.core
 /**
  * Immutable service declaration produced by the core service DSL.
  */
-data class Service(
-    val name: String,
-    val model: ServiceModel,
-) {
+data class Service(val name: String, val model: ServiceModel) {
     init {
         serviceKey(name)
     }

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceBuilder.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceBuilder.kt
@@ -5,9 +5,7 @@ import kotlin.reflect.KClass
 /**
  * Internal builder used to construct a [Service] from DSL blocks.
  */
-class ServiceBuilder(
-    private val name: String,
-) : ServiceScope {
+class ServiceBuilder(private val name: String) : ServiceScope {
     private var model = ServiceModel.empty()
 
     fun <T : ServiceExtension> put(type: KClass<T>, ext: T) {

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModel.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModel.kt
@@ -6,9 +6,7 @@ import kotlin.reflect.KClass
 /**
  * Immutable snapshot of the service-scoped extension payloads attached to a service.
  */
-class ServiceModel internal constructor(
-    private val extensions: Map<KClass<out ServiceExtension>, ServiceExtension>,
-) {
+class ServiceModel internal constructor(private val extensions: Map<KClass<out ServiceExtension>, ServiceExtension>) {
     @Suppress("UNCHECKED_CAST")
     fun <T : ServiceExtension> get(type: KClass<T>) = extensions[type] as? T?
 
@@ -28,9 +26,7 @@ class ServiceModel internal constructor(
 
     fun keys() = extensions.keys
 
-    override fun equals(other: Any?): Boolean {
-        return other is ServiceModel && extensions == other.extensions
-    }
+    override fun equals(other: Any?): Boolean = other is ServiceModel && extensions == other.extensions
 
     override fun hashCode(): Int = extensions.hashCode()
 

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesExtension.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesExtension.kt
@@ -6,10 +6,8 @@ import kotlin.reflect.KClass
 /**
  * Root extension that holds all declared services and shared services-scoped extensions.
  */
-data class ServicesExtension(
-    val services: Set<Service>,
-    val model: ServicesModel = ServicesModel.empty(),
-) : MicrosmithExtension {
+data class ServicesExtension(val services: Set<Service>, val model: ServicesModel = ServicesModel.empty()) :
+    MicrosmithExtension {
     init {
         val duplicateKeys =
             services

--- a/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesModel.kt
+++ b/modules/dsl-services/src/main/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesModel.kt
@@ -29,9 +29,7 @@ class ServicesModel internal constructor(
 
     fun keys() = extensions.keys
 
-    override fun equals(other: Any?): Boolean {
-        return other is ServicesModel && extensions == other.extensions
-    }
+    override fun equals(other: Any?): Boolean = other is ServicesModel && extensions == other.extensions
 
     override fun hashCode(): Int = extensions.hashCode()
 

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModelTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServiceModelTests.kt
@@ -7,9 +7,9 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
 private data class TestServiceExtension(val value: String) : ServiceExtension
-private data class MergeableTestServiceExtension(
-    val values: List<String>,
-) : ServiceExtension, MergeableExtension<MergeableTestServiceExtension> {
+private data class MergeableTestServiceExtension(val values: List<String>) :
+    ServiceExtension,
+    MergeableExtension<MergeableTestServiceExtension> {
     override fun merge(other: MergeableTestServiceExtension) = MergeableTestServiceExtension(values + other.values)
 }
 

--- a/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesModelTests.kt
+++ b/modules/dsl-services/src/test/kotlin/io/github/lmliam/microsmith/dsl/services/core/ServicesModelTests.kt
@@ -6,9 +6,9 @@ import io.github.lmliam.microsmith.dsl.services.helpers.require
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 
-private data class MergeableTestSharedExtension(
-    val values: List<String>,
-) : MicrosmithExtension, MergeableExtension<MergeableTestSharedExtension> {
+private data class MergeableTestSharedExtension(val values: List<String>) :
+    MicrosmithExtension,
+    MergeableExtension<MergeableTestSharedExtension> {
     override fun merge(other: MergeableTestSharedExtension) = MergeableTestSharedExtension(values + other.values)
 }
 

--- a/modules/dsl/src/main/kotlin/io/github/lmliam/microsmith/dsl/helpers/ModelExtensionMerging.kt
+++ b/modules/dsl/src/main/kotlin/io/github/lmliam/microsmith/dsl/helpers/ModelExtensionMerging.kt
@@ -10,7 +10,9 @@ import io.github.lmliam.microsmith.dsl.core.ModelExtension
 @Suppress("UNCHECKED_CAST")
 fun <T : ModelExtension> mergeModelExtension(existing: T?, incoming: T): T = when {
     existing == null -> incoming
+
     existing::class == incoming::class && existing is MergeableExtension<*> ->
         (existing as MergeableExtension<T>).merge(incoming)
+
     else -> incoming
 }

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/core/ArtifactRendererRegistry.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/core/ArtifactRendererRegistry.kt
@@ -4,16 +4,12 @@ import io.github.lmliam.microsmith.artifact.core.Artifact
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
-class ArtifactRendererRegistry(
-    renderers: List<ArtifactRenderer<*>> = loadArtifactRenderers(),
-) {
+class ArtifactRendererRegistry(renderers: List<ArtifactRenderer<*>> = loadArtifactRenderers()) {
     private val renderersByType = indexRenderers(renderers)
 
-    fun resolve(artifact: Artifact): ArtifactRenderer<Artifact> {
-        return renderersByType[artifact.id.artifactType]
-            ?.cast()
-            ?: error("No artifact renderer found for artifact type: ${artifact.id.artifactType}")
-    }
+    fun resolve(artifact: Artifact): ArtifactRenderer<Artifact> = renderersByType[artifact.id.artifactType]
+        ?.cast()
+        ?: error("No artifact renderer found for artifact type: ${artifact.id.artifactType}")
 
     private fun indexRenderers(renderers: List<ArtifactRenderer<*>>): Map<KClass<out Artifact>, ArtifactRenderer<*>> {
         val duplicates = renderers.groupBy(ArtifactRenderer<*>::artifactType).filterValues { it.size > 1 }

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/GeneratedFile.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/GeneratedFile.kt
@@ -2,11 +2,7 @@ package io.github.lmliam.microsmith.gen.files
 
 import java.nio.file.Path
 
-class GeneratedFile(
-    val relativePath: Path,
-    contents: ByteArray,
-    val outputRoot: Path = Path.of("."),
-) {
+class GeneratedFile(val relativePath: Path, contents: ByteArray, val outputRoot: Path = Path.of(".")) {
     private val bytes = contents.copyOf()
 
     val contents: ByteArray

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/BinaryFileArtifactRenderer.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/BinaryFileArtifactRenderer.kt
@@ -9,11 +9,9 @@ import io.github.lmliam.microsmith.gen.files.GeneratedFile
 class BinaryFileArtifactRenderer : ArtifactRenderer<BinaryFileArtifact> {
     override val artifactType = BinaryFileArtifact::class
 
-    override fun render(artifact: BinaryFileArtifact): GeneratedFile {
-        return GeneratedFile(
-            relativePath = artifact.id.relativePath,
-            contents = artifact.copiedContents,
-            outputRoot = artifact.id.outputRoot,
-        )
-    }
+    override fun render(artifact: BinaryFileArtifact): GeneratedFile = GeneratedFile(
+        relativePath = artifact.id.relativePath,
+        contents = artifact.copiedContents,
+        outputRoot = artifact.id.outputRoot,
+    )
 }

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/GeneratedByMicrosmithBanner.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/files/render/GeneratedByMicrosmithBanner.kt
@@ -67,10 +67,10 @@ internal object GeneratedByMicrosmithBanner {
     private fun resolveComment(path: Path): String? {
         val fileName = path.fileName.toString()
         val extension = fileName.substringAfterLast('.', missingDelimiterValue = "")
-        return when {
-            extension in xmlExtensions -> "<!-- $HEADER_TEXT -->"
-            extension in slashCommentExtensions -> "// $HEADER_TEXT"
-            extension in hashCommentExtensions -> "# $HEADER_TEXT"
+        return when (extension) {
+            in xmlExtensions -> "<!-- $HEADER_TEXT -->"
+            in slashCommentExtensions -> "// $HEADER_TEXT"
+            in hashCommentExtensions -> "# $HEADER_TEXT"
             else -> null
         }
     }

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/ArtifactRenderingService.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/ArtifactRenderingService.kt
@@ -7,9 +7,7 @@ import io.github.lmliam.microsmith.gen.files.GeneratedFile
 internal class ArtifactRenderingService(
     private val rendererRegistry: ArtifactRendererRegistry = ArtifactRendererRegistry(),
 ) {
-    fun render(assembly: ArtifactAssembly): List<GeneratedFile> {
-        return assembly.artifacts().map { artifact ->
-            rendererRegistry.resolve(artifact).run { render(artifact) }
-        }
+    fun render(assembly: ArtifactAssembly): List<GeneratedFile> = assembly.artifacts().map { artifact ->
+        rendererRegistry.resolve(artifact).run { render(artifact) }
     }
 }

--- a/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputWriter.kt
+++ b/modules/gen/src/main/kotlin/io/github/lmliam/microsmith/gen/helpers/GeneratedOutputWriter.kt
@@ -7,9 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.file.Files
 
-internal class GeneratedOutputWriter(
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) {
+internal class GeneratedOutputWriter(private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO) {
     suspend fun write(outputs: List<GeneratedFile>, space: FileSpace) {
         withContext(ioDispatcher) {
             outputs.forEach { output ->

--- a/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/FilePathSeparator.kt
+++ b/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/FilePathSeparator.kt
@@ -1,5 +1,7 @@
 package io.github.lmliam.microsmith.gradle
 
+import java.io.File
+
 internal object FilePathSeparator {
-    val value: String = System.getProperty("path.separator") ?: ":"
+    val value: String = File.pathSeparator
 }

--- a/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradlePlugin.kt
+++ b/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradlePlugin.kt
@@ -52,8 +52,7 @@ class MicrosmithGradlePlugin : Plugin<Project> {
             }
 
         project.plugins.withType(JavaBasePlugin::class.java) {
-            project.configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).configure {
-                    configuration ->
+            project.configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).configure { configuration ->
                 configuration.extendsFrom(microsmithIde.get())
             }
         }

--- a/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleWorkerFailure.kt
+++ b/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleWorkerFailure.kt
@@ -1,6 +1,4 @@
 package io.github.lmliam.microsmith.gradle
 
-internal data class MicrosmithGradleWorkerFailure(
-    val diagnostics: List<String>,
-    val type: String,
-) : MicrosmithGradleWorkerResult
+internal data class MicrosmithGradleWorkerFailure(val diagnostics: List<String>, val type: String) :
+    MicrosmithGradleWorkerResult

--- a/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleWorkerProcessOutcome.kt
+++ b/modules/gradle-plugin/src/main/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleWorkerProcessOutcome.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.gradle
 
-internal data class MicrosmithGradleWorkerProcessOutcome(
-    val exitCode: Int,
-    val processOutput: String,
-)
+internal data class MicrosmithGradleWorkerProcessOutcome(val exitCode: Int, val processOutput: String)

--- a/modules/gradle-plugin/src/test/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleFunctionalTestProject.kt
+++ b/modules/gradle-plugin/src/test/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleFunctionalTestProject.kt
@@ -5,9 +5,7 @@ import org.gradle.testkit.runner.GradleRunner
 import java.nio.file.Files
 import java.nio.file.Path
 
-internal class MicrosmithGradleFunctionalTestProject private constructor(
-    private val rootDirectory: Path,
-) {
+internal class MicrosmithGradleFunctionalTestProject private constructor(private val rootDirectory: Path) {
     fun writeFile(relativePath: String, contents: String) {
         val file = rootDirectory.resolve(relativePath)
         val parent = file.parent

--- a/modules/gradle-plugin/src/test/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleFunctionalTestRuntimeClasspath.kt
+++ b/modules/gradle-plugin/src/test/kotlin/io/github/lmliam/microsmith/gradle/MicrosmithGradleFunctionalTestRuntimeClasspath.kt
@@ -23,10 +23,12 @@ internal object MicrosmithGradleFunctionalTestRuntimeClasspath {
                 ?.takeIf(String::isNotBlank)
                 ?: error("Expected a non-empty java.class.path for Gradle functional tests.")
         return classpath.split(FilePathSeparator.value)
+            .asSequence()
             .filter(String::isNotBlank)
             .map(Path::of)
             .map(Path::toAbsolutePath)
             .map(Path::normalize)
             .distinct()
+            .toList()
     }
 }

--- a/modules/maven-plugin/src/main/kotlin/io/github/lmliam/microsmith/maven/MicrosmithMavenResultHandler.kt
+++ b/modules/maven-plugin/src/main/kotlin/io/github/lmliam/microsmith/maven/MicrosmithMavenResultHandler.kt
@@ -34,6 +34,7 @@ internal class MicrosmithMavenResultHandler {
             ScriptFailureType.COMPILATION,
             ScriptFailureType.EVALUATION,
             -> MojoFailureException(message)
+
             ScriptFailureType.HOST -> MojoExecutionException(message)
         }
     }

--- a/modules/maven-plugin/src/test/kotlin/io/github/lmliam/microsmith/maven/MicrosmithMavenTestProject.kt
+++ b/modules/maven-plugin/src/test/kotlin/io/github/lmliam/microsmith/maven/MicrosmithMavenTestProject.kt
@@ -3,9 +3,7 @@ package io.github.lmliam.microsmith.maven
 import java.nio.file.Files
 import java.nio.file.Path
 
-internal class MicrosmithMavenTestProject private constructor(
-    private val rootDirectory: Path,
-) {
+internal class MicrosmithMavenTestProject private constructor(private val rootDirectory: Path) {
     fun writeFile(relativePath: String, contents: String) {
         val file = file(relativePath)
         Files.createDirectories(checkNotNull(file.parent))

--- a/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ProtobufRpcSchemasResolver.kt
+++ b/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ProtobufRpcSchemasResolver.kt
@@ -92,9 +92,7 @@ class ProtobufRpcSchemasResolver : DomainResolver<SchemasExtension, ResolvedProt
     }
 }
 
-private fun ResolvedProtobufRpcEndpoint.importPath(current: QualifiedSchemaName): String? {
-    return qualifiedTypeName
-        .takeUnless { it == current.fullyQualifiedName }
-        ?.replace('.', '/')
-        ?.plus(".proto")
-}
+private fun ResolvedProtobufRpcEndpoint.importPath(current: QualifiedSchemaName): String? = qualifiedTypeName
+    .takeUnless { it == current.fullyQualifiedName }
+    ?.replace('.', '/')
+    ?.plus(".proto")

--- a/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ResolvedProtobufRpcEndpoint.kt
+++ b/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ResolvedProtobufRpcEndpoint.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.resolve.schemas.protobuf.rpc
 
-data class ResolvedProtobufRpcEndpoint(
-    val qualifiedTypeName: String,
-    val streaming: Boolean,
-)
+data class ResolvedProtobufRpcEndpoint(val qualifiedTypeName: String, val streaming: Boolean)

--- a/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ResolvedProtobufRpcSchemaModel.kt
+++ b/modules/resolve-schemas-protobuf-rpc/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/rpc/ResolvedProtobufRpcSchemaModel.kt
@@ -2,6 +2,4 @@ package io.github.lmliam.microsmith.resolve.schemas.protobuf.rpc
 
 import io.github.lmliam.microsmith.resolve.core.ResolvedModel
 
-data class ResolvedProtobufRpcSchemaModel(
-    val schemas: List<ResolvedProtobufRpcSchema>,
-) : ResolvedModel
+data class ResolvedProtobufRpcSchemaModel(val schemas: List<ResolvedProtobufRpcSchema>) : ResolvedModel

--- a/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/ResolvedProtobufSchema.kt
+++ b/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/ResolvedProtobufSchema.kt
@@ -3,7 +3,4 @@ package io.github.lmliam.microsmith.resolve.schemas.protobuf
 import io.github.lmliam.microsmith.dsl.schemas.protobuf.ProtobufSchema
 import io.github.lmliam.microsmith.resolve.schemas.protobuf.names.QualifiedSchemaName
 
-data class ResolvedProtobufSchema(
-    val schema: ProtobufSchema,
-    val qualifiedName: QualifiedSchemaName,
-)
+data class ResolvedProtobufSchema(val schema: ProtobufSchema, val qualifiedName: QualifiedSchemaName)

--- a/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/ResolvedProtobufSchemaModel.kt
+++ b/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/ResolvedProtobufSchemaModel.kt
@@ -2,6 +2,4 @@ package io.github.lmliam.microsmith.resolve.schemas.protobuf
 
 import io.github.lmliam.microsmith.resolve.core.ResolvedModel
 
-data class ResolvedProtobufSchemaModel(
-    val schemas: List<ResolvedProtobufSchema>,
-) : ResolvedModel
+data class ResolvedProtobufSchemaModel(val schemas: List<ResolvedProtobufSchema>) : ResolvedModel

--- a/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/names/QualifiedSchemaName.kt
+++ b/modules/resolve-schemas-protobuf/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/protobuf/names/QualifiedSchemaName.kt
@@ -5,11 +5,7 @@ import kotlin.io.path.Path
 /**
  * Parsed protobuf schema name with separated package/type segments.
  */
-data class QualifiedSchemaName(
-    val fullyQualifiedName: String,
-    val packageName: String?,
-    val typeName: String,
-) {
+data class QualifiedSchemaName(val fullyQualifiedName: String, val packageName: String?, val typeName: String) {
     fun relativePath(): java.nio.file.Path = buildRelativePath(prefix = Path("proto"))
 
     fun buildRelativePath(prefix: java.nio.file.Path): java.nio.file.Path = packageName

--- a/modules/resolve-schemas/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/core/ResolvedSchemasModel.kt
+++ b/modules/resolve-schemas/src/main/kotlin/io/github/lmliam/microsmith/resolve/schemas/core/ResolvedSchemasModel.kt
@@ -6,6 +6,4 @@ import io.github.lmliam.microsmith.resolve.core.ResolvedModel
 /**
  * Finalized schemas model at the domain-root level.
  */
-data class ResolvedSchemasModel(
-    val schemas: Set<Schema>,
-) : ResolvedModel
+data class ResolvedSchemasModel(val schemas: Set<Schema>) : ResolvedModel

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspBindingResolver.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspBindingResolver.kt
@@ -29,7 +29,7 @@ internal class DotnetAspBindingResolver {
         require(bindingFields == placeholderSet) {
             "ASP.NET path binding '${binding.name}' in operation '${endpoint.operationName}' " +
                 "must match route placeholders ${placeholders.joinToString(", ")}, " +
-                "but declared ${resolved.fields.map(ResolvedDotnetAspRequestField::name).joinToString(", ")}."
+                "but declared ${resolved.fields.joinToString(", ", transform = ResolvedDotnetAspRequestField::name)}."
         }
 
         return resolved

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspRouteResolver.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspRouteResolver.kt
@@ -23,12 +23,10 @@ internal class DotnetAspRouteResolver {
             .map { segment -> validateRouteSegment(segment, route, label) }
     }
 
-    fun normalizeRoute(segments: List<String>): String {
-        return if (segments.isEmpty()) {
-            "/"
-        } else {
-            "/" + segments.joinToString("/")
-        }
+    fun normalizeRoute(segments: List<String>): String = if (segments.isEmpty()) {
+        "/"
+    } else {
+        "/" + segments.joinToString("/")
     }
 
     fun extractRoutePlaceholders(segments: List<String>, route: String): List<String> {

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspWorkspace.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspWorkspace.kt
@@ -2,6 +2,4 @@ package io.github.lmliam.microsmith.resolve.services.dotnet.asp
 
 import io.github.lmliam.microsmith.resolve.core.ResolvedModel
 
-data class DotnetAspWorkspace(
-    val servicesByName: Map<String, ResolvedDotnetAspService>,
-) : ResolvedModel
+data class DotnetAspWorkspace(val servicesByName: Map<String, ResolvedDotnetAspService>) : ResolvedModel

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspWorkspaceDomainResolver.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/DotnetAspWorkspaceDomainResolver.kt
@@ -11,7 +11,8 @@ class DotnetAspWorkspaceDomainResolver(
     override val authoringType = ServicesExtension::class
     override val resolvedType = DotnetAspWorkspace::class
 
-    override fun resolve(authoring: ServicesExtension): DotnetAspWorkspace? {
-        return workspaceResolver.resolve(authoring).takeIf { it.servicesByName.isNotEmpty() }
-    }
+    override fun resolve(authoring: ServicesExtension): DotnetAspWorkspace? =
+        workspaceResolver.resolve(authoring).takeIf {
+            it.servicesByName.isNotEmpty()
+        }
 }

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspHeaderField.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspHeaderField.kt
@@ -2,10 +2,7 @@ package io.github.lmliam.microsmith.resolve.services.dotnet.asp
 
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-data class ResolvedDotnetAspHeaderField(
-    val name: String,
-    val headerName: String,
-) {
+data class ResolvedDotnetAspHeaderField(val name: String, val headerName: String) {
     init {
         validateDotnetIdentifier(name, "ASP.NET header field name")
     }

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspHeadersBinding.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspHeadersBinding.kt
@@ -2,10 +2,7 @@ package io.github.lmliam.microsmith.resolve.services.dotnet.asp
 
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.support.validateDotnetIdentifier
 
-data class ResolvedDotnetAspHeadersBinding(
-    val name: String,
-    val headers: List<ResolvedDotnetAspHeaderField>,
-) {
+data class ResolvedDotnetAspHeadersBinding(val name: String, val headers: List<ResolvedDotnetAspHeaderField>) {
     init {
         validateDotnetIdentifier(name, "ASP.NET headers binding name")
     }

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspModel.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspModel.kt
@@ -2,7 +2,4 @@ package io.github.lmliam.microsmith.resolve.services.dotnet.asp
 
 import io.github.lmliam.microsmith.dsl.services.dotnet.core.model.DotnetModel
 
-data class ResolvedDotnetAspModel(
-    val locality: ResolvedDotnetAspModelLocality,
-    val model: DotnetModel,
-)
+data class ResolvedDotnetAspModel(val locality: ResolvedDotnetAspModelLocality, val model: DotnetModel)

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspResponseHeader.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspResponseHeader.kt
@@ -1,5 +1,3 @@
 package io.github.lmliam.microsmith.resolve.services.dotnet.asp
 
-data class ResolvedDotnetAspResponseHeader(
-    val name: String,
-)
+data class ResolvedDotnetAspResponseHeader(val name: String)

--- a/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspRest.kt
+++ b/modules/resolve-services-dotnet-asp/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/asp/ResolvedDotnetAspRest.kt
@@ -1,8 +1,6 @@
 package io.github.lmliam.microsmith.resolve.services.dotnet.asp
 
-data class ResolvedDotnetAspRest(
-    val endpoints: List<ResolvedDotnetAspEndpoint>,
-) {
+data class ResolvedDotnetAspRest(val endpoints: List<ResolvedDotnetAspEndpoint>) {
     companion object {
         fun empty() = ResolvedDotnetAspRest(emptyList())
     }

--- a/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/DotnetPackageWorkspaceResolver.kt
+++ b/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/DotnetPackageWorkspaceResolver.kt
@@ -63,15 +63,13 @@ class DotnetPackageWorkspaceResolver(
         solutionName: String,
         references: List<DotnetPackageReferenceDeclaration>,
         centrallyManagedPackagesByName: Map<String, ResolvedDotnetPackageVersion>,
-    ): List<ResolvedDotnetPackageReference> {
-        return references.map { reference ->
-            resolveServicePackageReference(
-                serviceName = serviceName,
-                solutionName = solutionName,
-                reference = reference,
-                centrallyManagedPackagesByName = centrallyManagedPackagesByName,
-            )
-        }
+    ): List<ResolvedDotnetPackageReference> = references.map { reference ->
+        resolveServicePackageReference(
+            serviceName = serviceName,
+            solutionName = solutionName,
+            reference = reference,
+            centrallyManagedPackagesByName = centrallyManagedPackagesByName,
+        )
     }
 
     private fun resolveServicePackageReference(

--- a/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/ResolvedDotnetPackageReference.kt
+++ b/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/ResolvedDotnetPackageReference.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.resolve.services.dotnet.packages
 
-data class ResolvedDotnetPackageReference(
-    val name: String,
-    val version: String?,
-)
+data class ResolvedDotnetPackageReference(val name: String, val version: String?)

--- a/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/ResolvedDotnetPackageSolution.kt
+++ b/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/ResolvedDotnetPackageSolution.kt
@@ -1,9 +1,6 @@
 package io.github.lmliam.microsmith.resolve.services.dotnet.packages
 
-data class ResolvedDotnetPackageSolution(
-    val name: String,
-    val packages: List<ResolvedDotnetPackageVersion>,
-) {
+data class ResolvedDotnetPackageSolution(val name: String, val packages: List<ResolvedDotnetPackageVersion>) {
     fun packageVersionsByName(): Map<String, ResolvedDotnetPackageVersion> =
         packages.associateBy(ResolvedDotnetPackageVersion::name)
 }

--- a/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/ResolvedDotnetPackageVersion.kt
+++ b/modules/resolve-services-dotnet-packages/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/packages/ResolvedDotnetPackageVersion.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.resolve.services.dotnet.packages
 
-data class ResolvedDotnetPackageVersion(
-    val name: String,
-    val version: String,
-)
+data class ResolvedDotnetPackageVersion(val name: String, val version: String)

--- a/modules/resolve-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/DotnetWorkspaceResolutionErrors.kt
+++ b/modules/resolve-services-dotnet/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/DotnetWorkspaceResolutionErrors.kt
@@ -1,9 +1,7 @@
 package io.github.lmliam.microsmith.resolve.services.dotnet
 
 internal object DotnetWorkspaceResolutionErrors {
-    fun solutionNotDeclared(serviceName: String, solutionName: String): IllegalStateException {
-        return IllegalStateException(
-            "Dotnet solution '$solutionName' is not declared for service '$serviceName'.",
-        )
-    }
+    fun solutionNotDeclared(serviceName: String, solutionName: String): IllegalStateException = IllegalStateException(
+        "Dotnet solution '$solutionName' is not declared for service '$serviceName'.",
+    )
 }

--- a/modules/resolve-services-dotnet/src/test/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/DotnetWorkspaceResolverTests.kt
+++ b/modules/resolve-services-dotnet/src/test/kotlin/io/github/lmliam/microsmith/resolve/services/dotnet/DotnetWorkspaceResolverTests.kt
@@ -7,7 +7,6 @@ import io.github.lmliam.microsmith.dsl.services.dotnet.core.dotnet
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
 private fun MicrosmithBuilder.requireServicesExtension(): ServicesExtension =

--- a/modules/resolve-services/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/core/ResolvedServicesModel.kt
+++ b/modules/resolve-services/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/core/ResolvedServicesModel.kt
@@ -6,6 +6,4 @@ import io.github.lmliam.microsmith.resolve.core.ResolvedModel
 /**
  * Finalized services model at the domain-root level.
  */
-data class ResolvedServicesModel(
-    val services: Set<Service>,
-) : ResolvedModel
+data class ResolvedServicesModel(val services: Set<Service>) : ResolvedModel

--- a/modules/resolve-services/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/core/ServicesResolver.kt
+++ b/modules/resolve-services/src/main/kotlin/io/github/lmliam/microsmith/resolve/services/core/ServicesResolver.kt
@@ -9,7 +9,6 @@ class ServicesResolver : DomainResolver<ServicesExtension, ResolvedServicesModel
     override val authoringType = ServicesExtension::class
     override val resolvedType = ResolvedServicesModel::class
 
-    override fun resolve(authoring: ServicesExtension): ResolvedServicesModel {
-        return ResolvedServicesModel(authoring.services)
-    }
+    override fun resolve(authoring: ServicesExtension): ResolvedServicesModel =
+        ResolvedServicesModel(authoring.services)
 }

--- a/modules/resolve/src/main/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolutionService.kt
+++ b/modules/resolve/src/main/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolutionService.kt
@@ -4,18 +4,14 @@ import io.github.lmliam.microsmith.dsl.core.MicrosmithExtension
 import io.github.lmliam.microsmith.dsl.core.MicrosmithModel
 import io.github.lmliam.microsmith.dsl.helpers.extensions
 
-class DomainResolutionService(
-    private val resolverRegistry: DomainResolverRegistry = DomainResolverRegistry(),
-) {
-    fun resolve(model: MicrosmithModel): List<ResolvedModel> {
-        return model.extensions()
-            .sortedBy { it::class.qualifiedName ?: it::class.toString() }
-            .flatMap { extension ->
-                resolverRegistry.resolve(extension).mapNotNull { resolver ->
-                    resolver.resolveUnchecked(extension)
-                }
+class DomainResolutionService(private val resolverRegistry: DomainResolverRegistry = DomainResolverRegistry()) {
+    fun resolve(model: MicrosmithModel): List<ResolvedModel> = model.extensions()
+        .sortedBy { it::class.qualifiedName ?: it::class.toString() }
+        .flatMap { extension ->
+            resolverRegistry.resolve(extension).mapNotNull { resolver ->
+                resolver.resolveUnchecked(extension)
             }
-    }
+        }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/modules/resolve/src/main/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolverRegistry.kt
+++ b/modules/resolve/src/main/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolverRegistry.kt
@@ -4,17 +4,14 @@ import io.github.lmliam.microsmith.dsl.core.MicrosmithExtension
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
 
-class DomainResolverRegistry(
-    resolvers: List<DomainResolver<*, *>> = loadDomainResolvers(),
-) {
+class DomainResolverRegistry(resolvers: List<DomainResolver<*, *>> = loadDomainResolvers()) {
     private val resolversByAuthoringType: Map<KClass<out MicrosmithExtension>, List<DomainResolver<*, *>>> =
         indexResolvers(resolvers)
 
-    fun resolve(extension: MicrosmithExtension): List<DomainResolver<MicrosmithExtension, ResolvedModel>> {
-        return resolversByAuthoringType[extension::class]
+    fun resolve(extension: MicrosmithExtension): List<DomainResolver<MicrosmithExtension, ResolvedModel>> =
+        resolversByAuthoringType[extension::class]
             ?.map { it.cast() }
             .orEmpty()
-    }
 
     private fun indexResolvers(
         resolvers: List<DomainResolver<*, *>>,
@@ -36,7 +33,7 @@ class DomainResolverRegistry(
 
         return byAuthoringType.mapValues { (_, registrations) ->
             registrations.sortedWith(
-                compareBy<DomainResolver<*, *>>(
+                compareBy(
                     { it.resolvedType.qualifiedName ?: it.resolvedType.toString() },
                     { it::class.qualifiedName ?: it::class.toString() },
                 ),

--- a/modules/resolve/src/test/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolutionServiceTests.kt
+++ b/modules/resolve/src/test/kotlin/io/github/lmliam/microsmith/resolve/core/DomainResolutionServiceTests.kt
@@ -10,13 +10,9 @@ private data object AlphaExtension : MicrosmithExtension
 
 private data object BetaExtension : MicrosmithExtension
 
-private data class AlphaResolvedModel(
-    val value: String,
-) : ResolvedModel
+private data class AlphaResolvedModel(val value: String) : ResolvedModel
 
-private data class BetaResolvedModel(
-    val value: String,
-) : ResolvedModel
+private data class BetaResolvedModel(val value: String) : ResolvedModel
 
 private class AlphaFirstResolver : DomainResolver<AlphaExtension, AlphaResolvedModel> {
     override val authoringType = AlphaExtension::class

--- a/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/definition/MicrosmithScriptCompilationConfiguration.kt
+++ b/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/definition/MicrosmithScriptCompilationConfiguration.kt
@@ -39,7 +39,6 @@ object MicrosmithScriptCompilationConfiguration : ScriptCompilationConfiguration
         }
     },
 ) {
-    @Suppress("unused")
     private fun readResolve(): Any = MicrosmithScriptCompilationConfiguration
 }
 

--- a/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/definition/MicrosmithScriptCompilationConfiguration.kt
+++ b/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/definition/MicrosmithScriptCompilationConfiguration.kt
@@ -38,9 +38,7 @@ object MicrosmithScriptCompilationConfiguration : ScriptCompilationConfiguration
             )
         }
     },
-) {
-    private fun readResolve(): Any = MicrosmithScriptCompilationConfiguration
-}
+)
 
 private fun importFromPackageOf(owner: KClass<*>, symbol: KFunction<*>): String =
     "${owner.java.packageName}.${symbol.name}"

--- a/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/host/ProcessIsolationResultCodec.kt
+++ b/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/host/ProcessIsolationResultCodec.kt
@@ -31,7 +31,9 @@ internal class ProcessIsolationResultCodec {
 
         return when (properties.getProperty(ProcessIsolationPropertyNames.RESULT_STATUS)?.trim()) {
             ProcessIsolationPropertyNames.RESULT_STATUS_SUCCESS -> readSuccess(properties)
+
             ProcessIsolationPropertyNames.RESULT_STATUS_FAILURE -> readFailure(properties)
+
             else -> error(
                 "Missing or invalid '${ProcessIsolationPropertyNames.RESULT_STATUS}' in process isolation result.",
             )

--- a/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/host/ProcessIsolationWorkspace.kt
+++ b/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/host/ProcessIsolationWorkspace.kt
@@ -2,8 +2,4 @@ package io.github.lmliam.microsmith.runtime.scripting.host
 
 import java.nio.file.Path
 
-internal data class ProcessIsolationWorkspace(
-    val workingDirectory: Path,
-    val requestFile: Path,
-    val resultFile: Path,
-)
+internal data class ProcessIsolationWorkspace(val workingDirectory: Path, val requestFile: Path, val resultFile: Path)

--- a/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/host/ScriptEvaluationModelEmitter.kt
+++ b/modules/runtime-scripting/src/main/kotlin/io/github/lmliam/microsmith/runtime/scripting/host/ScriptEvaluationModelEmitter.kt
@@ -9,7 +9,9 @@ internal class ScriptEvaluationModelEmitter {
     fun ensureGenerated(evaluationResult: EvaluationResult, scriptContext: MicrosmithScriptContext) {
         when (val returnValue = evaluationResult.returnValue) {
             is ResultValue.Error -> rethrow(returnValue.error)
+
             is ResultValue.Value -> emitReturnedModelIfNeeded(returnValue.value, scriptContext)
+
             is ResultValue.Unit,
             ResultValue.NotEvaluated,
             -> requireGenerated(scriptContext)

--- a/modules/sbt-plugin/src/main/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtExecutionService.kt
+++ b/modules/sbt-plugin/src/main/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtExecutionService.kt
@@ -25,7 +25,9 @@ class MicrosmithSbtExecutionService(
 
     private fun RuntimeException.toHostFailure(): RuntimeException = when (this) {
         is MicrosmithSbtScriptFailureException -> this
+
         is MicrosmithSbtHostFailureException -> this
+
         else -> MicrosmithSbtHostFailureException(
             "Microsmith sbt plugin failed before generation completed.",
             this,

--- a/modules/sbt-plugin/src/main/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtHostFailureException.kt
+++ b/modules/sbt-plugin/src/main/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtHostFailureException.kt
@@ -1,6 +1,3 @@
 package io.github.lmliam.microsmith.sbt
 
-class MicrosmithSbtHostFailureException(
-    message: String,
-    cause: Throwable? = null,
-) : RuntimeException(message, cause)
+class MicrosmithSbtHostFailureException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/modules/sbt-plugin/src/main/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtResultInterpreter.kt
+++ b/modules/sbt-plugin/src/main/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtResultInterpreter.kt
@@ -8,16 +8,15 @@ import java.nio.file.Path
 import java.util.Locale
 
 class MicrosmithSbtResultInterpreter {
-    fun interpret(outputDirectory: Path, result: ScriptRunResult): MicrosmithSbtExecutionOutcome {
-        return when (result) {
-            is ScriptRunSuccess -> MicrosmithSbtExecutionOutcome(
-                outputDirectory = outputDirectory,
-                warnings = result.warnings,
-                cacheHit = result.cacheHit,
-                elapsedMillis = result.elapsedMillis,
-            )
-            is ScriptRunFailure -> throw buildFailure(result)
-        }
+    fun interpret(outputDirectory: Path, result: ScriptRunResult): MicrosmithSbtExecutionOutcome = when (result) {
+        is ScriptRunSuccess -> MicrosmithSbtExecutionOutcome(
+            outputDirectory = outputDirectory,
+            warnings = result.warnings,
+            cacheHit = result.cacheHit,
+            elapsedMillis = result.elapsedMillis,
+        )
+
+        is ScriptRunFailure -> throw buildFailure(result)
     }
 
     private fun buildFailure(result: ScriptRunFailure): RuntimeException {
@@ -27,6 +26,7 @@ class MicrosmithSbtResultInterpreter {
             ScriptFailureType.COMPILATION,
             ScriptFailureType.EVALUATION,
             -> MicrosmithSbtScriptFailureException(message)
+
             ScriptFailureType.HOST -> MicrosmithSbtHostFailureException(message)
         }
     }

--- a/modules/sbt-plugin/src/test/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtTestProject.kt
+++ b/modules/sbt-plugin/src/test/kotlin/io/github/lmliam/microsmith/sbt/MicrosmithSbtTestProject.kt
@@ -3,9 +3,7 @@ package io.github.lmliam.microsmith.sbt
 import java.nio.file.Files
 import java.nio.file.Path
 
-class MicrosmithSbtTestProject private constructor(
-    private val rootDirectory: Path,
-) {
+class MicrosmithSbtTestProject private constructor(private val rootDirectory: Path) {
     fun writeFile(relativePath: String, contents: String) {
         val file = file(relativePath)
         Files.createDirectories(checkNotNull(file.parent))


### PR DESCRIPTION
## Why
- This branch is a cleanup sweep rather than issue work, so the goal is to reduce duplicated internal logic, keep the broad declaration-style cleanup in a reviewable shape, and leave the branch fully green.
- A few follow-up fixes were also needed because the carried local cleanup introduced invalid escaped-dollar literals in one CLI test and one ASP.NET scaffold template.
- Gradle 8.14 has newer patch releases available, so the wrapper should stay current within the existing major/minor line.

## What Changed
- committed the broad repository cleanup already in the worktree as its own refactor commit so it remains distinct from the follow-up fixes
- extracted shared SHA-256 file hashing for CLI event logging and plugin locking, deduplicated protobuf duplicate-usage validation, and shared the Kotlin source scanning literal helper used by repository-quality checks
- simplified `FilePathSeparator` to use `File.pathSeparator` and removed the unnecessary non-capturing regex groups flagged in `ProductionKotlinLine`
- fixed escaped-dollar string literals in `IdeHelperGeneratorTests` and `DotnetAspServiceArtifactCompiler` so the carried cleanup changes compile and lint correctly
- upgraded the Gradle wrapper from `8.14` to `8.14.4`
- verified the `libs.versions.toml` library aliases are still live via build-logic `findLibrary(...)` lookups, so no catalog entries were removed

## Validation
- `./gradlew build-logic:test :artifact-schemas-protobuf:jvmKotest :cli:jvmKotest :gradle-plugin:jvmKotest verifyRepositoryStandards --no-build-cache`
- `./gradlew :cli:ktlintMainSourceSetCheck :compile-services-dotnet-asp:ktlintMainSourceSetCheck :compile-services-dotnet-asp:jvmKotest --no-build-cache`
- `./gradlew build --no-build-cache`
